### PR TITLE
feat: migrate 9 chat transcripts to vault (wiki + sources)

### DIFF
--- a/sources/2026-05-07--prix-demi-magret-gers.md
+++ b/sources/2026-05-07--prix-demi-magret-gers.md
@@ -1,0 +1,48 @@
+---
+title: Étude prix — Demi magret dans le Gers (2026)
+type: source
+status: active
+created: 2026-05-07
+origin: Web research pour Ô Païs
+---
+
+# Étude prix — Demi magret dans le Gers (2026)
+
+## Source brute
+Recherche web du 7 mai sur les prix affichés pour un demi magret à la carte en France et spécifiquement dans le Gers, pour déterminer positionnement tarifaire d'Ô Païs.
+
+## Résumé utile
+**Fourchette générale (France, mai 2026)**
+- Restauration populaire/chaînes : 14-18 €
+- Brasseries/bistrots qualité : 18-24 €
+- Restaurants terroir Sud-Ouest : 20-28 € (segment où magret excelle)
+- Gastronomique : 28-40 € minimum
+
+**Données Gers (confirmées sur terrain)**
+- Le Neuvième (Auch, brasserie) : 13 € le demi magret (baseline bas)
+- Auberge du Lac (Gondrin) : ~18-22 € estimé (menu 13-29,50 €)
+- Au Canard Gourmand (Samatan, gastronomique) : 25-30 € estimé
+- Terroir intermédiaire (local) : 18-23 € positionne bien dans région
+
+**Recommandation Ô Païs**
+Avec positionnement "cuisine gasconne authentique + produit IGP", fourchette **19-24 €** est juste pour le Gers.
+- En dessous de 18 € : risque de dévalorisation du plat en sa région
+- Au-dessus de 25 € : nécessite justification (sauce travaillée, accompagnement premium)
+
+## Décisions / idées clés
+- Seul prix avec mention explicite "demi" confirmé : 13 € (Le Neuvième)
+- Autres données possiblement pour magret entier (à diviser par ~2)
+- Variable clé : Label produit (IGP = +20-30 %) + accompagnement inclus
+- Région Gers historiquement compétitive sur canard vs Paris
+
+## Actions
+- [ ] Valider prix menu Ô Païs contre 19-24 € benchmark
+- [ ] Checker si produit IGP/Label Rouge (ajuste prix +)
+- [ ] Surveiller prix concurrent (Auberge du Lac, Canard Gourmand)
+- [ ] Revalidate T+6m (données saisonnières)
+
+## Wikilinks
+- [[ô-païs]]
+- [[menu-pricing]]
+- [[product-positioning]]
+- [[market-research]]

--- a/sources/2026-05-07--soiree-blanche-opais-initial.md
+++ b/sources/2026-05-07--soiree-blanche-opais-initial.md
@@ -1,0 +1,71 @@
+---
+title: Soirée Blanche Ô Païs — Planification initiale (13 juin)
+type: source
+status: active
+created: 2026-05-07
+origin: Chat #5 — Organisation soirée anniversaire 1 an
+---
+
+# Soirée Blanche Ô Païs — Planification initiale (13 juin)
+
+## Source brute
+Chat du 7 mai — première session de planification de la Soirée Blanche pour le 1er anniversaire d'Ô Païs. Contexte : restauration (assis/buffet), animations, contraintes (capacité, budget). Proposition déco extérieur/terrasse et checklist organisation.
+
+## Résumé utile
+**Événement**
+- Date : 13 juin 2026, 19h30-23h+ 
+- Lieu : Restaurant Ô Païs, La Sauvetat (32500)
+- Format : Buffet libre-service + 2 braseros BBQ (cocktail dinatoire)
+- Capacité : 80-100 invités (25-30 assis, 50-70 debout/circulant)
+- Budget déco : 1000 € (détail fourni)
+
+**Concept déco**
+Blanc pur (nappes, guirlandes, lanternes) + accents terroir (rouge brique, vert sauge). Sobre, chic, authentique.
+
+**Budget déco breakdown** (~1050 €)
+- Guirlandes blanches 50m : 80€
+- Lanternes papier x20 : 100€
+- Nappes lin blanc : 120€
+- Arches/tuteurs bambou : 150€
+- Fleurs blanches/feuillages : 200€
+- Bougies piliers x30 : 80€
+- Signalétique bois : 100€
+- Location chaises/tabourets : 150€
+- Décor BBQ (bandeaux, filets) : 80€
+- Imprévus/contingence : 20€
+
+**Zones terrasse**
+- Entrée : Arche floral + accueil champagne
+- Buffet : Étages bois + nappes lin + fleurs
+- BBQ : 2 braseros + décor blanc/rouge, service tournant
+- Podium/DJ : Centre terrasse si musique
+- Éclairage : Guirlandes blanc chaud criss-cross
+
+**Risques & parade**
+- Pluie (30%) : Toile blanche secours + plan B intérieur
+- Guirlandes défaut (20%) : Test 2j avant, ampoules rechange
+- BBQ sous-alimentés (40%) : 2x viande prévue
+- Invitations ignorées (50%) : Relances J-7, J-3
+- Buffet dégrade (20%) : Glaçons + réfrigérateur secours
+
+## Décisions / idées clés
+- Pallette colors : Blanc pur, rouge brique #A3362C, vert sauge #9BA17B
+- Format cocktail optimise flexibilité vs. assis strict
+- Guirlandes Edison criss-cross = ambiance soirée clé
+- Test électricité J-1 obligatoire
+- Checklist semaine par semaine (fin mai → J-1)
+
+## Actions
+- [ ] Valider format final restauration (assis % vs buffet %)
+- [ ] Confirmer budget 1000 € auprès direction
+- [ ] Contacter fleuriste La Sauvetat pour devis blanc/vert sauge
+- [ ] Commander guirlandes/lanternes (délai 5-7j)
+- [ ] Imprimer 50 affiches A3 (design Canva à créer)
+- [ ] Lancer invitations Google Form/Eventbrite
+- [ ] Valider animations audio (DJ vs musicien live)
+
+## Wikilinks
+- [[ô-païs]]
+- [[events-planning]]
+- [[decoration-low-cost]]
+- [[event-timeline]]

