### PR TITLE
fix: remove prompt-type hooks from SessionStart and PostCompact

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -6,21 +6,24 @@ Plugin hooks for the claude-obsidian wiki vault. All hooks are defined in `hooks
 
 | Event | Type | Purpose |
 |---|---|---|
-| `SessionStart` | command | Loads `wiki/hot.md` into context via `[ -f wiki/hot.md ] && cat wiki/hot.md` (works for non-vault sessions without erroring). Matcher: `startup\|resume`. |
-| `PostCompact` | command | Re-loads `wiki/hot.md` via `cat` after context compaction. Hook-injected context does NOT survive compaction (only `CLAUDE.md` does), so this hook restores the hot cache mid-session. |
-| `PostToolUse` | command | Auto-commits any wiki/ or .raw/ changes after Write or Edit tool calls. Guarded by `[ -d .git ]` so it never errors in non-git directories, and by `git diff --cached --quiet` so it never creates empty commits. |
-| `Stop` | prompt | Updates `wiki/hot.md` at the end of every Claude response with a brief summary of what changed. |
+| `SessionStart` | command | Injects `wiki/hot.md` into the model context by emitting the documented `hookSpecificOutput.additionalContext` JSON schema. Resolves the vault path via `${CLAUDE_PROJECT_DIR:-$PWD}/wiki/hot.md`, exits silently when the file is absent (non-vault sessions) or `jq` is not installed. Matcher: `startup\|resume`. |
+| `PostToolUse` | command | Auto-commits any `wiki/` or `.raw/` changes after Write or Edit tool calls. Guarded by `[ -d .git ]` so it never errors in non-git directories, and by `git diff --cached --quiet` so it never creates empty commits. |
+| `Stop` | command | Emits a `WIKI_CHANGED:` nudge when files under `wiki/` have changed this session, prompting Claude to refresh `wiki/hot.md`. Guarded by `[ -d wiki ]`, `[ -d .git ]`, and `grep -q '^wiki/'` so it stays silent otherwise (and avoids the infinite-loop regression caused by the earlier prompt-type version; see commit `e54b419`). |
 
-## Known Issue: Plugin Hooks STDOUT Bug
+## Why no `PostCompact` / `prompt`-type hooks
 
-`anthropics/claude-code#10875` documents that **plugin hook STDOUT may not be captured** by Claude Code, while identical inline hooks in `settings.json` work correctly.
+Claude Code's official [hooks reference](https://code.claude.com/docs/en/hooks) lists `PostCompact` under events with **"None" decision control** — it has no mechanism (no `additionalContext`, no prompt injection) to reach the model. Registering any hook there can only produce side effects (or errors). The earlier `prompt`-type hook on `PostCompact`/`SessionStart` failed with `Failed to run: ToolUseContext is required for prompt hook` because prompt hooks depend on a tool-use-scoped runtime that session lifecycle events do not provide. We therefore unregister `PostCompact` entirely and rely on the supported `SessionStart` JSON schema.
 
-**Impact**: If this bug is active in your Claude Code version, the command-type SessionStart and PostCompact hooks may not inject `wiki/hot.md` into context as expected.
+## Dependencies
 
-**Workaround**: Both hooks run `cat wiki/hot.md` and rely on STDOUT capture for context injection. If hot cache restoration fails, copy the hook config from `hooks.json` into your user-level `~/.claude/settings.json` instead of relying on plugin hooks.
-
-**Test for the bug**: After installing the plugin, open a fresh Claude Code session in a directory containing a populated `wiki/hot.md`. Ask Claude "what's in the hot cache?". If Claude has no idea, the STDOUT bug is active in your version.
+The `SessionStart` hook uses `jq` to emit the JSON payload. The command is guarded by `command -v jq` and exits silently (`|| true`) when `jq` is missing, so the plugin stays safe to install globally — you simply lose hot-cache injection until `jq` is available (`brew install jq` on macOS).
 
 ## Non-Vault Sessions
 
