### PR TITLE
docs: add CLAUDE.md best practices reference (Karpathy 21-rule framework)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,3 +62,47 @@ Do NOT read the wiki for general coding questions or things already in this proj
 
 If you configured the MCP server, Claude can read and write vault notes directly.
 See `skills/wiki/references/mcp-setup.md` for setup instructions.
+
+---
+
+## CLAUDE.md Best Practices Reference
+
+**Sources:** [Article by @0xDepressionn](https://x.com/0xDepressionn/status/2055999112470839383) · [21-rule reference card](https://x.com/0xDepressionn/status/2057115586480513376/photo/1)
+
+Karpathy's method: 65% → 94% coding accuracy. One plain text file. 21 rules. 2-hour setup. ~$975/week saved per developer.
+
+### Karpathy's 4 core rules
+
+1. **Ask, don't assume** — Unclear? Ask before writing a single line. Never assume intent.
+2. **Simplest first** — No abstractions or flexibility not explicitly requested.
+3. **Don't touch unrelated** — Not part of the task? Don't touch it. Even if it seems like a good idea.
+4. **Flag uncertainty** — Not confident? Say it before proceeding. Always.
+
+### Full 21-rule framework
+
+**DEFAULTS (1–7)** — eliminate repeated context
+1. Kill filler — No "Great question!" — start with the answer.
+2. Match length — Short for simple. Full for complex. No padding.
+3. Show options — 2–3 approaches first. Wait for choice.
+4. Admit gaps — Not sure? Say it before including it.
+5. Who I am — Name / Role / Strong in / Still learning.
+6. Project context — Goal / Stack / Audience / What to avoid.
+7. Lock voice — Style + words I use / words I never use.
+
+**BEHAVIOR (8–14)** — prevent unauthorized changes
+8. Stay in scope — Touch only what's asked. Note the rest.
+9. Ask first — Describe the change. Wait for yes.
+10. Confirm destruct — Deleting? List what's affected. Wait.
+11. Hard stops — Deploy / migrate / send = explicit yes.
+12. Show changes — Files touched / modified / untouched / next.
+13. No acting alone — Never send/post/publish without yes.
+14. Think first — Reason step by step before coding.
+
+**MEMORY + STACK (15–21)** — prevent forgotten decisions
+15. MEMORY.md — Log: what / why / what was rejected.
+16. Session end — Summary: done / in progress / next.
+17. ERRORS.md — Log failures. Check before suggesting.
+18. Permanent facts — Always-true rules. Flag any conflict.
+19. Lock stack — Define tech stack. Never switch without asking.
+20. Think deep — Architecture = extended thinking. Always.
+21. Karpathy's 4 — See above. The rules that went viral.


### PR DESCRIPTION
## Summary

- Adds a `## CLAUDE.md Best Practices Reference` section at the end of `CLAUDE.md`
- Synthesises the 21-rule framework from two viral posts by @0xDepressionn ([article](https://x.com/0xDepressionn/status/2055999112470839383) · [reference card](https://x.com/0xDepressionn/status/2057115586480513376/photo/1))
- Karpathy's original 4 rules (65% → 94% coding accuracy) plus the full 21-rule expansion across DEFAULTS, BEHAVIOR, and MEMORY + STACK categories

## What changed

Added a reference section covering:
- **Karpathy's 4 core rules** — Ask/don't assume, Simplest first, Don't touch unrelated, Flag uncertainty
- **DEFAULTS (1–7)** — Kill filler, Match length, Show options, Admit gaps, Who I am, Project context, Lock voice
- **BEHAVIOR (8–14)** — Stay in scope, Ask first, Confirm destruct, Hard stops, Show changes, No acting alone, Think first
- **MEMORY + STACK (15–21)** — MEMORY.md, Session end, ERRORS.md, Permanent facts, Lock stack, Think deep, Karpathy's 4

## Why

This framework is widely adopted (82,000 GitHub stars) and directly relevant to any project using Claude Code. Including it in the plugin's CLAUDE.md makes these best practices available to all users of claude-obsidian as a built-in reference.

## Test plan

- [ ] Confirm `CLAUDE.md` renders correctly in GitHub
- [ ] Verify the new section does not conflict with existing plugin instructions