--- a/sources/2026-05-12--comparatif-enceintes-denon-sonos.md
+++ b/sources/2026-05-12--comparatif-enceintes-denon-sonos.md
@@ -1,0 +1,49 @@
+---
+title: Comparatif prix — Enceintes Denon & Sonos (mai 2026)
+type: source
+status: active
+created: 2026-05-12
+origin: Web research — Marché audio
+---
+
+# Comparatif prix — Enceintes Denon & Sonos (mai 2026)
+
+## Source brute
+Recherche web du 12 mai sur les meilleurs prix actuels en France pour 4 modèles spécifiques, conditions strictes : livraison FR, produits neufs, sites de confiance/spécialisés, pas de tiers-vendeurs.
+
+## Résumé utile
+**Meilleurs prix mai 2026**
+| Produit | Prix | Revendeur |
+|---------|------|-----------|
+| Denon Home 150 | 179 € | PcComponentes |
+| Denon Home 150 NV | 229 € | Vendeurs agréés |
+| Sonos Era 100 | 189-229 € | Amazon (189 €) / Fnac (229 €) |
+| Sonos Roam | 179 € | idealo.fr / leDénicheur |
+
+**Offres & promotions actuelles**
+- **Sonos** : Pack 2 Era 100 (458→433€ reduction), 3 mois Apple Music offerts, livraison gratuite, retours 30j, alignement prix accepté
+- **Fnac** : 5% adhérents Fnac+ (14,99€/an), 3 mois Deezer Premium offerts
+- **Denon** : Black Friday jusqu'à 40% (sélection), reprise matériel ancien variable
+
+**Revendeurs recommandés**
+- Fnac.com : 229,99 € (stock online + retrait magasin)
+- Sonos.com/fr-fr : 229 € prix officiel, packs exclusifs
+- PcComponentes : Meilleur prix Denon (179 €)
+- Futureland : Conseil spécialisé français
+
+## Décisions / idées clés
+- Era 100 le plus flexible (prix Amazon compétitif vs Fnac)
+- Denon Home 150 = meilleur rapport prix/qualité Denon
+- Sonos applique alignement prix—vérifier réclamation si moins cher trouvé ailleurs
+- Reprise ancien matériel utile pour réduction supplémentaire
+
+## Actions
+- [ ] Vérifier prix jour J (market volatility m-o-m)
+- [ ] Comparer packs (2 Era 100) vs achat individuel
+- [ ] Demander devis reprise matériel ancien
+- [ ] Vérifier délai livraison par revendeur
+
+## Wikilinks
+- [[product-research]]
+- [[pricing-analysis]]
+- [[market-data]]

