### PR TITLE
fix(hooks): remove unsupported prompt hook from SessionStart

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,10 +7,6 @@
           {
             "type": "command",
             "command": "[ -f wiki/hot.md ] && cat wiki/hot.md || true"
-          },
-          {
-            "type": "prompt",
-            "prompt": "If a vault is configured for this session (check CLAUDE.md for VAULT_PATH or a wiki/ folder in the current directory), silently read wiki/hot.md to restore recent context. If wiki/hot.md does not exist, do nothing. This is a non-vault session. Do not announce this. Do not report what you read. Just have the context available."
           }
         ]
       }


### PR DESCRIPTION
## Summary

`SessionStart` hooks only accept `type: "command"` (per [Claude Code hook docs](https://code.claude.com/docs/en/hooks)), but `hooks/hooks.json` registers a `type: "prompt"` entry under `SessionStart`. This triggers a `SessionStart:startup hook error` on every new or resumed session.

The preceding `cat wiki/hot.md` command hook already injects the hot cache via stdout, so the prompt entry is both unsupported *and* redundant.

## Fix

Remove the `type: "prompt"` entry from the `SessionStart` block. No functionality is lost.

## Test plan

- [x] Start a new session — no hook error in the banner
- [x] Resume a session — no hook error in the banner
- [x] Confirm `wiki/hot.md` contents are still available in context

## Open question

`PostCompact` in the same file also uses `type: "prompt"`. The docs don't explicitly forbid it there, but worth a maintainer sanity check — happy to follow up in a separate PR if it's also broken.