### PR TITLE
Fix: Claude Code command discovery in cloned vault (#2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ Open the folder in Obsidian: **Manage Vaults → Open folder as vault → select
 
 Open Claude Code in the same folder. Type `/wiki`.
 
-> `setup-vault.sh` configures `graph.json` (filter + colors), `app.json` (excludes plugin dirs), and `appearance.json` (enables CSS). Run it once before the first Obsidian open. You get the fully pre-configured graph view, color scheme, and wiki structure out of the box.
+> `setup-vault.sh` configures `graph.json` (filter + colors), `app.json` (excludes plugin dirs), `appearance.json` (enables CSS), and symlinks the `skills/` and `commands/` directories to `.claude/` so Claude Code discovers them. Run it once before the first Obsidian open. You get the fully pre-configured graph view, color scheme, and wiki structure out of the box.
+>
+> *Note on updates: If you run `git pull` later to get new skills, the symlinks in `.claude/` will automatically point to the updated files on macOS/Linux. If the links ever break, run `bash bin/sync-claude.sh` to recreate them without overwriting your Obsidian settings.*
 
 ---
 

--- a/bin/setup-vault.sh
+++ b/bin/setup-vault.sh
@@ -55,6 +55,7 @@ cat > "$OBSIDIAN/app.json" << 'EOF'
     "commands/",
     "hooks/",
     "skills/",
+    ".claude/",
     "_templates/",
     "README.md",
     "CLAUDE.md",
@@ -86,6 +87,10 @@ if [ -f "$EXCALIDRAW/manifest.json" ] && [ ! -f "$EXCALIDRAW/main.js" ]; then
 elif [ -f "$EXCALIDRAW/main.js" ]; then
   echo "✓ Excalidraw main.js already present"
 fi
+
+# ── 6. Sync Claude Code directories ─────────────────────────────────────────
+echo "Linking Claude Code commands and skills..."
+bash "$SCRIPT_DIR/sync-claude.sh"
 
 echo ""
 echo "✓ Setup complete."

--- a/bin/sync-claude.sh
+++ b/bin/sync-claude.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# claude-obsidian: claude code directory sync script
+# Creates symlinks in .claude/ for Claude Code's agent discovery.
+# This script targets *nix/macOS environments where symlinks are standard.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CLAUDE_DIR="$REPO_ROOT/.claude"
+
+echo "Syncing Claude Code directories to .claude/..."
+
+mkdir -p "$CLAUDE_DIR"
+
+cd "$CLAUDE_DIR"
+
+# Use relative symlinks so they remain valid if the vault is moved.
+# The -n flag ensures we don't nest symlinks if they already exist.
+# The -f flag forces an overwrite if the symlink needs updating.
+ln -snf ../skills skills
+ln -snf ../commands commands
+
+echo "✓ Claude Code directories synced."


### PR DESCRIPTION
Fixes #2. Added bin/sync-claude.sh to symlink skills and commands into .claude/ for Option 1 installations, updated setup-vault.sh to run it, and updated README instructions.