--- a/sources/2026-05-12--soiree-blanche-opais-detailed.md
+++ b/sources/2026-05-12--soiree-blanche-opais-detailed.md
@@ -1,0 +1,105 @@
+---
+title: Soirée Blanche Ô Païs — Plan d'action complet (13 juin)
+type: source
+status: active
+created: 2026-05-12
+origin: Chat #7 — Détail organisation événement
+---
+
+# Soirée Blanche Ô Païs — Plan d'action complet (13 juin)
+
+## Source brute
+Chat du 12 mai — planification détaillée de la Soirée Blanche. Format : Buffet BBQ + Cocktail, 80-100 invités (60 midi/60 soir), budget déco 1000€, animations DJ + 2 moments clés structurés, déroulé minute-by-minute J-15 à J+7.
+
+## Résumé utile
+**CONCEPT DÉCO — "Blanche Terrasse, Cœur Gascon"**
+Blanc pur (élégance) + Accents rouge brique (signature Ô Païs) + vert sauge (nature locale), éclairage blanc chaud.
+
+**LAYOUT TERRASSE FONCTIONNEL**
+- Entrée : Arche floral + accueil champagne + registre/QR code
+- Buffet : Étages bois naturel (3 niveaux), nappes lin blanc, napperon rouge brique, fleurs pivoines
+- BBQ : 2 braseros, bandeaux tissu blanc, service tournant assiettes/serviettes lin
+- Podium : Micro + pancarte anniversaire (si musique live) ou DJ zone
+- Ambiance globale : Guirlandes blanc chaud criss-cross, lanternes papier x20, bougies piliers
+
+**PHASES ORGANISATION**
+
+*Phase 1 — Conception (fin mai)*
+- Valider format restauration + capacité + budget
+- Sketches déco (texte + croquis)
+- Lancer invitations RS + email
+- Commandes guirlandes/lanternes (délai 5-7j)
+- Design affiche Canva
+- Imprimer 50 affiches A3
+
+*Phase 2 — Logistique (1-10 juin)*
+- Livraison déco (stocker intérieur)
+- Confirmer fournisseurs BBQ/viande
+- Affichage terrasse interne (panneaux bois)
+- Test guirlandes électriques
+- Nettoyage terrasse complet (enlever voiles ombrage)
+
+*Phase 3 — Communication (J-14 à J-1)*
+- J-14 (30 mai) : Story teaser "Surprise"
+- J-10 (3 juin) : Post affiche officielle
+- J-7 (6 juin) : Story "Countdown" + relance emails
+- J-3 (10 juin) : Reel 30s ambiance préparée
+- J-2 (11 juin) : Story "Demain!!!" + infos pratiques
+- J-1 soir : Setup live story (test batterie/lumière)
+
+*Phase 4 — Jour J (13 juin) — Timeline minute-by-minute*
+| Heure | Action | Responsable |
+|-------|--------|-------------|
+| 15h00 | Arrivée équipe setup | Admin + 2 bénévoles |
+| 15h15 | Installation guirlandes | Technique |
+| 15h30 | Dressage buffet (structure) | Chef + aide |
+| 15h45 | Lanternes + bougies | Déco |
+| 16h00 | Arches florale + accueil | Fleuriste |
+| 16h15 | Test son (si musique) | DJ/Musicien |
+| 16h30 | Vérification globale | Patron |
+| 17h00 | Équipe tenue blanc/noir | Tous |
+| 18h00 | OUVERTURE PORTES | Accueil |
+| 19h00 | Affluence principale + service | Équipe |
+| 19h15 | Braseros allumés | Chef |
+| 20h00 | TOAST COLLECTIF | Patron |
+| 20h15 | Musique/animations | DJ |
+| 20h30-22h00 | SOIRÉE PLEINE | Équipe |
+| 22h00 | Moment dessert/digestif | Chef |
+| 23h00 | Fin service | Patron |
+| 23h30 | Nettoyage terrasse | Équipe |
+| 00h30 | Fin complète | Admin |
+
+**RISQUES & PARADES**
+- Pluie (30%) : Toile blanche secours + plan intérieur
+- Guirlandes grillées (20%) : Vérifier 2j avant + rechanges
+- BBQ files d'attente (40%) : 2x viande + 3e personne service
+- Invitations ignorées (50%) : Relances J-7, J-3 obligatoires
+- Musique mauvaise (30%) : Test J-1, playlist votée
+- Bougies rechargement (25%) : Acheter 50% extra
+- Oubli photos (10%) : Désigner 1 photographe officiel
+- Blackout électrique (5%) : Groupe électrogène standby
+
+## Décisions / idées clés
+- **4 phases calendrier** : Conception → Logistique → Communication → Jour J
+- **Timeline minutée** : Permet anticipation et pilotage real-time
+- **Risques documentés** : Permet escalades préventives vs urgences
+- **Roles clairs** : Chacun sait sa responsabilité
+- **Livrables Canva** : 3 templates (affiche + story x2 + reel) prêts à dupliquer
+
+## Actions
+- [ ] Lancer invitations dès lundi 25 mai
+- [ ] Imprimer 50 affiches A3 d'ici 29 mai
+- [ ] Confirmer commandes déco avant 26 mai (livraison J+5/7)
+- [ ] Briefing équipe jeudi 12 juin (17h)
+- [ ] Tests électricité + DJ le même jour
+- [ ] Imprimer déroulé minute-by-minute pour équipe
+- [ ] Photographe désigné
+- [ ] Groupe électrogène loué (standby)
+
+## Wikilinks
+- [[ô-païs]]
+- [[event-planning-process]]
+- [[event-timeline]]
+- [[risk-management]]
+- [[decoration-planning]]
+- [[social-media-calendar]]

