### PR TITLE
fix: replace prompt-type PostCompact hook with command-type

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,10 +7,6 @@
           {
             "type": "command",
             "command": "[ -f wiki/hot.md ] && cat wiki/hot.md || true"
-          },
-          {
-            "type": "prompt",
-            "prompt": "If a vault is configured for this session (check CLAUDE.md for VAULT_PATH or a wiki/ folder in the current directory), silently read wiki/hot.md to restore recent context. If wiki/hot.md does not exist, do nothing. This is a non-vault session. Do not announce this. Do not report what you read. Just have the context available."
           }
         ]
       }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -16,8 +16,8 @@
         "matcher": "",
         "hooks": [
           {
-            "type": "prompt",
-            "prompt": "Hook-injected context does not survive context compaction. If wiki/hot.md exists in the current directory, silently re-read it now to restore the hot cache. Do not announce this."
+            "type": "command",
+            "command": "[ -f wiki/hot.md ] && cat wiki/hot.md || true"
           }
         ]
       }


### PR DESCRIPTION
## Summary

- Replaces the `PostCompact` `prompt`-type hook with the same `command`-type pattern already used by `SessionStart` (post-`fc5bb32`).
- Mirrors the rationale of the existing SessionStart fix: Claude Code is tightening prompt-type hook enforcement, and `cat wiki/hot.md` works equivalently via STDOUT capture.

## Context

Filed as #48. Worth noting: `fc5bb32` removed the SessionStart prompt-type hook on `main` but **was never tagged/released** — v1.6.0 in the Claude Code marketplace still ships both prompt-type hooks, so users on the latest release see this error in the TUI banner:

```
Failed to run: prompt-type hooks are not supported for SessionStart events
(no conversation context is available). Use a command-type hook instead.
```

A v1.6.1 (or similar) release cut after this merge would push both fixes to marketplace users.

## Test plan

- [ ] `python3 -c "import json; json.load(open('hooks/hooks.json'))"` — JSON validates
- [ ] Start a Claude Code session in a vault directory — `wiki/hot.md` still loads via STDOUT
- [ ] Start a Claude Code session in a non-vault directory — no error; hook is a no-op
- [ ] Trigger compaction — `wiki/hot.md` reloads after compact (if vault present)

## Out of scope

- The `Stop` hook is unaffected (was already converted in `e54b419`).
- No changes to `PostToolUse` or other hooks.