-The SessionStart command hook uses `[ -f wiki/hot.md ] && cat wiki/hot.md || true` so it always exits 0, even when no vault is present. This makes the plugin safe to install globally without breaking non-vault Claude Code sessions.
+The `SessionStart` hook's `[ -f "$HOT" ]` guard and trailing `|| true` ensure it always exits 0, even when no vault is present. This makes the plugin safe to install globally without breaking non-vault Claude Code sessions.
+
+## Known Issue: Plugin Hooks STDOUT Bug
+
+`anthropics/claude-code#10875` documents that **plugin hook STDOUT may not be captured** by Claude Code in some versions, while identical inline hooks in `settings.json` work correctly. If hot-cache injection fails to take effect after installing the plugin, copy the `SessionStart` hook from `hooks.json` into your user-level `~/.claude/settings.json` as a fallback.
+
+**Test for the bug:** open a fresh Claude Code session in a directory with a populated `wiki/hot.md` and ask Claude "what's in the hot cache?". If Claude has no idea, the STDOUT bug is active in your version.

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -6,8 +6,8 @@ Plugin hooks for the claude-obsidian wiki vault. All hooks are defined in `hooks
 
 | Event | Type | Purpose |
 |---|---|---|
-| `SessionStart` | command + prompt | Loads `wiki/hot.md` into context. Command type runs `[ -f wiki/hot.md ] && cat wiki/hot.md` as the canonical safety check (works for non-vault sessions without erroring). Prompt type complements with semantic context restoration. Matcher: `startup\|resume`. |
-| `PostCompact` | prompt | Re-loads `wiki/hot.md` after context compaction. Hook-injected context does NOT survive compaction (only `CLAUDE.md` does), so this hook restores the hot cache mid-session. |
+| `SessionStart` | command | Loads `wiki/hot.md` into context via `[ -f wiki/hot.md ] && cat wiki/hot.md` (works for non-vault sessions without erroring). Matcher: `startup\|resume`. |
+| `PostCompact` | command | Re-loads `wiki/hot.md` via `cat` after context compaction. Hook-injected context does NOT survive compaction (only `CLAUDE.md` does), so this hook restores the hot cache mid-session. |
 | `PostToolUse` | command | Auto-commits any wiki/ or .raw/ changes after Write or Edit tool calls. Guarded by `[ -d .git ]` so it never errors in non-git directories, and by `git diff --cached --quiet` so it never creates empty commits. |
 | `Stop` | prompt | Updates `wiki/hot.md` at the end of every Claude response with a brief summary of what changed. |
 
@@ -15,9 +15,9 @@ Plugin hooks for the claude-obsidian wiki vault. All hooks are defined in `hooks
 
 `anthropics/claude-code#10875` documents that **plugin hook STDOUT may not be captured** by Claude Code, while identical inline hooks in `settings.json` work correctly.
 
-**Impact**: If this bug is active in your Claude Code version, the prompt-type SessionStart and PostCompact hooks may not inject context as expected.
+**Impact**: If this bug is active in your Claude Code version, the command-type SessionStart and PostCompact hooks may not inject `wiki/hot.md` into context as expected.
 
-**Workaround**: The command-type SessionStart hook (`cat wiki/hot.md`) is the canonical safety check. It relies on STDOUT capture for context injection, so test against this issue if hot cache restoration fails. As a fallback, copy the hook config from `hooks.json` into your user-level `~/.claude/settings.json` instead of relying on plugin hooks.
+**Workaround**: Both hooks run `cat wiki/hot.md` and rely on STDOUT capture for context injection. If hot cache restoration fails, copy the hook config from `hooks.json` into your user-level `~/.claude/settings.json` instead of relying on plugin hooks.
 
 **Test for the bug**: After installing the plugin, open a fresh Claude Code session in a directory containing a populated `wiki/hot.md`. Ask Claude "what's in the hot cache?". If Claude has no idea, the STDOUT bug is active in your version.
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,10 +7,6 @@
           {
             "type": "command",
             "command": "[ -f wiki/hot.md ] && cat wiki/hot.md || true"
-          },
-          {
-            "type": "prompt",
-            "prompt": "If a vault is configured for this session (check CLAUDE.md for VAULT_PATH or a wiki/ folder in the current directory), silently read wiki/hot.md to restore recent context. If wiki/hot.md does not exist, do nothing. This is a non-vault session. Do not announce this. Do not report what you read. Just have the context available."
           }
         ]
       }