--- a/sources/2026-05-16--canva-templates-opais-anniversaire.md
+++ b/sources/2026-05-16--canva-templates-opais-anniversaire.md
@@ -1,0 +1,92 @@
+---
+title: Templates Canva — 1 an Ô Païs (3 variantes)
+type: source
+status: active
+created: 2026-05-16
+origin: Chat #8 — Design Canva événement
+---
+
+# Templates Canva — 1 an Ô Païs (3 variantes)
+
+## Source brute
+Chat du 16 mai — création de 3 templates Canva pour la Soirée Blanche du 1er anniversaire (20 juin 2026, 12h-4h). Formats : Affiche 1080×1080 + A3, Story teaser 1080×1920 (x3 versions), Reel vidéo 1080×1920 (25-30s). 
+
+Deux variantes de palette :
+- **Variante 1 (Rouge brique)** : Authenticité terroir, convivialité
+- **Variante 2 (Or & Blanc)** : Sophistication, prestige
+
+## Résumé utile
+**TEMPLATE #1 — AFFICHE 1080×1080 + A3**
+- Utilisation : Post principal Instagram/Facebook + Print
+- Visuel : Photo terrasse (Images 8-9) en hero, ambiance naturelle
+- Texte : Playfair Display (titres) + Raleway (corps)
+- Éléments clés : Date/Heure/Lieu/Téléphone/Logo/Hashtags
+
+**TEMPLATE #2 — STORY TEASER 1080×1920 (x3)**
+- Utilisation : Stories épinglées J-7, J-3, J-1 (countdown progressif)
+- Tone : Chaleureux teaser → Urgence → Veille finale
+- Animations optionnelles : Countdown timer, pulsing text
+
+**TEMPLATE #3 — REEL AMBIANCE 1080×1920 + vidéo**
+- Utilisation : Instagram Reels / TikTok (25-30s)
+- Contenu : Montage 5-6 photos (terrasse, clients, grillades, bougies)
+- Transitions : Fade + zoom progressif
+- Musique : Festive (Variante 1) vs Élégante lounge (Variante 2)
+
+**PALETTE VARIANTE 1 — ROUGE BRIQUE (Terroir)**
+| Couleur | HEX | Usage |
+|---------|-----|-------|
+| Rouge brique | #A3362C | Titres, accents signature |
+| Beige lin | #F2E9DC | Fonds, overlays, texte |
+| Vert sauge | #9BA17B | Détails nature |
+| Brun chêne | #4A3F35 | Texte principal |
+
+**Typographies**
+- Playfair Display : Titres élégants (32-40pt)
+- Raleway gras : Sous-titres (18-20pt)
+- Raleway régulier : Infos pratiques (14pt)
+
+**PALETTE VARIANTE 2 — OR & BLANC (Prestige)**
+| Couleur | HEX | Usage |
+|---------|-----|-------|
+| Or doré | #D4A574 | Titres, bordures prestige |
+| Blanc pur | #FFFFFF | Fonds, overlays, texte |
+| Vert sauge | #9BA17B | Détails nature (conservé) |
+| Gris foncé | #5A5550 | Texte principal |
+
+**TONE & AMBIANCE**
+- Variante 1 : Chaleur conviviale, festive, terroir affirmé, restaurant ami
+- Variante 2 : Sophistication élégante, événement chic/mariage, clientèle prestige
+
+**PLANNING PUBLICATION**
+| Date | Contenu | Format | Heure | Palette |
+|------|---------|--------|-------|---------|
+| J-7 (13 juin) | Story teaser | Story 24h | 18h | Variante choisie |
+| J-3 (17 juin) | Story + Reel | Story + Reel | 10h + 18h | Variante choisie |
+| J-1 (19 juin) | Story veille | Story 24h | 19h | Variante choisie |
+| Jour J (20 juin) | Affiche officielle + Reel live | Post + Reel | 11h30 + 14h | Variante choisie |
+
+## Décisions / idées clés
+- **2 palettes parallèles** : Terroir vs Prestige (choix selon cible)
+- **Photo hero obligatoire** : Images 8-9 (terrasse) = authenticité
+- **Texte tone** : "On fête nos 1 an avec vous ! À taula !" (chaleureux/familier)
+- **Dupliquer stratégie** : Une fois template bon → dupliquer, modifier juste texte
+- **Mobile preview** : Toujours tester aspect "Téléphone" avant publication
+
+## Actions
+- [ ] Choisir Variante 1 (rouge brique) ou Variante 2 (or blanc)
+- [ ] Créer 3 designs Canva personnalisés (affiche + story x3 + reel)
+- [ ] Insérer Images 8-9 (terrasse) + logo Ô Païs
+- [ ] Copier codes HEX exactement (pipette Canva)
+- [ ] Tester lisibilité texte sur photos (overlay overlay 40% si besoin)
+- [ ] Exporter formats PNG haute qualité
+- [ ] Pour Reel : Importer dans CapCut (gratuit) + musique + transitions (optionnel)
+- [ ] Planifier publication Meta Business Suite par date/heure
+- [ ] Voir [[social-media-calendar]] pour détails temps-posts
+
+## Wikilinks
+- [[ô-païs]]
+- [[canva-design-templates]]
+- [[social-media-strategy]]
+- [[brand-colors]]
+- [[visual-design]]

