### PR TITLE
docs(wiki): add note on vault root vs content path for Dataview queries

### DIFF
--- a/skills/wiki/SKILL.md
+++ b/skills/wiki/SKILL.md
@@ -232,3 +232,40 @@ Do NOT show the footer after:
 - `obsidian-bases`, `obsidian-markdown` (reference skills, not output)
 - Hot cache updates, index updates, or any background maintenance
 - Error messages or prompts for more information
+ ---
+
+## Vault root vs content path — critical for Dataview
+
+Dataview `FROM "<path>"` is resolved relative to **vault root** (where `.obsidian/` lives), not relative to the open note or to the `wiki/` content folder.
+
+If the vault is structured as:
+
+```
+<vault-root>/         # .obsidian/ lives here
+├── .obsidian/
+├── .raw/
+└── wiki/             # content folder (NOT vault root)
+    ├── papers/
+    ├── Projects/
+    └── meta/
+```
+
+Then Dataview queries inside any note must address subfolders relative to `<vault-root>`:
+
+- ❌ Wrong: `FROM "papers"` → resolves to `<vault-root>/papers/` (does not exist → 0 results)
+- ✅ Right: `FROM "wiki/papers"` → resolves to `<vault-root>/wiki/papers/`
+
+Same applies to all subfolders: `wiki/Projects`, `wiki/meta`, `wiki/thesis`, etc.
+
+**Verify before writing any Dataview query in this vault:**
+
+```bash
+ls "<vault-parent>/.obsidian"   # if exists, that path IS vault root
+```
+
+If `.obsidian/` is at the same level as `wiki/`, then `wiki/` is NOT vault root, and all Dataview paths must be prefixed with `wiki/`.
+
+**Symptom of getting this wrong:** Dataview blocks render with "No results to show for table/list query" even though the folder contains hundreds of files.
+
+This rule applies when creating synthesis matrices, dashboards, lint reports, query notes, or any artefact that embeds Dataview queries.
+


### PR DESCRIPTION
 "Documents the path-resolution rule that trips up agents creating Dataview queries when content lives in a wiki/ subfolder"

```markdown
## Problem

When the vault is structured with content under a `wiki/` subfolder (per this plugin's standard scaffold), Dataview queries inside notes silently return zero results if they use `FROM "papers"` instead of `FROM "wiki/papers"`. The Dataview engine resolves `FROM` paths relative to the **vault root** (the directory containing `.obsidian/`), not relative to the open note or to the `wiki/` content folder.

This trips up agents (and humans) who assume the `wiki/` content folder IS the vault root. Symptom: every Dataview block in a newly-created synthesis matrix, dashboard, or query note renders `Dataview: No results to show for table/list query` despite the folder containing hundreds of files.

I hit this bug across 4 newly-created vault files in a single session (synthesis-matrix, lit-review-protocol, recipe doc, ingest-candidates doc) before noticing the path-resolution rule. Promoting the rule into `skills/wiki/SKILL.md` makes it active context for any future agent creating Dataview-enabled notes in a vault that follows the standard scaffold this plugin sets up.

## Change

Adds a new section "Vault root vs content path — critical for Dataview" at the end of `skills/wiki/SKILL.md` (after the "When to skip" footer block). The section:

- Explains the path-resolution rule
- Shows the standard vault scaffold tree
- Gives wrong/right examples
- Provides a one-line `ls` verification command
- Names the failure symptom so users can recognize it

No code changes. Pure documentation addition.

## Test plan

- [x] Created a Dataview query in a vault folder structured per the standard scaffold (`<vault-root>/wiki/papers/`) — `FROM "papers"` returns 0 results
- [x] Confirmed `FROM "wiki/papers"` returns expected files
- [x] Verified `.obsidian/` location confirms vault root resolution
```

---