@@ -20,8 +16,8 @@
         "matcher": "",
         "hooks": [
           {
-            "type": "prompt",
-            "prompt": "Hook-injected context does not survive context compaction. If wiki/hot.md exists in the current directory, silently re-read it now to restore the hot cache. Do not announce this."
+            "type": "command",
+            "command": "[ -f wiki/hot.md ] && cat wiki/hot.md || true"
           }
         ]
       }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,18 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "[ -f wiki/hot.md ] && cat wiki/hot.md || true"
-          }
-        ]
-      }
-    ],
-    "PostCompact": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "[ -f wiki/hot.md ] && cat wiki/hot.md || true"
+            "command": "HOT=\"${CLAUDE_PROJECT_DIR:-$PWD}/wiki/hot.md\"; [ -f \"$HOT\" ] && command -v jq >/dev/null && jq -n --rawfile ctx \"$HOT\" '{hookSpecificOutput:{hookEventName:\"SessionStart\",additionalContext:$ctx}}' || true"
           }
         ]
       }


### PR DESCRIPTION
## Summary

Closes #7 (also reported as duplicate #10) — removes the `Failed to run: ToolUseContext is required for prompt hook` banner on session start by emitting the documented `hookSpecificOutput.additionalContext` JSON from a command-type `SessionStart` hook, and unregisters `PostCompact` because it has no supported injection mechanism.

> This PR supersedes the approach proposed in [#8](https://github.com/AgriciDaniel/claude-obsidian/pull/8), which its author closed after finding that plain `cat` stdout is not actually injected into the model context on `SessionStart`.

## Changes

| File | Change |
|---|---|
| `hooks/hooks.json` | `SessionStart` emits `{hookSpecificOutput:{hookEventName,additionalContext}}` via `jq`, resolving `${CLAUDE_PROJECT_DIR:-$PWD}/wiki/hot.md`; guarded with `[ -f "$HOT" ]`, `command -v jq`, and `\|\| true`. `PostCompact` event fully removed. |
| `hooks/README.md` | Events table updated; new "Why no `PostCompact` / `prompt`-type hooks" and "Dependencies" sections; stale plain-`cat` workaround removed. |

## Why this approach

Per the [official hooks reference](https://code.claude.com/docs/en/hooks):

- `SessionStart` supports context injection **only** through `hookSpecificOutput.additionalContext` — plain stdout is not guaranteed to reach the model.
- `PostCompact` is listed under events with **"None" decision control** — no `additionalContext`, no prompt injection, no way to reach the model. Keeping any hook there can only produce side effects or errors.
- `prompt`-type hooks depend on a tool-use-scoped runtime (`ToolUseContext`) that session lifecycle events do not supply, which is why the banner appeared on every session start.

## Verified

- [x] `hooks/hooks.json` parses as valid JSON
- [x] Hook command exits 0 in a populated vault (`wiki/hot.md` present) and produces the documented JSON payload
- [x] Hook command exits 0 in a non-vault directory (`wiki/hot.md` absent)
- [x] Hook command exits 0 when `jq` is not on `PATH` (feature degrades silently)
- [x] JSON escaping correct for content containing `"` and `\` (spot-checked via `jq --rawfile`)
- [x] No remaining `"type": "prompt"` entries in `hooks.json`; other hooks (`PostToolUse`, `Stop`) unchanged

## Unverified (requires maintainer env)

- [ ] End-to-end: install the plugin in a fresh Claude Code session and confirm (a) the `ToolUseContext` banner is gone and (b) `wiki/hot.md` content is available in context (e.g., ask Claude for the `Last Updated` value without it running a Read tool)
- [ ] Interaction with the upstream plugin-hook STDOUT bug (`anthropics/claude-code#10875`), still documented in README as a fallback pointer

## Rollback

`git revert <sha>` is safe — no state migration, no downstream dependencies. The prior behavior (error banner on startup, no-op on compact) would be restored.