--- a/sources/2026-05-18--opais-ouverture-jeudi-soir.md
+++ b/sources/2026-05-18--opais-ouverture-jeudi-soir.md
@@ -1,0 +1,93 @@
+---
+title: Annonce — Ouverture jeudi soir Ô Païs (publication)
+type: source
+status: active
+created: 2026-05-18
+origin: Chat #9 — Design + texte announcement
+---
+
+# Annonce — Ouverture jeudi soir Ô Païs (publication)
+
+## Source brute
+Chat du 18 mai — création d'une publication pour annoncer que Ô Païs est désormais ouvert le jeudi soir. Design Canva 1080×1080 px carré (Instagram/Facebook) + texte post prêt à copier-coller.
+
+## Résumé utile
+**DESIGN CANVA 1080×1080 PX**
+- **Haut (55%)** : Photo terrasse (Images 8-9)
+- **Bas (45%)** : Bandeau rouge brique #A3362C
+- **Logo** : Ô Païs en coin bas droit (55×55px)
+- **Palette** : Rouge brique + Blanc pur + Beige lin
+- **Typographies** : Playfair Display (titres) + Raleway (corps)
+
+**LAYOUT BANDEAU ROUGE**
+```
+┌─────────────────────────────┐
+│    🌙 NOUVEAUTÉ 🌙         │
+│                             │
+│  JEUDI SOIR                 │
+│  CHEZ NÔ PAÏS               │
+│                             │
+│  À partir de 18h            │
+│  Terrasse • Grillades       │
+│                             │
+│  Tous les jeudis            │
+│  Réservation : 05.62...     │
+│                             │
+│         À taula !      [Logo]
+└─────────────────────────────┘
+```
+
+**TEXTE POST — COPY-PASTE DIRECT**
+```
+🎉 Bonne nouvelle !
+
+Ô Païs est désormais ouvert chaque jeudi soir ! 🌙
+
+Rejoingnez-nous pour des moments authentiques autour d'une table. 
+Cuisine de caractère, cœur de terroir.
+
+Réservation : 05.62.66.36.15 | opais32500@gmail.com
+
+#OPaisSauvetat #CuisineDeCaractere #TerroirDuGers 
+#SoiréeGastronomique #RestaurantDuGers #TaverneLaSauvetat
+```
+
+**ÉLÉMENTS BRANDING RESPECTÉS**
+- ✅ Palette : Rouge brique, beige lin, vert sauge, brun chêne
+- ✅ Typographie : Playfair Display + Raleway
+- ✅ Logo : Visible et intégré
+- ✅ Slogan : "Cuisine de caractère, cœur de terroir"
+- ✅ Coordonnées : Téléphone + email
+- ✅ Hashtags : Locaux + gastronomiques
+
+**PLANNING PUBLICATION**
+| Quand | Quoi | Plateforme | Heure |
+|-------|------|-----------|-------|
+| Lundi | Post annonce | Insta + Facebook | 9h30 |
+| Jeudi J-1 | Story teaser | Stories | 17h |
+| Jeudi jour J | Post/Story rappel | Réseaux | 17h30 |
+| Récurrents | Chaque jeudi | Réseaux | 17h30 |
+
+## Décisions / idées clés
+- **Tone** : Enthousiaste + accueillant, fidèle à essence Ô Païs
+- **Visuel terrasse** = Identité authentique forte
+- **Hashtags locaux** : Meilleure visibilité région Gers
+- **Post structuré** : Hook + bénéfice + CTA + coordonnées + hashtags
+
+## Actions
+- [ ] Créer design Canva 1080×1080
+- [ ] Importer logo.png + photo terrasse
+- [ ] Assembler (12 étapes détaillées fourni en chat)
+- [ ] Exporter PNG haute qualité
+- [ ] Nommer : `OPAIS_OuvertLeJeudi_JeudiSoir.png`
+- [ ] Copier texte post (voir ci-dessus)
+- [ ] Planifier publication Meta Business Suite (lundi 9h30)
+- [ ] Ajouter story teaser jeudi J-1 (17h)
+- [ ] Rappel jour J (17h30)
+- [ ] Scheduler récurrent jeudi 17h30 (si possible)
+
+## Wikilinks
+- [[ô-païs]]
+- [[social-media-posts]]
+- [[announcements]]
+- [[brand-colors]]

