### PR TITLE
wiki: scaffold domains/_index and log first-run bootstrap walkthrough

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ node_modules/
 .env.local
 *.local.md
 
+# Local MCP config — paths and keys are user-specific
+.mcp.json
+
 # Private keys and credentials (defense-in-depth, catches accidental drops)
 *.pem
 *.key

--- a/wiki/domains/_index.md
+++ b/wiki/domains/_index.md
@@ -1,0 +1,32 @@
+---
+type: meta
+title: "Domains Index"
+created: 2026-05-11
+updated: 2026-05-11
+tags:
+  - meta
+  - index
+status: evergreen
+related:
+  - "[[index]]"
+  - "[[overview]]"
+  - "[[concepts/_index]]"
+  - "[[entities/_index]]"
+  - "[[sources/_index]]"
+---
+
+# Domains
+
+Top-level topic areas. Each domain gets its own page here and pulls together the concepts, entities, sources, and comparisons that belong to it.
+
+This index is empty at scaffold time. Domain pages are added as the wiki accumulates enough material in a topic area to warrant a hub.
+
+## How to add a domain
+
+1. Create `wiki/domains/<Domain Name>.md` with frontmatter `type: domain`.
+2. Add a one-line entry below.
+3. Link the domain from `wiki/index.md` under `## Domains`.
+
+## Domains
+
+(none yet)

--- a/wiki/hot.md
+++ b/wiki/hot.md
@@ -1,7 +1,7 @@
 ---
 type: meta
 title: "Hot Cache"
-updated: 2026-04-24T13:10:00
+updated: 2026-05-11T00:00:00
 tags:
   - meta
   - hot-cache
@@ -19,6 +19,8 @@ related:
 Navigation: [[index]] | [[log]] | [[overview]]
 
 ## Last Updated
+
+2026-05-11: First-run bootstrap walkthrough on this vault. Obsidian install confirmed (Windows, `$env:USERPROFILE\AppData\Local\Programs\Obsidian\`). Local REST API plugin not installed; port 27124 not listening. Configured MCP via project-scope `.mcp.json` with `@bitbonsai/mcpvault@latest` (filesystem-based, no plugin/key/TLS needed), targeting the main checkout `C:\Users\gerar\Documents\Claude\claude-obsidian` rather than the worktree. Filled the only schema gap: created `wiki/domains/_index.md`. Mode confirmed as **E (Research) + meta-documentation** about the LLM Wiki pattern. Existing v1.6.0 content untouched. To unlock REST-API-only features (PATCH, Dataview-via-API), user can install Local REST API plugin and re-run `claude mcp add-json` with `--scope user`.
 
 2026-04-24 (late night): v1.6.0 public release notes shipped. `docs/releases/v1.6.0.md` (Karpathy-style, 346 lines) establishes the release-notes convention. Three original SVGs at `wiki/meta/dragonscale-{mechanism-overview,6-test-flow,frontier-graph}.svg` carry the visual load; Wikipedia dragon curve referenced by text link only (no binary vendoring). R4 codex verifier ACCEPT WITH FIXES, 3 wording fixes applied. User runs `gh release create v1.6.0 --notes-file docs/releases/v1.6.0.md` when ready. Commits `85515bb` (docs), plus wiki/meta/ auto-commits for SVGs.
 

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -25,6 +25,16 @@ Parse recent entries: `grep "^## \[" wiki/log.md | head -10`
 
 ---
 
+## [2026-05-11] bootstrap | First-run setup walkthrough
+- Verified Obsidian installation: present at `$env:USERPROFILE\AppData\Local\Programs\Obsidian\Obsidian.exe`
+- Checked Local REST API plugin: NOT installed (community-plugins.json holds excalidraw, banners, calendar, thino only). Port 27124 not listening.
+- Checked Obsidian CLI: not present.
+- Configured MCP: wrote project-scope `.mcp.json` at worktree root with `obsidian-vault` server using `@bitbonsai/mcpvault@latest` (filesystem-based, Option B). Target path is the main checkout `C:\Users\gerar\Documents\Claude\claude-obsidian`, not the worktree. No API key required, no TLS bypass, no plugin install needed.
+- Mode confirmed: Mode E (Research) + meta-documentation. Vault demonstrates the LLM Wiki pattern per [[README]] and [[overview]].
+- Created: [[domains/_index]] — fills the only schema gap vs WIKI.md Section 1.
+- Existing vault preserved: 47+ pages from v1.6.0 untouched.
+- Next steps for user (manual, optional): install Local REST API plugin from Community Plugins to unlock Option A capabilities (PATCH frontmatter, Dataview query over API, append-under-heading). When installed, re-run `claude mcp add-json obsidian-vault ...` with `--scope user` to switch to mcp-obsidian.
+
 ## [2026-04-24] save | v1.6.0 public release notes (Teams, Karpathy-style)
 - Type: release doc + visual assets
 - Locations (new): `docs/releases/v1.6.0.md` (346 lines, 6 sections, Karpathy-style prose), `wiki/meta/dragonscale-mechanism-overview.svg` (4-mechanism diagram with shared .vault-meta/ gate), `wiki/meta/dragonscale-6-test-flow.svg` (validation timeline), `wiki/meta/dragonscale-frontier-graph.svg` (M4 candidate + 3 filed pages)


### PR DESCRIPTION
Walked through WIKI.md Section 0 bootstrap on this vault. The vault was already ~90% scaffolded at v1.6.0, so this is idempotent fill-in:

- Created wiki/domains/_index.md (the only schema gap vs WIKI.md §1).
- Prepended bootstrap entry to wiki/log.md documenting what was checked (Obsidian install, port 27124, obsidian-cli) and the chosen MCP route (Option B: filesystem-based @bitbonsai/mcpvault, no plugin/key/TLS).
- Refreshed wiki/hot.md "Last Updated" with the bootstrap summary.
- Added .mcp.json to .gitignore — local MCP config holds machine-specific absolute paths and should not ship with the public plugin repo.

No existing wiki content was modified.