### PR TITLE
fix(hooks): drop SessionStart/PostCompact prompt hooks (#40)

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -11,10 +11,6 @@
           {
             "type": "command",
             "command": "[ -x scripts/wiki-lock.sh ] && bash scripts/wiki-lock.sh clear-stale --max-age 3600 >/dev/null 2>&1 || true"
-          },
-          {
-            "type": "prompt",
-            "prompt": "If a vault is configured for this session (check CLAUDE.md for VAULT_PATH or a wiki/ folder in the current directory), silently read wiki/hot.md to restore recent context. If wiki/hot.md does not exist, do nothing. This is a non-vault session. Do not announce this. Do not report what you read. Just have the context available."
           }
         ]
       }
@@ -24,8 +20,8 @@
         "matcher": "",
         "hooks": [
           {
-            "type": "prompt",
-            "prompt": "Hook-injected context does not survive context compaction. If wiki/hot.md exists in the current directory, silently re-read it now to restore the hot cache. Do not announce this."
+            "type": "command",
+            "command": "[ -f wiki/hot.md ] && cat wiki/hot.md || true"
           }
         ]
       }


### PR DESCRIPTION
Fixes #40.

## Problem

`hooks/hooks.json` declares `"type": "prompt"` entries under `SessionStart` and `PostCompact`. Both lifecycles run without a `ToolUseContext` (there's no triggering tool call), so the Claude Code harness rejects them with:

> Failed to run: ToolUseContext is required for prompt hooks. This is a bug.

The harness surfaces this every session as `SessionStart:startup hook error`, and the prompt hook silently never runs.

## Fix

Converted both `prompt` hooks to `command` hooks, per the issue's suggested fix.

- **`SessionStart`** — dropped the prompt hook entirely. A preceding `command` hook already `cat`s `wiki/hot.md`, so the prompt's directive ("silently read `wiki/hot.md`") was redundant — the file content is already injected into context.
- **`PostCompact`** — replaced the prompt hook with a `command` hook that re-`cat`s `wiki/hot.md`. Same effect (re-injects the hot cache after compaction), no `ToolUseContext` required.

## Diff

```diff
     "SessionStart": [
       {
         "matcher": "startup|resume",
         "hooks": [
           {
             "type": "command",
             "command": "[ -f wiki/hot.md ] && cat wiki/hot.md || true"
           },
           {
             "type": "command",
             "command": "[ -x scripts/wiki-lock.sh ] && bash scripts/wiki-lock.sh clear-stale ..."
-          },
-          {
-            "type": "prompt",
-            "prompt": "If a vault is configured for this session ..."
           }
         ]
       }
     ],
     "PostCompact": [
       {
         "matcher": "",
         "hooks": [
           {
-            "type": "prompt",
-            "prompt": "Hook-injected context does not survive context compaction ..."
+            "type": "command",
+            "command": "[ -f wiki/hot.md ] && cat wiki/hot.md || true"
           }
         ]
       }
     ],
```

## Verification

- `jq . hooks/hooks.json` parses cleanly.
- Locally applied to the cached plugin copy; `SessionStart:startup hook error` no longer appears at session start.
- Behavior preserved: when `wiki/hot.md` exists, it's injected into context at both `SessionStart` and `PostCompact`; when it doesn't, the hook is a no-op (`|| true`).

Tested on Claude Code 2.1.132, darwin 25.4.0, `claude-opus-4-7`.