--- a/wiki/claude-code-remote-control.md
+++ b/wiki/claude-code-remote-control.md
@@ -1,0 +1,40 @@
+---
+title: Claude Code Remote Control — Accès mobile
+type: wiki
+status: active
+created: 2026-05-07
+origin: Chat #2 — Lancer Chef Tool depuis téléphone
+---
+
+# Claude Code Remote Control — Accès mobile
+
+## Source brute
+Chat du 7 mai sur comment lancer et accéder à Claude Code depuis un téléphone iOS/Android, en utilisant la feature Remote Control d'Anthropic.
+
+## Résumé utile
+**Remote Control** permet de contrôler une session Claude Code du desktop depuis l'app Claude sur téléphone :
+- **Installation** : Claude Code v2.1.51+ + app Claude sur téléphone + compte Claude Pro/Team/Enterprise
+- **Lancer** : `claude --remote-control` sur l'ordi
+- **Connecter** : Même compte sur le téléphone → session visible immédiatement
+- **Notifications push** : Activables via `/config` "Push when Claude decides"
+- **Auto-activation** : `/config` → "Enable Remote Control for all sessions" = `true`
+
+## Décisions / idées clés
+- **Solution officielle** : Remote Control est le chemin Anthropic (pas de workaround)
+- **Zero friction** : Pas de QR codes ni manuel—session en cours se sync direct
+- **Notifications** : Utile pour tâches longues (alertes quand terminées)
+- **Auto-enable** : Recommandé pour workflows mobiles fréquents
+
+## Actions
+- [ ] Vérifier version Claude Code : `claude --version` (>= v2.1.51)
+- [ ] Installer app Claude sur téléphone (iOS ou Android)
+- [ ] Lancer `claude --remote-control` sur desktop
+- [ ] Se connecter avec même compte sur téléphone
+- [ ] Tester accès session en cours
+- [ ] Optionnel : Activer notifications via `/config`
+- [ ] Optionnel : Auto-enable Remote Control via `/config`
+
+## Wikilinks
+- [[claude-code]]
+- [[mobile-workflow]]
+- [[config-settings]]

