### PR TITLE
fix: replace prompt-type SessionStart/PostCompact hooks with command-type

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,10 +7,6 @@
           {
             "type": "command",
             "command": "[ -f wiki/hot.md ] && cat wiki/hot.md || true"
-          },
-          {
-            "type": "prompt",
-            "prompt": "If a vault is configured for this session (check CLAUDE.md for VAULT_PATH or a wiki/ folder in the current directory), silently read wiki/hot.md to restore recent context. If wiki/hot.md does not exist, do nothing. This is a non-vault session. Do not announce this. Do not report what you read. Just have the context available."
           }
         ]
       }
@@ -20,8 +16,8 @@
         "matcher": "",
         "hooks": [
           {
-            "type": "prompt",
-            "prompt": "Hook-injected context does not survive context compaction. If wiki/hot.md exists in the current directory, silently re-read it now to restore the hot cache. Do not announce this."
+            "type": "command",
+            "command": "[ -f wiki/hot.md ] && cat wiki/hot.md || true"
           }
         ]
       }


### PR DESCRIPTION
## Summary

Fixes the `SessionStart:resume hook error: Failed to run: ToolUseContext is required for prompt hooks. This is a bug.` error reported in #7.

## Root Cause

`SessionStart` (second hook) and `PostCompact` use `type: "prompt"`, which requires a `ToolUseContext` runtime object that is not available during session resume or post-compaction. Same class of issue as the one fixed for the `Stop` hook in e54b419 — prompt-type hooks depend on LLM-conversation runtime state that isn't always available, while command-type hooks only depend on the shell.

## Changes

- **SessionStart**: drop the redundant second (prompt) hook. The first command hook already runs `cat wiki/hot.md`, which injects hot cache content via stdout. The prompt hook was defense-in-depth that never worked on resume paths.
- **PostCompact**: convert prompt hook to command hook with the same `cat wiki/hot.md` pattern. Preserves the "re-inject hot cache after compaction" functionality using the same technique already validated by the Stop fix.

## Diff

```diff
 "SessionStart": [{
   "matcher": "startup|resume",
   "hooks": [
     { "type": "command", "command": "[ -f wiki/hot.md ] && cat wiki/hot.md || true" }
-    ,{ "type": "prompt", "prompt": "If a vault is configured..." }
   ]
 }],
 "PostCompact": [{
   "matcher": "",
   "hooks": [
-    { "type": "prompt", "prompt": "Hook-injected context does not survive..." }
+    { "type": "command", "command": "[ -f wiki/hot.md ] && cat wiki/hot.md || true" }
   ]
 }]
```

## Verification

- [x] JSON validated with `python3 -m json.tool hooks/hooks.json`
- [x] No remaining `"type": "prompt"` entries in hooks.json
- [x] Fix pattern matches the existing `Stop` hook fix (e54b419) — same approach: replace prompt-type with command-type that writes prompt-like output to stdout when needed
- [x] Untouched: `PostToolUse` auto-commit, `Stop` WIKI_CHANGED nudge
- [ ] End-to-end runtime verification (starting + resuming a Claude Code session with patched plugin) — **not performed by author**; intentionally left for maintainer/reviewer. The change is a small config transform and relies on the same command-stdout pattern already validated in e54b419.

## Behavioral Notes

- **Hot cache injection**: unchanged — still works on every session start (command hook cats `wiki/hot.md`).
- **Post-compaction restore**: now functional (was silently broken before due to the `ToolUseContext` error on the prompt hook).
- **Lost nuance**: the original prompt hooks included "silently, do not announce" language directed at the LLM. With command-type hooks, this instruction is no longer emitted. In practice, command hook stdout is injected as context, and the vault's `CLAUDE.md` governs how Claude describes it. No observable difference expected in a typical Obsidian vault session.

## Rollback

Revertible by `git revert <sha>`. No state migration, no downstream dependencies. The prior behavior (with error banner) would be restored.

## Closes

Fixes #7