### PR TITLE
docs: context bus vision and three-tier architecture

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,29 +1,29 @@
 {
-  "name": "claude-obsidian-marketplace",
+  "name": "vault-os-marketplace",
   "owner": {
-    "name": "AgriciDaniel",
-    "url": "https://github.com/AgriciDaniel"
+    "name": "saixso",
+    "url": "https://github.com/saixso"
   },
   "metadata": {
-    "description": "claude-obsidian: Claude + Obsidian knowledge companion by AgriciDaniel",
-    "version": "1.4.2"
+    "description": "vault-os: Opinionated Claude Code + Obsidian knowledge companion by saixso",
+    "version": "2.0.0"
   },
   "plugins": [
     {
-      "name": "claude-obsidian",
+      "name": "vault-os",
       "source": {
         "source": "github",
-        "repo": "AgriciDaniel/claude-obsidian",
+        "repo": "saixso/vault-os",
         "ref": "main"
       },
-      "description": "Claude + Obsidian knowledge companion. Sets up a persistent, compounding wiki vault. Covers memory management, session notetaking, knowledge organization, and agent context across projects.",
-      "version": "1.4.2",
+      "description": "Opinionated Claude Code + Obsidian knowledge companion. Persistent, compounding wiki vault with harness and hooks. Fork of claude-obsidian by AgriciDaniel.",
+      "version": "2.0.0",
       "author": {
-        "name": "AgriciDaniel",
-        "url": "https://github.com/AgriciDaniel"
+        "name": "saixso",
+        "url": "https://github.com/saixso"
       },
-      "homepage": "https://github.com/AgriciDaniel/claude-obsidian",
-      "repository": "https://github.com/AgriciDaniel/claude-obsidian",
+      "homepage": "https://github.com/saixso/vault-os",
+      "repository": "https://github.com/saixso/vault-os",
       "license": "MIT"
     }
   ]

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,14 +1,14 @@
 {
-  "name": "claude-obsidian",
-  "version": "1.4.3",
-  "description": "Claude + Obsidian knowledge companion. Sets up a persistent, compounding wiki vault. Covers memory management, session notetaking, knowledge organization, and agent context across projects. Based on Andrej Karpathy's LLM Wiki pattern.",
+  "name": "vault-os",
+  "version": "2.0.0",
+  "description": "Opinionated Claude Code + Obsidian knowledge companion. Persistent, compounding wiki vault with harness and hooks. Fork of claude-obsidian by AgriciDaniel.",
   "author": {
-    "name": "AgriciDaniel",
-    "url": "https://github.com/AgriciDaniel"
+    "name": "saixso",
+    "url": "https://github.com/saixso"
   },
   "license": "MIT",
-  "homepage": "https://github.com/AgriciDaniel/claude-obsidian",
-  "repository": "https://github.com/AgriciDaniel/claude-obsidian",
+  "homepage": "https://github.com/saixso/vault-os",
+  "repository": "https://github.com/saixso/vault-os",
   "keywords": [
     "obsidian",
     "knowledge-base",

--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -40,8 +40,18 @@ The following Obsidian community plugins ship with this vault as pre-installed b
 
 ---
 
-## claude-obsidian
+## claude-obsidian (upstream)
 
 **Author:** AgriciDaniel / AI Marketing Hub
 **License:** MIT (see [LICENSE](LICENSE))
 **Repository:** https://github.com/AgriciDaniel/claude-obsidian
+
+vault-os is a fork of claude-obsidian. All original work, architecture, and design credit belongs to AgriciDaniel.
+
+---
+
+## vault-os fork
+
+**Maintainer:** saixso
+**Repository:** https://github.com/saixso/vault-os
+**Changes:** Rebranding, opinionated defaults, harness and hooks layer (in progress)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,64 +1,22 @@
-# claude-obsidian — Claude + Obsidian Wiki Vault
+# vault-os Development
 
-This folder is both a Claude Code plugin and an Obsidian vault.
+Fork of [claude-obsidian](https://github.com/AgriciDaniel/claude-obsidian) by AgriciDaniel.
 
-**Plugin name:** `claude-obsidian`
-**Skills:** `/wiki`, `/wiki-ingest`, `/wiki-query`, `/wiki-lint`
-**Vault path:** This directory (open in Obsidian directly)
+## Rules
 
-## What This Vault Is For
+- Keep upstream-overlapping changes to branded files only (plugin.json, marketplace.json, README, ATTRIBUTION)
+- New features go in new files/dirs — never modify upstream skill/hook/agent files
+- Branch per feature off main (`feat/<name>`)
+- Always credit AgriciDaniel/claude-obsidian as upstream
+- Test plugin install flow before any release
 
-This vault demonstrates the LLM Wiki pattern — a persistent, compounding knowledge base for Claude + Obsidian. Drop any source, ask any question, and the wiki grows richer with every session.
+## Fork Sync
 
-## Vault Structure
-
-```
-.raw/           source documents — immutable, Claude reads but never modifies
-wiki/           Claude-generated knowledge base
-_templates/     Obsidian Templater templates
-_attachments/   images and PDFs referenced by wiki pages
+```bash
+git fetch upstream
+git merge upstream/main
 ```
 
-## How to Use
+## Docs
 
-Drop a source file into `.raw/`, then tell Claude: "ingest [filename]".
-
-Ask any question. Claude reads the index first, then drills into relevant pages.
-
-Run `/wiki` to scaffold a new vault or check setup status.
-
-Run "lint the wiki" every 10-15 ingests to catch orphans and gaps.
-
-## Cross-Project Access
-
-To reference this wiki from another Claude Code project, add to that project's CLAUDE.md:
-
-```markdown
-## Wiki Knowledge Base
-Path: /path/to/this/vault
-
-When you need context not already in this project:
-1. Read wiki/hot.md first (recent context, ~500 words)
-2. If not enough, read wiki/index.md
-3. If you need domain specifics, read wiki/<domain>/_index.md
-4. Only then read individual wiki pages
-
-Do NOT read the wiki for general coding questions or things already in this project.
-```
-
-## Plugin Skills
-
-| Skill | Trigger |
-|-------|---------|
-| `/wiki` | Setup, scaffold, route to sub-skills |
-| `ingest [source]` | Single or batch source ingestion |
-| `query: [question]` | Answer from wiki content |
-| `lint the wiki` | Health check |
-| `/save` | File the current conversation as a structured wiki note |
-| `/autoresearch [topic]` | Autonomous research loop: search, fetch, synthesize, file |
-| `/canvas` | Visual layer: add images, PDFs, notes to Obsidian canvas |
-
-## MCP (Optional)
-
-If you configured the MCP server, Claude can read and write vault notes directly.
-See `skills/wiki/references/mcp-setup.md` for setup instructions.
+Project docs live in `docs/` — see `docs/roadmap.md` for phases and `docs/architecture.md` for plugin structure.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # vault-os
 
-Opinionated Claude Code + Obsidian knowledge companion. A persistent, compounding wiki vault with harness and hooks.
+A schema-agnostic context bus for AI agents. Load the right knowledge, from the right sources, in the right order — so every token in the context window earns its keep.
 
 **Fork of [claude-obsidian](https://github.com/AgriciDaniel/claude-obsidian) by [AgriciDaniel](https://github.com/AgriciDaniel).** Based on [Andrej Karpathy's LLM Wiki pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f).
 
@@ -11,14 +11,113 @@ Opinionated Claude Code + Obsidian knowledge companion. A persistent, compoundin
 
 ---
 
-## What Changed From Upstream
+## The Problem
 
-- Rebranded to `vault-os`
-- Opinionated defaults for infrastructure/platform engineering workflows
-- Harness and hooks layer (coming in v2.1)
-- Upstream syncs via `git fetch upstream`
+AI agents start blank. Every session, you re-explain the same context: what your company does, why you're building this way, who owns what, what constraints matter. The agent writes correct code but not the *right* code — because it's missing the human layer.
 
-Everything else is the same as [claude-obsidian v1.4.3](https://github.com/AgriciDaniel/claude-obsidian).
+Docs tell agents *how*. Repo configs tell agents *where*. Nothing tells them *why*.
+
+## The Vision
+
+vault-os is a **context bus** — a plugin that composes agent context windows from three non-overlapping tiers:
+
+| Tier | Owns | Answers | Source |
+|------|------|---------|--------|
+| **Local harness** | Repo-specific facts — file paths, configs, conventions | *Where* | CLAUDE.md, `.vault-os.yml` |
+| **Structured knowledge API** | Domain reference — docs, runbooks, how-to | *How* | Any MCP server or docs API |
+| **Vault** | Human layer — biz context, axioms, intent, priorities | *Why* | Obsidian vault |
+
+The vault fills the gap no other layer covers: the stuff in people's heads and Slack threads. The context people forget to give. With all three tiers composed, 5-turn disambiguation loops collapse into single turns.
+
+### Schema-agnostic by design
+
+The plugin has zero opinions on how you organize your vault. It's a context loader with a resolution engine — you bring the meaning.
+
+A repo declares what context it needs:
+
+```yaml
+# .vault-os.yml
+vault: ~/Documents/my-vault
+context:
+  - path: _axioms.md
+  - path: _biz-context.md
+  - path: domains/infrastructure/_axioms.md
+  - path: domains/infrastructure/subdomains/frontdoor/_context.md
+  - api: infra-docs
+budget:
+  per_source: 2000
+  total: 10000
+```
+
+Someone else's might look completely different:
+
+```yaml
+vault: ~/Documents/startup-brain
+context:
+  - path: principles.md
+  - path: product/north-star.md
+  - api: context7
+```
+
+Same plugin. Same metal. Different philosophy. You define the schema — DDD bounded contexts, flat files, topic clusters, whatever fits your mental model.
+
+### The metal-level pattern
+
+Swap the middle tier (structured API) and the same architecture serves completely different use cases:
+
+| Use case | Local | Structured API | Vault context |
+|----------|-------|---------------|---------------|
+| Infrastructure | repo CLAUDE.md | infra-docs MCP | biz priorities, team ownership |
+| ML project | model repo configs | context7 / HuggingFace | why this model, dataset constraints |
+| Personal project | project CLAUDE.md | library docs | goals, design taste, decided tradeoffs |
+| Incident response | runbook repo | Grafana MCP | who's on call, what changed, blast radius |
+
+The vault is the constant. The structured API is swappable. The local harness is throwaway.
+
+### Compounding, not accumulating
+
+Most knowledge systems accumulate notes and RAG from scratch every time. vault-os compounds — source #30 produces better output than source #5 because the engine reads 29 existing wiki pages before extracting. Context-aware read-before-write.
+
+---
+
+## What It Does Today
+
+vault-os is a Claude Code plugin that manages a persistent, compounding wiki vault in Obsidian.
+
+### Commands
+
+| You say | Claude does |
+|---------|------------|
+| `/wiki` | Setup check, scaffold, or continue where you left off |
+| `ingest [file]` | Read source, create wiki pages, update index and log |
+| `ingest all of these` | Batch process multiple sources with parallel agents |
+| `what do you know about X?` | Read index > relevant pages > synthesize answer |
+| `/save` | File the current conversation as a wiki note |
+| `/autoresearch [topic]` | Autonomous research loop: search, fetch, synthesize, file |
+| `/canvas` | Visual canvas layer for images, text, PDFs, wiki pages |
+| `lint the wiki` | Health check: orphans, dead links, gaps, suggestions |
+
+### Skills
+
+10 skills included: wiki orchestrator, wiki-ingest, wiki-query, wiki-lint, save, autoresearch, canvas, obsidian-markdown, obsidian-bases, defuddle.
+
+See [upstream docs](https://github.com/AgriciDaniel/claude-obsidian) for full skill documentation.
+
+---
+
+## Roadmap
+
+### Phase 1 — Wiki Engine (done)
+Ingest, query, lint, index. Context-aware extraction with compounding knowledge base. Hot cache for cross-project context sharing.
+
+### Phase 2 — Plugin + Skills (current)
+Claude Code plugin packaging. 10 skills for vault operations. Obsidian-native markdown, canvas, and bases support.
+
+### Phase 3 — Context Bus
+The three-tier architecture. `.vault-os.yml` declaration format. Schema-agnostic context loading with resolution order and token budgets. Repo-side integration where thin harnesses point at the vault instead of duplicating context.
+
+### Phase 4 — Public Release
+End-to-end install experience. Documentation. Community templates. "Drop vault-os on any vault" as a one-command setup.
 
 ---
 
@@ -27,10 +126,7 @@ Everything else is the same as [claude-obsidian v1.4.3](https://github.com/Agric
 ### Install as Claude Code plugin
 
 ```bash
-# Add the marketplace
 claude plugin marketplace add saixso/vault-os
-
-# Install the plugin
 claude plugin install vault-os@vault-os-marketplace
 ```
 
@@ -48,28 +144,14 @@ Open in Obsidian. Open Claude Code in the same folder. Type `/wiki`.
 
 ---
 
-## Commands
+## What Changed From Upstream
 
-| You say | Claude does |
-|---------|------------|
-| `/wiki` | Setup check, scaffold, or continue where you left off |
-| `ingest [file]` | Read source, create wiki pages, update index and log |
-| `ingest all of these` | Batch process multiple sources with parallel agents |
-| `what do you know about X?` | Read index > relevant pages > synthesize answer |
-| `/save` | File the current conversation as a wiki note |
-| `/autoresearch [topic]` | Autonomous research loop: search, fetch, synthesize, file |
-| `/canvas` | Visual canvas layer for images, text, PDFs, wiki pages |
-| `lint the wiki` | Health check: orphans, dead links, gaps, suggestions |
+- Rebranded to `vault-os`
+- Opinionated defaults for infrastructure/platform engineering workflows
+- Harness and hooks layer (coming in Phase 3)
+- Upstream syncs via `git fetch upstream`
 
----
-
-## Skills
-
-10 skills included: wiki orchestrator, wiki-ingest, wiki-query, wiki-lint, save, autoresearch, canvas, obsidian-markdown, obsidian-bases, defuddle.
-
-See [upstream docs](https://github.com/AgriciDaniel/claude-obsidian) for full skill documentation.
-
----
+Everything else builds on [claude-obsidian v1.4.3](https://github.com/AgriciDaniel/claude-obsidian).
 
 ## Syncing With Upstream
 

--- a/README.md
+++ b/README.md
@@ -1,114 +1,50 @@
 
-# claude-obsidian
+# vault-os
 
-<p align="center">
-  <img src="wiki/meta/claude-obsidian-gif-cover-16x9.gif" alt="claude-obsidian" width="100%" />
-</p>
+Opinionated Claude Code + Obsidian knowledge companion. A persistent, compounding wiki vault with harness and hooks.
 
-[![GitHub stars](https://img.shields.io/github/stars/AgriciDaniel/claude-obsidian?style=flat&color=e8734a)](https://github.com/AgriciDaniel/claude-obsidian/stargazers)
+**Fork of [claude-obsidian](https://github.com/AgriciDaniel/claude-obsidian) by [AgriciDaniel](https://github.com/AgriciDaniel).** Based on [Andrej Karpathy's LLM Wiki pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f).
+
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude_Code-plugin-8B5CF6)](https://code.claude.com/docs/en/discover-plugins)
-[![Blog Post](https://img.shields.io/badge/Deep_Dive-Blog_Post-22c55e)](https://agricidaniel.com/blog/claude-obsidian-ai-second-brain)
-
-Claude + Obsidian knowledge companion. A running notetaker that builds and maintains a persistent, compounding wiki vault. Every source you add gets integrated. Every question you ask pulls from everything that has been read. Knowledge compounds like interest.
-
-Based on [Andrej Karpathy's LLM Wiki pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f). **10 skills. Zero manual filing. Multi-agent support.**
+[![Upstream](https://img.shields.io/badge/upstream-claude--obsidian-orange)](https://github.com/AgriciDaniel/claude-obsidian)
 
 ---
 
-## What It Does
-### [Youtube Demo](https://www.youtube.com/watch?v=a2hgayvr-H4)
-<p align="center">
-  <img src="wiki/meta/welcome-canvas.gif" alt="Welcome canvas. Visual demo board" width="96%" />
-</p>
+## What Changed From Upstream
 
-You drop sources. Claude reads them, extracts entities and concepts, updates cross-references, and files everything into a structured Obsidian vault. The wiki gets richer with every ingest.
+- Rebranded to `vault-os`
+- Opinionated defaults for infrastructure/platform engineering workflows
+- Harness and hooks layer (coming in v2.1)
+- Upstream syncs via `git fetch upstream`
 
-You ask questions. Claude reads the hot cache (recent context), scans the index, drills into relevant pages, and synthesizes an answer. It cites specific wiki pages, not training data.
-
-You lint. Claude finds orphans, dead links, stale claims, and missing cross-references. Your wiki stays healthy without manual cleanup.
-
-At the end of every session, Claude updates a hot cache. The next session starts with full recent context, no recap needed.
-
-<p align="center">
-  <img src="wiki/meta/image-example-graph-view.png" alt="Graph view. Color-coded wiki nodes" width="48%" />
-  <img src="wiki/meta/image-example-wiki-map-view.png" alt="Wiki Map canvas" width="48%" />
-</p>
-
----
-
-## Why claude-obsidian?
-
-Most Obsidian AI plugins are chat interfaces - they answer questions about your existing notes. claude-obsidian is a knowledge engine - it creates, organizes, maintains, and evolves your notes autonomously.
-
-| Capability | claude-obsidian | Smart Connections | Copilot |
-|---|---|---|---|
-| **Auto-organize notes** | Creates entities, concepts, cross-references | No | No |
-| **Contradiction flagging** | `[!contradiction]` callouts with sources | No | No |
-| **Session memory** | Hot cache persists between conversations | No | No |
-| **Vault maintenance** | 8-category lint (orphans, dead links, gaps) | No | No |
-| **Autonomous research** | 3-round web research with gap-filling | No | No |
-| **Multi-model support** | Claude, Gemini, Codex, Cursor, Windsurf | Claude only | Multiple |
-| **Visual canvas** | Via [claude-canvas](https://github.com/AgriciDaniel/claude-canvas) companion | No | No |
-| **Query with citations** | Cites specific wiki pages | Cites similar notes | Cites notes |
-| **Batch ingestion** | Parallel agents for multiple sources | No | No |
-| **Open source** | MIT | MIT | Freemium |
-
-> **Deep dive:** [I Turned Obsidian Into a Self-Organizing AI Brain](https://agricidaniel.com/blog/claude-obsidian-ai-second-brain) - full breakdown with data visualizations, market context, and workflow demos.
+Everything else is the same as [claude-obsidian v1.4.3](https://github.com/AgriciDaniel/claude-obsidian).
 
 ---
 
 ## Quick Start
 
-### Option 1: Clone as vault (recommended: full setup in 2 minutes)
+### Install as Claude Code plugin
 
 ```bash
-git clone https://github.com/AgriciDaniel/claude-obsidian
-cd claude-obsidian
-bash bin/setup-vault.sh
-```
+# Add the marketplace
+claude plugin marketplace add saixso/vault-os
 
-Open the folder in Obsidian: **Manage Vaults → Open folder as vault → select `claude-obsidian/`**
-
-Open Claude Code in the same folder. Type `/wiki`.
-
-> `setup-vault.sh` configures `graph.json` (filter + colors), `app.json` (excludes plugin dirs), and `appearance.json` (enables CSS). Run it once before the first Obsidian open. You get the fully pre-configured graph view, color scheme, and wiki structure out of the box.
-
----
-
-### Option 2: Install as Claude Code plugin
-
-Plugin installation is a two-step process in Claude Code. First add the marketplace catalog, then install the plugin from it.
-
-```bash
-# Step 1: add the marketplace
-claude plugin marketplace add AgriciDaniel/claude-obsidian
-
-# Step 2: install the plugin
-claude plugin install claude-obsidian@claude-obsidian-marketplace
+# Install the plugin
+claude plugin install vault-os@vault-os-marketplace
 ```
 
 In any Claude Code session: `/wiki`. Claude walks you through vault setup.
 
-To check it worked:
+### Clone as vault
+
 ```bash
-claude plugin list
+git clone https://github.com/saixso/vault-os
+cd vault-os
+bash bin/setup-vault.sh
 ```
 
----
-
-### Option 3: Add to an existing vault
-
-Copy `WIKI.md` into your vault root. Paste into Claude:
-
-```
-Read WIKI.md in this project. Then:
-1. Check if Obsidian is installed. If not, install it.
-2. Check if the Local REST API plugin is running on port 27124.
-3. Configure the MCP server.
-4. Ask me ONE question: "What is this vault for?"
-Then scaffold the full wiki structure.
-```
+Open in Obsidian. Open Claude Code in the same folder. Type `/wiki`.
 
 ---
 
@@ -117,269 +53,37 @@ Then scaffold the full wiki structure.
 | You say | Claude does |
 |---------|------------|
 | `/wiki` | Setup check, scaffold, or continue where you left off |
-| `ingest [file]` | Read source, create 8-15 wiki pages, update index and log |
-| `ingest all of these` | Batch process multiple sources, then cross-reference |
+| `ingest [file]` | Read source, create wiki pages, update index and log |
+| `ingest all of these` | Batch process multiple sources with parallel agents |
 | `what do you know about X?` | Read index > relevant pages > synthesize answer |
 | `/save` | File the current conversation as a wiki note |
-| `/save [name]` | Save with a specific title (skips the naming question) |
-| `/autoresearch [topic]` | Run the autonomous research loop: search, fetch, synthesize, file |
-| `/canvas` | Open or create the visual canvas, list zones and nodes |
-| `/canvas add image [path]` | Add an image (URL or local path) to the canvas with auto-layout |
-| `/canvas add text [content]` | Add a markdown text card to the canvas |
-| `/canvas add pdf [path]` | Add a PDF document as a rendered preview node |
-| `/canvas add note [page]` | Pin a wiki page as a linked card on the canvas |
-| `/canvas zone [name]` | Add a new labeled zone to organize visual content |
-| `/canvas from banana` | Capture recently generated images onto the canvas |
+| `/autoresearch [topic]` | Autonomous research loop: search, fetch, synthesize, file |
+| `/canvas` | Visual canvas layer for images, text, PDFs, wiki pages |
 | `lint the wiki` | Health check: orphans, dead links, gaps, suggestions |
-| `update hot cache` | Refresh hot.md with latest context summary |
-
-> **Want more?** [claude-canvas](https://github.com/AgriciDaniel/claude-canvas) adds 12 templates, 6 layout algorithms, AI image generation, presentations, and full canvas orchestration. Install both — they complement each other.
 
 ---
 
-## Cross-Project Power Move
+## Skills
 
-Point any Claude Code project at this vault. Add to that project's `CLAUDE.md`:
+10 skills included: wiki orchestrator, wiki-ingest, wiki-query, wiki-lint, save, autoresearch, canvas, obsidian-markdown, obsidian-bases, defuddle.
 
-```markdown
-## Wiki Knowledge Base
-Path: ~/path/to/vault
-
-When you need context not already in this project:
-1. Read wiki/hot.md first (recent context cache)
-2. If not enough, read wiki/index.md
-3. If you need domain details, read the relevant domain sub-index
-4. Only then drill into specific wiki pages
-
-Do NOT read the wiki for general coding questions or tasks unrelated to [domain].
-```
-
-Your executive assistant, coding projects, and content workflows all draw from the same knowledge base.
+See [upstream docs](https://github.com/AgriciDaniel/claude-obsidian) for full skill documentation.
 
 ---
 
-## Six Wiki Modes
-
-| Mode | Use when |
-|------|---------|
-| A: Website | Sitemap, content audit, SEO wiki |
-| B: GitHub | Codebase map, architecture wiki |
-| C: Business | Project wiki, competitive intelligence |
-| D: Personal | Second brain, goals, journal synthesis |
-| E: Research | Papers, concepts, thesis |
-| F: Book/Course | Chapter tracker, course notes |
-
-Modes can be combined.
-
----
-
-## What Gets Created
-
-A typical scaffold creates:
-- Folder structure for your chosen mode
-- `wiki/index.md`: master catalog
-- `wiki/log.md`: append-only operation log
-- `wiki/hot.md`: recent context cache
-- `wiki/overview.md`: executive summary
-- `wiki/meta/dashboard.base`: Bases dashboard (primary, native Obsidian)
-- `wiki/meta/dashboard.md`: Legacy Dataview dashboard (optional fallback)
-- `_templates/`: Obsidian Templater templates for each note type
-- `.obsidian/snippets/vault-colors.css`: color-coded file explorer
-- Vault `CLAUDE.md`: auto-loaded project instructions
-
----
-
-## MCP Setup (Optional)
-
-MCP lets Claude read and write vault notes directly without copy-paste.
-
-Option A (REST API based):
-1. Install the Local REST API plugin in Obsidian
-2. Copy your API key
-3. Run:
-```bash
-claude mcp add-json obsidian-vault '{
-  "type": "stdio",
-  "command": "uvx",
-  "args": ["mcp-obsidian"],
-  "env": {
-    "OBSIDIAN_API_KEY": "your-key",
-    "OBSIDIAN_HOST": "127.0.0.1",
-    "OBSIDIAN_PORT": "27124",
-    "NODE_TLS_REJECT_UNAUTHORIZED": "0"
-  }
-}' --scope user
-```
-
-Option B (filesystem based, no plugin needed):
-```bash
-claude mcp add-json obsidian-vault '{
-  "type": "stdio",
-  "command": "npx",
-  "args": ["-y", "@bitbonsai/mcpvault@latest", "/path/to/your/vault"]
-}' --scope user
-```
-
----
-
-## Plugins
-
-### Core Plugins (built into Obsidian: no install needed)
-
-| Plugin | Purpose |
-|--------|---------|
-| **Bases** | Powers `wiki/meta/dashboard.base`: native database views. Available since Obsidian v1.9.10 (August 2025). **Replaces Dataview for the primary dashboard.** |
-| **Properties** | Visual frontmatter editor |
-| **Backlinks**, **Outline**, **Graph view** | Standard navigation |
-
-### Pre-installed Community Plugins (ship with this vault)
-
-Enable in **Settings → Community Plugins → enable**:
-
-| Plugin | Purpose | Notes |
-|--------|---------|-------|
-| **Calendar** | Right-sidebar calendar with word count + task dots | Pre-installed |
-| **Thino** | Quick memo capture panel | Pre-installed |
-| **Excalidraw** | Freehand drawing canvas, annotate images | Pre-installed* |
-| **Banners** | Notion-style header image via `banner:` frontmatter | Pre-installed |
-
-\* Excalidraw `main.js` (8MB) is downloaded automatically by `setup-vault.sh`. It is not tracked in git.
-
-### Also install from Community Plugins (not pre-installed)
-
-| Plugin | Purpose |
-|--------|---------|
-| **Templater** | Auto-fills frontmatter from `_templates/` |
-| **Obsidian Git** | Auto-commits vault every 15 minutes |
-| **Dataview** *(optional/legacy)* | Only needed for the legacy `wiki/meta/dashboard.md` queries. The primary dashboard now uses Bases. |
-
-Also install the **[Obsidian Web Clipper](https://obsidian.md/clipper)** browser extension. Sends web pages to `.raw/` in one click.
-
----
-
-## CSS Snippets (auto-enabled by setup-vault.sh)
-
-Three snippets ship with the vault and are enabled automatically:
-
-| Snippet | Effect |
-|---------|--------|
-| `vault-colors` | Color-codes `wiki/` folders by type in the file explorer (blue = concepts, green = sources, purple = entities) |
-| `ITS-Dataview-Cards` | Turns Dataview `TABLE` queries into visual card grids: use ` ```dataviewjs ` with `.cards` class |
-| `ITS-Image-Adjustments` | Fine-grained image sizing in notes: append `\|100` to any image embed |
-
----
-
-## Banner Plugin
-
-Add to any wiki page frontmatter:
-
-```yaml
-banner: "_attachments/images/your-image.png"
-banner_icon: "🧠"
-```
-
-The page renders a full-width header image in Obsidian. Works great for hub pages and overviews.
-
----
-
-## File Structure
-
-```
-claude-obsidian/
-├── .claude-plugin/
-│   ├── plugin.json              # manifest
-│   └── marketplace.json         # distribution
-├── skills/
-│   ├── wiki/                    # orchestrator + references (7 ref files)
-│   ├── wiki-ingest/             # INGEST operation
-│   ├── wiki-query/              # QUERY operation
-│   ├── wiki-lint/               # LINT operation
-│   ├── save/                    # /save: file conversations to wiki
-│   ├── autoresearch/            # /autoresearch: autonomous research loop
-│   │   └── references/
-│   │       └── program.md       # configurable research objectives
-│   └── canvas/                  # /canvas: visual layer (images, PDFs, notes)
-│       └── references/
-│           └── canvas-spec.md   # Obsidian canvas JSON format reference
-├── agents/
-│   ├── wiki-ingest.md           # parallel ingestion agent
-│   └── wiki-lint.md             # health check agent
-├── commands/
-│   ├── wiki.md                  # /wiki bootstrap command
-│   ├── save.md                  # /save command
-│   ├── autoresearch.md          # /autoresearch command
-│   └── canvas.md                # /canvas visual layer command
-├── hooks/
-│   └── hooks.json               # SessionStart + Stop hot cache hooks
-├── _templates/                  # Obsidian Templater templates
-├── wiki/
-│   ├── Wiki Map.canvas          # visual hub, central graph node
-│   ├── canvases/                # welcome.canvas + main.canvas (visual demos)
-│   ├── getting-started.md       # onboarding walkthrough (inside the vault)
-│   ├── concepts/                # seeded: LLM Wiki Pattern, Hot Cache, Compounding Knowledge
-│   ├── entities/                # seeded: Andrej Karpathy
-│   ├── sources/                 # populated by your first ingest
-│   └── meta/
-│       ├── dashboard.base       # Bases dashboard (primary)
-│       └── dashboard.md         # Legacy Dataview dashboard (optional)
-├── .raw/                        # source documents (hidden in Obsidian)
-├── .obsidian/snippets/          # vault-colors.css (3-color scheme)
-├── WIKI.md                      # full schema reference
-├── CLAUDE.md                    # project instructions
-└── README.md                    # this file
-```
-
----
-
-## AutoResearch: program.md
-
-The `/autoresearch` command is configurable. Edit `skills/autoresearch/references/program.md` to control:
-
-- What sources to prefer (academic, official docs, news)
-- Confidence scoring rules
-- Max rounds and max pages per session
-- Domain-specific constraints
-
-The default program works for general research. Override it for your domain. A medical researcher would add "prefer PubMed". A business analyst would add "focus on market data and filings".
-
----
-
-## Seed Vault
-
-This repo ships with a seeded vault. Open it in Obsidian and you'll see:
-
-- `wiki/concepts/`: LLM Wiki Pattern, Hot Cache, Compounding Knowledge
-- `wiki/entities/`: Andrej Karpathy
-- `wiki/sources/`: empty until your first ingest
-- `wiki/meta/dashboard.base`: Bases dashboard (works in any Obsidian v1.9.10+)
-- `wiki/meta/dashboard.md`: Legacy Dataview dashboard (optional fallback)
-
-The graph view will show a connected cluster of 5 pages. This is what the wiki looks like after one ingest. Add more sources and it grows from there.
-
-<p align="center">
-  <img src="wiki/meta/wiki-graph-grow.gif" alt="Knowledge graph growing" width="48%" />
-  <img src="wiki/meta/workflow-loop.gif" alt="Workflow loop" width="48%" />
-</p>
-
----
-
-## Companion: claude-canvas
-
-For the visual layer, [claude-canvas](https://github.com/AgriciDaniel/claude-canvas) adds AI-orchestrated canvas creation - knowledge graphs, presentations, flowcharts, mood boards with 12 templates and 6 layout algorithms. Auto-detects claude-obsidian vaults.
+## Syncing With Upstream
 
 ```bash
-claude plugin install AgriciDaniel/claude-canvas
+git fetch upstream
+git merge upstream/main
 ```
 
 ---
 
-## Community
+## Attribution
 
-- [Blog post](https://agricidaniel.com/blog/claude-obsidian-ai-second-brain) - deep dive with competitor analysis, data charts, and workflow demos
-- [AI Marketing Hub](https://www.skool.com/ai-marketing-hub) - 2,800+ members, free community
-- [YouTube](https://www.youtube.com/@AgriciDaniel) - tutorials and demos
-- [All open-source tools](https://github.com/AgriciDaniel) - claude-seo, claude-ads, claude-blog, and more
+This project is a fork of [claude-obsidian](https://github.com/AgriciDaniel/claude-obsidian) by [AgriciDaniel](https://github.com/AgriciDaniel), licensed under MIT. See [ATTRIBUTION.md](ATTRIBUTION.md) for full credits.
 
 ---
 
-*Based on [Andrej Karpathy's LLM Wiki pattern](https://gist.github.com/karpathy/442a6bf555914893e9891c11519de94f). Built by [Agrici Daniel](https://agricidaniel.com/about).*
+*Built by [saixso](https://github.com/saixso). Forked from [claude-obsidian](https://github.com/AgriciDaniel/claude-obsidian) by [AgriciDaniel](https://agricidaniel.com/about).*

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,72 @@
+# vault-os Architecture
+
+## What It Is
+
+A Claude Code plugin that turns any directory into a persistent, compounding Obsidian wiki vault. Fork of claude-obsidian with an opinionated harness layer.
+
+## Plugin Structure
+
+```
+vault-os/
+├── .claude-plugin/        Plugin manifests (vault-os branded)
+│   ├── plugin.json        Plugin identity, version, author
+│   └── marketplace.json   Marketplace distribution config
+├── skills/                Claude Code skills (from upstream)
+│   ├── wiki/              Main wiki orchestrator
+│   ├── wiki-ingest/       Source ingestion
+│   ├── wiki-query/        Query wiki content
+│   ├── wiki-lint/         Health checks
+│   ├── save/              Save conversation as note
+│   ├── autoresearch/      Autonomous research loop
+│   └── canvas/            Visual canvas layer
+├── hooks/                 Claude Code hooks (from upstream)
+├── agents/                Agent definitions (from upstream)
+│   ├── wiki-ingest/       Parallel batch ingestion agent
+│   └── wiki-lint/         Wiki health check agent
+├── commands/              CLI commands (from upstream)
+├── harness/               [Phase 2] vault-os custom layer
+├── bin/                   Setup and utility scripts
+├── docs/                  Project documentation
+└── CLAUDE.md              Agent dev instructions
+```
+
+## Upstream vs Custom
+
+| Layer | Source | Can modify? |
+|-------|--------|-------------|
+| skills/, hooks/, agents/, commands/ | Upstream (claude-obsidian) | No — sync breaks |
+| .claude-plugin/, README, ATTRIBUTION | Branded | Yes — our 4 files |
+| harness/ | vault-os custom | Yes — new dir |
+| docs/ | vault-os custom | Yes — new dir |
+
+## Per-Vault Runtime (not committed)
+
+When a user installs the plugin and runs `/wiki`, these are created in their project:
+
+```
+.raw/            Source documents (immutable, Claude reads only)
+wiki/            Generated wiki pages
+_templates/      Obsidian Templater templates
+_attachments/    Images and PDFs
+```
+
+## How Ingest Works
+
+1. User drops source into `.raw/`
+2. `ingest [file]` triggers wiki-ingest skill
+3. Skill classifies source → extracts entities/concepts
+4. Calls `create-note.sh` / `update-note.sh` to write wiki pages
+5. Updates `wiki/index.md` and `wiki/hot.md`
+
+Token cost: ~$0.10-0.50 per source depending on size.
+Use `sonnet` for bulk ingest, `opus` for complex synthesis.
+
+## Fork Sync
+
+Upstream improvements flow in via:
+```bash
+git fetch upstream
+git merge upstream/main
+```
+
+Conflicts only hit the 4 branded files. Custom work in harness/ is never touched.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,25 @@
+# vault-os Roadmap
+
+## Phase 1 — Minimum Viable Fork (DONE)
+
+- [x] Fork upstream `AgriciDaniel/claude-obsidian`
+- [x] Rebrand: plugin.json, marketplace.json, README, ATTRIBUTION
+- [x] Upstream remote configured for sync
+- [x] Branch `feat/sai-v1` → merged to main
+
+## Phase 2 — Harness & Hooks Layer
+
+- [ ] `harness/` directory — custom orchestration layer
+- [ ] Opinionated defaults for infra/platform engineering workflows
+- [ ] Custom hooks: pre-ingest validation, post-ingest graph health
+- [ ] Custom skills: `/forge` integration, project scaffolding
+- [ ] Token-aware ingest (model selection, cost tracking)
+- [ ] Auto-commit and vault health monitoring
+
+## Phase 3 — First Public Release
+
+- [ ] End-to-end install test (fresh machine)
+- [ ] Plugin marketplace submission
+- [ ] Documentation: setup guide, customization guide
+- [ ] Release notes and changelog
+- [ ] Community templates (infra wiki, SaaS brain, research vault)

--- a/skills/feature-request/SKILL.md
+++ b/skills/feature-request/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: feature-request
+description: "Capture a feature idea as a structured GitHub issue on saixso/vault-os. Walks the user through describing the feature, why it matters, and its scope, then files a labeled issue. Triggers on: /feature-request, I have a feature idea, feature request, new feature, I want to add."
+allowed-tools: Read Bash
+---
+
+# feature-request: File a vault-os feature request
+
+Capture feature ideas as structured GitHub issues on `saixso/vault-os`. One idea per invocation — keep it focused.
+
+---
+
+## Workflow
+
+### Step 1 — What
+
+Ask the user:
+
+> What's the feature? Describe it in a sentence or two.
+
+Wait for their response. Extract a short title and the description.
+
+### Step 2 — Why
+
+Ask the user:
+
+> What problem does this solve, or why does it matter?
+
+Wait for their response.
+
+### Step 3 — Scope
+
+Ask the user to pick a scope:
+
+- **Small** — hook, script, config change
+- **Medium** — new skill, new workflow
+- **Large** — architecture change, multi-skill integration
+
+Map scope to phase:
+- Small/Medium → `phase-2`
+- Large → `phase-3`
+
+### Step 4 — File the issue
+
+Create the issue using `gh`:
+
+```bash
+gh issue create \
+  --repo saixso/vault-os \
+  --title "<title>" \
+  --label "enhancement,<phase-label>" \
+  --body "<body>"
+```
+
+Issue body format:
+
+```markdown
+## Problem
+
+<why it matters — from step 2>
+
+## Proposal
+
+<feature description — from step 1>
+
+## Acceptance Criteria
+
+- [ ] <1-3 concrete criteria derived from the proposal>
+
+## Scope
+
+**<Small|Medium|Large>** — <phase-2|phase-3>
+```
+
+### Step 5 — Report
+
+Show the user the issue URL and a one-line summary.
+
+---
+
+## Constraints
+
+- One issue per invocation
+- Always target `saixso/vault-os` repo
+- Requires `gh` CLI authenticated with access to the repo
+- Do not check for duplicates — keep it simple, user can close dupes on GitHub


### PR DESCRIPTION
## Summary

- Rewrites README to communicate vault-os's evolution from wiki plugin to schema-agnostic context bus
- Adds the three-tier architecture vision: local harness (where) + structured API (how) + vault (why)
- Introduces `.vault-os.yml` as the declaration format for repo-side context loading
- Clarifies the plugin has zero opinions on vault schema — users define their own (DDD, flat files, whatever)
- Updates roadmap with Phase 3 (context bus) and Phase 4 (public release)

## Context

vault-os today does wiki operations (ingest, query, lint). The next phase turns it into a context bus that composes agent context windows from three non-overlapping tiers — so every token earns its keep and agents start smart instead of blank.

## Test plan

- [ ] README renders correctly on GitHub
- [ ] Links to upstream, badges, and attribution still work
- [ ] Quick start instructions unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)