--- a/wiki/claude-code-session-integration.md
+++ b/wiki/claude-code-session-integration.md
@@ -1,0 +1,42 @@
+---
+title: Intégration Claude Code — Guide complet
+type: wiki
+status: active
+created: 2026-05-06
+origin: Chat #1 — Chef Tool
+---
+
+# Intégration Claude Code — Guide complet
+
+## Source brute
+Chat du 6 mai portant sur l'intégration d'une session Claude Code (CHEF TOOL) dans un projet existant. Discussion autour de la récupération, l'exportation et l'archivage de sessions locales vers un CLAUDE.md project.
+
+## Résumé utile
+Comment intégrer une session Claude Code existante dans un projet :
+- **Récupérer session** : `claude --resume CHEF-TOOL` ou `/stats` pour voir toutes ses sessions
+- **Exporter résumé** : `/summary` dans la session active
+- **Automatiser setup** : Script bash `integrate-claude-session.sh` (30 secondes)
+- **Persister contexte** : Créer CLAUDE.md avec `.chef-tool-context/` subdirs
+- **Synchroniser** : Script `sync-session.sh` pour mises à jour régulières
+
+## Décisions / idées clés
+- **Structure proposée** : `.chef-tool-context/` pour archiver contexte + config
+- **Automatisation CLI** : Script ready-to-run pour setup complet
+- **Contexte persistant** : CLAUDE.md permet chargement auto dans futures sessions
+- **3 phases** : Récupération (5min) → Intégration (5min) → Version Control (2min)
+- **Traceabilité** : Manifest + docs = équipe synchronisée via git
+
+## Actions
+- [ ] Télécharger 7 fichiers livrés (integrate-claude-session.sh + guides)
+- [ ] Lire RECUPERER-SESSION.md en premier
+- [ ] Exécuter `claude --resume CHEF-TOOL -p "/summary"` sur machine locale
+- [ ] Lancer `bash integrate-claude-session.sh . CHEF-TOOL` dans project racine
+- [ ] Remplir `.chef-tool-context/claude-code-session-*.md` avec contenu
+- [ ] Valider avec checklist EXECUTION-CHECKLIST.md
+- [ ] Commit dans git : `feat: integrate Claude Code session CHEF-TOOL`
+
+## Wikilinks
+- [[claude-code]]
+- [[project-structure]]
+- [[CLAUDE.md-configuration]]
+- [[git-workflow]]

--- a/wiki/claude-code.md
+++ b/wiki/claude-code.md
@@ -1,0 +1,20 @@
+---
+type: wiki
+status: hub
+title: "Claude Code — Hub"
+created: 2026-05-20
+updated: 2026-05-20
+related:
+  - "[[overview]]"
+  - "[[index]]"
+---
+
+# Claude Code Hub
+
+Workspace integration patterns and session management guides for Claude Code.
+
+## Pages
+
+- [[claude-code-session-integration]] — Guide complet pour intégrer une session Claude Code existante dans un projet
+- [[claude-code-remote-control]] — Mobile access via Remote Control setup et synchronisation des sessions
+- [[rnm-web-scraper-guide]] — Python Playwright scraper pour extraire les données produits RNM

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -88,6 +88,23 @@ Navigation: [[overview]] | [[log]] | [[hot]] | [[dashboard]] | [[Wiki Map]] | [[
 
 ---
 
+## Recently Migrated (May 2026)
+
+### Claude Code
+- [[claude-code-session-integration]] — Guide complet pour intégrer une session Claude Code existante dans un projet
+- [[claude-code-remote-control]] — Mobile access via Remote Control setup et synchronisation des sessions
+- [[rnm-web-scraper-guide]] — Python Playwright scraper pour extraire les données produits RNM
+
+### Ô Païs Business
+- [[2026-05-07--prix-demi-magret-gers]] — Étude prix magret dans le Gers pour positionnement tarifaire
+- [[2026-05-07--soiree-blanche-opais-initial]] — Soirée blanche Ô Païs : première version du plan d'événement
+- [[2026-05-12--comparatif-enceintes-denon-sonos]] — Comparatif enceintes Denon vs Sonos pour sonorisation
+- [[2026-05-12--soiree-blanche-opais-detailed]] — Soirée blanche Ô Païs : plan détaillé des opérations
+- [[2026-05-16--canva-templates-opais-anniversaire]] — Spécifications design Canva pour les réseaux sociaux anniversaire
+- [[2026-05-18--opais-ouverture-jeudi-soir]] — Annonce ouverture jeudi soir et communication client
+
+---
+
 ## Domains
 
 <!-- Add domain entries here after scaffold -->

--- a/wiki/rnm-web-scraper-guide.md
+++ b/wiki/rnm-web-scraper-guide.md
@@ -1,0 +1,64 @@
+---
+title: RNM Web Scraper — Récupérer liste produits France AgriMer
+type: wiki
+status: active
+created: 2026-05-07
+origin: Chat #4 — Scrape RNM franceagrimer.fr
+---
+
+# RNM Web Scraper — Récupérer liste produits France AgriMer
+
+## Source brute
+Chat du 7 mai sur la récupération complète des produits du site RNM (https://rnm.franceagrimer.fr) avec sa structure hiérarchique (secteurs → groupes → sous-groupes → produits → variétés) en format Markdown.
+
+Site : JavaScript SPA (Single Page App) — rendu dynamique, pas d'HTML statique.
+
+## Résumé utile
+**Structure RNM (5 niveaux)**
+```
+Secteur (5 totaux)
+├─ Groupe
+│  └─ Sous-groupe
+│     └─ Produit/Libellé
+│        └─ Variétés (exclure Catégories/Qualités)
+```
+
+**Secteurs** : Fruits et Légumes, Fleurs & plantes ornementales, Pêche et aquaculture, Beurre Œuf Fromage, Viande
+
+**Approche extraction** :
+- **Playwright + Chromium** : Méthode A (complète, 15-30 min d'exec)
+- **Google Search** : Méthode B (partielle, ~60% de couverture, 0 setup)
+- Sortie : `produits_rnm.md` (hiérarchie respectée) + `produits_rnm.json` (sauvegarde brute)
+
+**Script key features**
+- Hiérarchie respectée jusqu'à 5 niveaux (configurable `MAX_PROFONDEUR`)
+- Filtres auto : Cat I/II/Qualité/Extra exclas via regex
+- Sauvegarde incrémentale JSON (résilience crash)
+- Délai 0,6s entre requêtes (politesse)
+- Error handling + logging verbeux
+
+## Décisions / idées clés
+- **Production locale recommandée** : Firewall/proxy Anthropic bloque rnm.franceagrimer.fr
+- **Script ready-to-run** : `scrape_rnm.py` dans repo (Playwright v1.40+)
+- **Sauvegarde double** : .md (lisible) + .json (continuation si crash)
+- **Heuristique variétés** : Cherche `<th>/<h2>` "Variét..." puis cellule/bloc voisin—variable par secteur
+
+## Actions
+- [ ] Télécharger `scrape_rnm.py`, `requirements.txt`, `README.md`
+- [ ] Sur machine locale (hors proxy) :
+  ```bash
+  python3 -m venv .venv && source .venv/bin/activate
+  pip install -r requirements.txt
+  playwright install chromium
+  python scrape_rnm.py
+  ```
+- [ ] Attendre 15-30 min (dépend de ~500 produits)
+- [ ] Récupérer `produits_rnm.md` (sortie finale)
+- [ ] Si crash → relancer (reprend depuis checkpoint JSON)
+- [ ] Vérifier variétés par secteur (heuristique peut varier)
+
+## Wikilinks
+- [[data-collection]]
+- [[web-scraping]]
+- [[rnm-products]]
+- [[market-data]]

--- a/wiki/ô-païs.md
+++ b/wiki/ô-païs.md
@@ -1,0 +1,23 @@
+---
+type: wiki
+status: hub
+title: "Ô Païs — Hub"
+created: 2026-05-20
+updated: 2026-05-20
+related:
+  - "[[overview]]"
+  - "[[index]]"
+---
+
+# Ô Païs Business Hub
+
+Research, planning, and operations documentation for Ô Païs restaurant business.
+
+## Pages
+
+- [[2026-05-07--prix-demi-magret-gers]] — Étude prix magret dans le Gers pour positionnement tarifaire
+- [[2026-05-07--soiree-blanche-opais-initial]] — Soirée blanche Ô Païs : première version du plan d'événement
+- [[2026-05-12--comparatif-enceintes-denon-sonos]] — Comparatif enceintes Denon vs Sonos pour sonorisation
+- [[2026-05-12--soiree-blanche-opais-detailed]] — Soirée blanche Ô Païs : plan détaillé des opérations
+- [[2026-05-16--canva-templates-opais-anniversaire]] — Spécifications design Canva pour les réseaux sociaux anniversaire
+- [[2026-05-18--opais-ouverture-jeudi-soir]] — Annonce ouverture jeudi soir et communication client


### PR DESCRIPTION
## Summary
Migration of 9 chat transcripts from INBOX to structured Obsidian vault.

## Changes
**Wiki (3 notes)** — Reusable processes:
- claude-code-session-integration.md
- claude-code-remote-control.md
- rnm-web-scraper-guide.md

**Sources (6 notes)** — Business context:
- 2026-05-07--prix-demi-magret-gers.md
- 2026-05-07--soiree-blanche-opais-initial.md
- 2026-05-12--comparatif-enceintes-denon-sonos.md
- 2026-05-12--soiree-blanche-opais-detailed.md
- 2026-05-16--canva-templates-opais-anniversaire.md
- 2026-05-18--opais-ouverture-jeudi-soir.md

## Results
✅ 9 notes created (validated)
✅ 29 wikilinks established
✅ 0 orphaned pages
✅ 604 lines inserted
✅ Original INBOX files removed after validation