### PR TITLE
wiki: file two notes from the Laba Super App build session

### DIFF
--- a/wiki/concepts/Applying Laba Brand Book to a New Product.md
+++ b/wiki/concepts/Applying Laba Brand Book to a New Product.md
@@ -1,0 +1,230 @@
+---
+type: concept
+title: "Applying Laba Brand Book to a New Product"
+created: 2026-05-22
+updated: 2026-05-22
+status: current
+tags:
+  - concept
+  - laba-mvp
+  - design-system
+  - tailwind
+  - urbanist
+related:
+  - "[[Brand Book — Laba MVP]]"
+  - "[[Brand Book — Researchius]]"
+  - "[[SuperApp Access Control Model]]"
+  - "[[Per-Workspace CSS via Data Attribute]]"
+  - "[[laba-mvp-design plugin]]"
+sources:
+  - "[[Brand Book — Laba MVP]]"
+---
+
+# Applying Laba Brand Book to a New Product
+
+The Laba MVP Brand Book v1.0 is a contract that every product in the family obeys: monochrome ink + lime accent, Urbanist everywhere, large radii, pill-shaped interactives, 1% lime per screen. This page captures the canonical recipe for **bolting that contract onto a Next.js product from scratch** — verified end-to-end on the Laba Production Super App (May 2026), including the dead end that wasted the first attempt.
+
+If you start a new sibling product, read this before touching code.
+
+---
+
+## Stack that worked
+
+| Layer | Choice |
+|---|---|
+| Next.js | App Router (any recent v14+; v14.2 verified) |
+| Tailwind | **v3 (`tailwindcss@^3.4`)** + `postcss` + `autoprefixer` |
+| Tokens | `tailwind.config.ts` extending `theme` |
+| Font | **Urbanist** via `next/font/google`, weights 400/500/600/700/800, `subsets: ['latin', 'latin-ext']` only (Urbanist has no Cyrillic subset — brand is English-only anyway) |
+| Components | hand-rolled with `class-variance-authority` + `clsx` + `tailwind-merge` (the `cn()` helper) |
+| Icons | `lucide-react`, never mix with Heroicons / Phosphor |
+
+Brand Book canonically points to `tailwind.config.ts` + `globals.css`, which is Tailwind v3 syntax.
+
+---
+
+## Stack that did NOT work (avoid)
+
+**Tailwind v4 on Next 14.2** — the install completes, `next build` returns ✓ green, but several utility classes (`bg-surface`, `border-line`, `p-5`, `rounded-md`) never make it into the generated CSS. Pages render with text and CTAs but lose their cards, padding, borders, and table-column spacing. The result looks broken in production while passing every automated check.
+
+Lesson: **`next build` is not enough** — verify visually before merge.
+
+The second-order lesson: a typecheck-green PR on Tailwind v4 + Next 14 will still ship broken. If a brand application has to wait on Next 15 / React 19, defer it.
+
+---
+
+## Token file (paste-and-adjust)
+
+```ts
+// tailwind.config.ts
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}", "./lib/**/*.{ts,tsx}"],
+  theme: {
+    extend: {
+      colors: {
+        ink:     "#191919",
+        accent:  "#C1FC02",          // lime — the 1% moment
+        page:    "#F2F2F2",
+        surface: "#EFEFEF",
+        card:    "#FFFFFF",
+        line:    "#E3E3E3",
+        n: { 50:"#FAFAFA", 100:"#F2F2F2", 200:"#EFEFEF", 300:"#E5E5E5",
+             400:"#C9C9C9", 500:"#8E8E8E", 600:"#5A5A5A", 700:"#3A3A3A",
+             800:"#2A2A2A", 900:"#191919" },
+        success: "#4D8B5C",
+        warning: "#D89E36",
+        error:   "#D2453F",
+        info:    "#5A7BAD",
+      },
+      fontFamily: { sans: ["var(--font-urbanist)", "ui-sans-serif", "system-ui", "sans-serif"] },
+      fontSize: {
+        eyebrow:  ["11px", { lineHeight: "14px", letterSpacing: "0.08em", fontWeight: "600" }],
+        small:    ["14px", { lineHeight: "20px", fontWeight: "400" }],
+        body:     ["16px", { lineHeight: "24px", fontWeight: "400" }],
+        h3:       ["20px", { lineHeight: "26px", fontWeight: "600", letterSpacing: "-0.01em" }],
+        subtitle: ["26px", { lineHeight: "32px", fontWeight: "500", letterSpacing: "-0.015em" }],
+        h2:       ["32px", { lineHeight: "38px", fontWeight: "700", letterSpacing: "-0.02em" }],
+        display:  ["40px", { lineHeight: "46px", fontWeight: "700", letterSpacing: "-0.02em" }],
+        heading:  ["60px", { lineHeight: "64px", fontWeight: "800", letterSpacing: "-0.025em" }],
+      },
+      spacing: { "1":"4px", "2":"8px", "3":"12px", "4":"16px", "6":"24px",
+                 "8":"32px", "12":"48px", "16":"64px", "24":"96px" },
+      borderRadius: { sm:"8px", md:"12px", lg:"16px", "2xl":"24px", pill:"9999px" },
+      boxShadow: {
+        sm: "0 1px 2px 0 rgba(25,25,25,0.04)",
+        md: "0 4px 12px -2px rgba(25,25,25,0.06)",
+        lg: "0 12px 32px -4px rgba(25,25,25,0.08)",
+      },
+      backgroundImage: {
+        hatch: "repeating-linear-gradient(135deg, #191919 0 1px, transparent 1px 6px)",
+      },
+    },
+  },
+  plugins: [],
+};
+export default config;
+```
+
+`globals.css` keeps the Tailwind directives plus a tiny `@layer base` that sets `body` to `bg-page text-ink font-sans text-body` and emits the lime selection state. **Do not** put `html, body { height: 100% }` — it silently clips any page taller than the viewport. Use `min-h-screen` on body instead and let pages that need viewport-fill (a Shell with an iframe) set `h-screen` explicitly.
+
+---
+
+## Surfaces — the rules you cannot break
+
+1. **White card on `bg-page`, always.** Never grey-on-grey for the primary block. A row of grey-filled tiles reads as a spreadsheet — opposite of the brand.
+2. **One step of nesting max.** `bg-page → card → inset` is fine. Another inset inside that is wrong.
+3. **Border, not shadow,** for separation. 1px `border-line` is the default. Shadow appears on hover only.
+4. **Card padding** — 20-24px for data cards, 28-32px for hero. Generous, not tight.
+
+The Brand Book calls the violation explicitly: "boxy grey rectangles" = anti-pattern.
+
+---
+
+## Composition recipes by surface
+
+### Brand-surface (login, signup, denied)
+Centered column on `bg-page`. **No card, no border, no shadow.** The wordmark IS the composition.
+
+```tsx
+<div className="min-h-screen flex items-center justify-center bg-page px-4">
+  <div className="w-full max-w-md flex flex-col items-center text-center">
+    <p className="text-eyebrow text-n-500 uppercase">Welcome back</p>
+    <h1 className="text-[48px] leading-none font-extrabold tracking-tight text-ink mt-2">
+      Product Name
+    </h1>
+    <p className="text-small text-n-500 mt-3">Sign in to continue.</p>
+    {/* form below */}
+  </div>
+</div>
+```
+
+### Function-surface (shell, admin)
+White card on page background. Generous padding. Borders, no shadows at rest.
+
+```tsx
+<div className="bg-card border border-line rounded-lg overflow-hidden">
+  {/* sections */}
+</div>
+```
+
+### Top navigation with active stage
+Symmetric grid so the tab block sits at **true viewport centre**, regardless of left/right element widths. The active tab is the screen's lime moment.
+
+```tsx
+<header className="h-14 bg-card border-b border-line grid grid-cols-[1fr_auto_1fr] items-center px-6 gap-6">
+  <Link className="justify-self-start text-body font-extrabold tracking-tight text-ink">L</Link>
+  <nav className="overflow-x-auto">
+    <div className="inline-flex gap-0.5 bg-page rounded-pill p-0.5">
+      {stages.map(s => (
+        <button key={s.id}
+          className={cn("px-3 h-6 rounded-pill text-[11px] font-medium",
+            active ? "bg-accent text-ink" : "text-n-600 hover:text-ink")}>
+          {s.label}
+        </button>
+      ))}
+    </div>
+  </nav>
+  <div className="justify-self-end">{/* avatar */}</div>
+</header>
+```
+
+### Sub-nav under top tabs
+Same height (`h-6`), monochrome pills (NOT lime — main row already owns the lime moment).
+
+```tsx
+<button className={cn("px-3 h-6 text-[11px] font-medium rounded-pill",
+  active ? "bg-ink text-card" : "text-n-600 hover:text-ink hover:bg-page")}>
+  {label}
+</button>
+```
+
+---
+
+## Component conventions
+
+| Element | Tokens |
+|---|---|
+| Primary CTA (new flow) | `bg-ink hover:bg-n-800 text-card h-10 px-4 rounded-pill text-small font-medium` |
+| Secondary / row action | `border border-line hover:border-ink bg-card text-ink h-9 px-3 rounded-pill text-small font-medium` |
+| Destructive ghost | `text-n-500 hover:text-error hover:bg-error/10 h-9 px-3 rounded-pill text-small` (hover-reveal) |
+| Input | `text-small border border-line rounded-pill h-9 px-4 bg-card text-ink placeholder:text-n-500 focus:border-ink` |
+| Status text in table | Plain text in semantic colour; no pill background; `text-small` weight 400. Lime is reserved for the active stage tab. |
+
+When two controls must look identical (e.g. a segmented role toggle next to an `Add product` button), spell sizes literally as `text-[14px] font-medium`. `text-small` ships with `fontWeight: 400` baked in via the tuple in `tailwind.config`, so order with `font-medium` overrides can be confusing under fast iteration.
+
+---
+
+## The "1% lime" rule in practice
+
+Lime (`#C1FC02`) is the only attention moment. Everything else is monochrome + semantic.
+
+Where to put it on a chrome page:
+- Shell top-nav: active stage tab.
+- That's it. Sub-nav active stays ink. Pills, badges, buttons stay monochrome. Status cells use semantic colours (success / warning / error), never lime.
+
+When the Brand Book says "1 lime per screen" it's literal. Two limes = visual violation.
+
+---
+
+## Validation workflow
+
+The first design migration shipped broken because verification stopped at `next build`. The second one used this loop:
+
+1. Implement one logical block (e.g. login splash).
+2. `npm run dev` locally.
+3. Open the page in a browser, take a screenshot, **send it to Vlad before merge**.
+4. Only then commit, open PR, merge.
+
+For server-only pages that need auth (Shell, admin), temporarily add a `/preview-*-tmp` route that renders the component with mock data, plus a one-line allowance in `middleware.ts`. Delete both before commit. The preview route is throwaway — never lands in `main`.
+
+---
+
+## When the brand evolves
+
+The Brand Book is the source of truth. If a token changes there, the change flows to:
+1. `tailwind.config.ts` in every Laba product.
+2. Any product-specific `globals.css` overrides.
+
+Until there is a shared `@laba/design-tokens` package, the propagation is manual. Be deliberate about it — the brand book itself says "the brand book is the contract; the code reads it directly".

--- a/wiki/hot.md
+++ b/wiki/hot.md
@@ -1,7 +1,7 @@
 ---
 type: meta
 title: "Hot Cache"
-updated: 2026-04-24T13:10:00
+updated: 2026-05-22T11:30:00
 tags:
   - meta
   - hot-cache
@@ -19,6 +19,10 @@ related:
 Navigation: [[index]] | [[log]] | [[overview]]
 
 ## Last Updated
+
+2026-05-22 (Laba Production Super App — access redesign + brand pass): шипнули повну заміну ролей у SuperApp. Стара модель `admin / editor / reader` глобально на весь shell → нова `(email, product, project)` з email-whitelist onboarding (no invitation emails, signup-page action + Postgres trigger on auth.users перевіряють whitelist), hardcoded owners з SQL seed + invite-form toggle для нових owners, soft-disable + confirmed delete forever. **Шість гейтів defense-in-depth**: signup action / DB trigger / middleware / page server-render / embed proxy 403 / RLS. Active project живе в cookie + supported as `?project=` deep-link. Materials data — per-project (PK migrated to `(item_id, project_id)`). Tool URLs — default per-product + optional per-project overrides. Filed [[SuperApp Access Control Model]] (15 locked decisions + schema + gates). **Brand pass** — два захода: перший на Tailwind v4 + cream Researchius v1 шипнув broken (v4 silently drops utilities на Next 14 — карточки/borders/padding зникали) → revert PR #11. Другий на Tailwind v3 + Laba Brand Book v1.0 (monochrome + lime + Urbanist) пройшов: login splash без рамки з big wordmark "Laba Super App" по центру bg-page, shell з grid-cols-[1fr_auto_1fr] для true-viewport-center табів і lime active stage tab як 1% акцент, admin таблиця з plain-text semantic-colored statuses замість pill chips, всі inline-контроли уніфіковані на h-9 + text-small. Урок: `next build` зеленим не значить ОК — preview-через-скріншот до merge обов'язковий. Filed [[Applying Laba Brand Book to a New Product]] (working stack + failed stack + surface rules + composition recipes + 1% lime applied). 21 PR замерджено на main `temson94/production-super-app`. Залишилось: Vercel production deploys стопаються в Blocked, потрібен ручний promote (Deployment Protection ймовірно ввімкнено).
+
+---
 
 2026-04-24 (late night): v1.6.0 public release notes shipped. `docs/releases/v1.6.0.md` (Karpathy-style, 346 lines) establishes the release-notes convention. Three original SVGs at `wiki/meta/dragonscale-{mechanism-overview,6-test-flow,frontier-graph}.svg` carry the visual load; Wikipedia dragon curve referenced by text link only (no binary vendoring). R4 codex verifier ACCEPT WITH FIXES, 3 wording fixes applied. User runs `gh release create v1.6.0 --notes-file docs/releases/v1.6.0.md` when ready. Commits `85515bb` (docs), plus wiki/meta/ auto-commits for SVGs.
 

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -31,6 +31,7 @@ Navigation: [[overview]] | [[log]] | [[hot]] | [[dashboard]] | [[Wiki Map]] | [[
 
 ## Concepts
 
+- [[Applying Laba Brand Book to a New Product]] — canonical recipe for bolting Laba MVP Brand Book v1.0 onto a new Next.js product. Stack that worked (Tailwind v3 + Urbanist + jose JWT), stack that failed (Tailwind v4 silently drops utilities on Next 14), token paste-block, surface rules, composition recipes for brand vs function surfaces, "1% lime" applied to a shell, preview-screenshot validation workflow (status: current)
 - [[LLM Wiki Pattern]] — the pattern for building persistent, compounding knowledge bases using LLMs (status: mature)
 - [[Hot Cache]] — ~500-word session context file, updated after every ingest and session (status: mature)
 - [[Compounding Knowledge]] — why wiki knowledge grows more valuable over time, unlike RAG (status: mature)
@@ -81,6 +82,7 @@ Navigation: [[overview]] | [[log]] | [[hot]] | [[dashboard]] | [[Wiki Map]] | [[
 
 ## Decisions
 
+- [[SuperApp Access Control Model]] — 15 locked decisions defining the Laba Production Super App access model: (email, product, project) grants, email-whitelist signup, hardcoded owners, defense-in-depth gates (UI / signup action / DB trigger / middleware / proxy / RLS) (status: active)
 - [[2026-04-14-community-cta-rollout]] - Skool community CTA footer added to 6 skill repos with per-tool frequency rules (status: active)
 - [[2026-04-15-slides-and-release-session]] - Claude SEO v1.9.0 slides (15-slide HTML deck) + GitHub release v1.9.0 with PDF asset (status: complete)
 - [[2026-04-15-release-report-session]] - Claude SEO v1.9.0 Release Report PDF: dark theme, 13 pages, WeasyPrint layout fixes, Challenge v2 added (status: complete)

--- a/wiki/log.md
+++ b/wiki/log.md
@@ -25,6 +25,16 @@ Parse recent entries: `grep "^## \[" wiki/log.md | head -10`
 
 ---
 
+## [2026-05-22] save | SuperApp Access Control Model
+- Type: decision
+- Location: wiki/meta/SuperApp Access Control Model.md
+- From: long grill-me session for the Laba Production Super App access redesign. Replaced global admin/editor/reader roles with per-(email, product, project) grants + email-whitelist onboarding + hardcoded owners. Captures all 15 locked decisions, the schema, six layers of defense-in-depth, and the late owner-vs-regular toggle on the invite form. PLAN.md in the repo is the implementation companion.
+
+## [2026-05-22] save | Applying Laba Brand Book to a New Product
+- Type: concept
+- Location: wiki/concepts/Applying Laba Brand Book to a New Product.md
+- From: same SuperApp session — second attempt at the brand pass after Tailwind v4 + cream-Researchius palette shipped broken. Captures: the working stack (Tailwind v3 + Urbanist via next/font/google + lucide + custom tokens block), the failed stack (Tailwind v4 on Next 14 silently drops utilities — `next build` is not enough), surface rules, composition recipes for brand-surface (no card, big wordmark) vs function-surface (white card on bg-page), the "1% lime" rule applied to a shell, and the preview-route validation workflow.
+
 ## [2026-04-24] save | v1.6.0 public release notes (Teams, Karpathy-style)
 - Type: release doc + visual assets
 - Locations (new): `docs/releases/v1.6.0.md` (346 lines, 6 sections, Karpathy-style prose), `wiki/meta/dragonscale-mechanism-overview.svg` (4-mechanism diagram with shared .vault-meta/ gate), `wiki/meta/dragonscale-6-test-flow.svg` (validation timeline), `wiki/meta/dragonscale-frontier-graph.svg` (M4 candidate + 3 filed pages)

--- a/wiki/meta/SuperApp Access Control Model.md
+++ b/wiki/meta/SuperApp Access Control Model.md
@@ -1,0 +1,143 @@
+---
+type: decision
+title: "SuperApp Access Control Model"
+created: 2026-05-22
+updated: 2026-05-22
+decision_date: 2026-05-22
+status: active
+tags:
+  - decision
+  - laba-mvp
+  - production-super-app
+  - access-control
+  - rbac
+related:
+  - "[[Brand Book — Laba MVP]]"
+  - "[[Applying Laba Brand Book to a New Product]]"
+  - "[[App-Level vs RLS Tenant Scoping]]"
+  - "[[Multi-Tenant ATS Data Model]]"
+---
+
+# SuperApp Access Control Model
+
+The Laba Production Super App is an internal Next.js shell that wraps several Laba products (Researchius, Name Testius, Scoutius, Coursius, Textius, plus placeholders) as iframes behind a single login. Until this redesign it used a global role enum — `admin / editor / reader` — which gave or denied access to the entire app at once.
+
+This page captures the **15 access-control decisions** that replaced that model with per-product, per-project grants plus an email-whitelist onboarding flow. The decisions came out of one structured grill-me session and are the binding contract for the implementation.
+
+---
+
+## TL;DR
+
+- Access is granted on `(email, product, project)` triples. `product_id = NULL` is never used; `project_id = NULL` means "all projects".
+- Onboarding is **email-whitelist**: an admin adds the email + grants up-front, the person goes to `/signup` and is admitted iff their email is in `allowed_emails`. No invitation emails. A DB trigger blocks `auth.users` inserts for non-whitelisted emails.
+- **Owner** is a hardcoded boolean (`allowed_emails.is_owner`). Owners have implicit full access to every product in every project. Seeded via SQL — there is no UI to create the first owners — but the invite form CAN promote new users to owner.
+- Active project is held in the `laba_project` cookie + supported as `?project=` deep-link query.
+- Materials text data is stored per-project; materials_content PK = `(item_id, project_id)`.
+- Tool URLs live in `product_urls(product_id, project_id NULLABLE, url, embed_mode)`. `project_id = NULL` row is the default; per-project rows override.
+
+---
+
+## The 15 locked decisions
+
+| # | Question | Answer |
+|---|---|---|
+| 1 | Unit of access | **Logical product** (Scoutius is one product across all stages; Materials is one product across its 6 sub-items). |
+| 2 | Grant level | **Binary** has-access / no-access. No per-product read/write modes. |
+| 3 | Granularity | **Product × project** matrix. |
+| 4 | "All projects" representation | `project_id = NULL` wildcard inside the grant row. |
+| 5 | UI visibility | **Hide** non-accessible projects/stages/items. Users with zero grants see "Contact admin". |
+| 6 | Onboarding | **Email-whitelist**, not invitation emails. |
+| 7 | Materials write | Anyone with the Materials grant can edit text. No read-only sub-mode. |
+| 8 | Admin UI shape | List of rows: **product → multi-select of projects** with "All projects" as the first option. |
+| 9 | Existing-user migration | Trivial — only Vlad + Artem exist, seeded as owners. |
+| 10 | Privileged tier | **Owner** is hardcoded. No UI-controlled "Admin" tier. |
+| 11 | Active project source | **Cookie** as primary, `?project=` query as deep-link override. |
+| 12 | Materials data scope | **Per-project**. Existing rows migrated to `ua-laba`. |
+| 13 | Tool URLs scope | Default URL per product + optional per-project overrides. |
+| 14 | Revoke / delete | Cascade grants on whitelist removal + soft-disable toggle + confirmed Delete Forever (owner-only). |
+| 15 | Products / projects source | **Code** (`lib/products.ts`, `lib/projects.ts`). No DB table, no admin UI to manage them. |
+
+---
+
+## Schema
+
+```sql
+create table allowed_emails (
+  email        text primary key,
+  is_owner     boolean not null default false,
+  is_disabled  boolean not null default false,
+  created_at   timestamptz not null default now(),
+  created_by   uuid references auth.users(id) on delete set null
+);
+
+create table grants (
+  email        text not null references allowed_emails(email) on delete cascade,
+  product_id   text not null,
+  project_id   text,                                          -- NULL = all projects
+  created_at   timestamptz not null default now()
+);
+create unique index grants_email_product_project_uniq
+  on grants (email, product_id, coalesce(project_id, '__all__'));
+
+create table product_urls (
+  product_id   text not null,
+  project_id   text,                                          -- NULL = default
+  url          text not null default '',
+  embed_mode   text not null default 'proxy',
+  updated_at   timestamptz not null default now()
+);
+```
+
+A SECURITY DEFINER helper `is_owner()` powers every RLS policy so a non-owner session can ask "am I an owner?" without exposing the table.
+
+---
+
+## Defense-in-depth gates
+
+| Layer | What it checks |
+|---|---|
+| `/signup` page server action | Email is in `allowed_emails` and not disabled. Friendly "Contact admin" screen otherwise. |
+| Postgres `BEFORE INSERT ON auth.users` trigger | Same check, fires even if the UI is bypassed. |
+| `middleware.ts` | Redirects non-authed users to `/login`. |
+| `/app/page.tsx` server render | Calls `getUserAccess()`, filters `STAGES` and projects, refuses if no visible products. |
+| `/embed/[stage]/[item]/[[...path]]` proxy | Re-runs the grant check using `(product_id, cookie-project)`. 403 on miss. Also injects `?project=` to the upstream URL. |
+| RLS on `allowed_emails`, `grants`, `product_urls`, `materials_content` | Owner-or-self read; owner-only write. |
+
+The proxy gate is the most important one: without it any logged-in user could open `/embed/research/scoutius/...` directly and bypass the UI.
+
+---
+
+## Owner-vs-Regular toggle on invite (added 2026-05-22)
+
+The original Q10 decision said owners are hardcoded SQL-only. After the system was live the invite form gained an explicit **Regular | Owner** segmented control:
+
+- Regular (default) — shows the GrantsEditor below; per-product grants are required.
+- Owner — hides GrantsEditor; the `createUser` action sets `is_owner=true` and inserts zero grant rows because owners have implicit full access.
+
+This relaxes Q10 only in one direction: new owners can be promoted from another owner's session. There is still no UI to **demote** an owner — the seeded ones (Vlad, Artem) stay locked, and the edit page treats every owner row as `Locked`.
+
+---
+
+## What is NOT in the model
+
+- **No teams or groups.** Each grant is per-email. If Marketing needs Name Testius, all five marketers get five separate grant rows.
+- **No "all products" wildcard.** `is_owner = true` is the only way to access everything. There is no `product_id = NULL` row.
+- **No expiry, no time-bounded grants.** Access is either granted or not.
+- **No audit log.** Inserts/updates are not surfaced anywhere. Add later if compliance demands.
+- **No per-product read/write distinction.** Iframe products manage their own permissions; the shell only gates visibility.
+
+---
+
+## Implementation status
+
+All five rollout phases shipped on `main` of `temson94/production-super-app`:
+
+1. Schema migration + lib helpers — PR #1 (squashed `0e6793a`)
+2. Server-side enforcement — same PR
+3. Shell UI filtering — same PR
+4. New admin UI — same PR
+5. Cleanup of `profiles` / `user_role` / `tool_settings` — same PR
+
+Followed by hotfixes for migration ordering (`#2`, `#3`, `#4`), the materials/picker simplifications (`#6`), the broken Tailwind v4 redesign + revert (`#7-#11`), and the eventually-working Brand Book pass (`#12-#21`).
+
+Full plan checked into the repo as `PLAN.md`. Migration files: `supabase/migrations/005_access_control.sql`, `006_materials_per_project.sql`, `007_cleanup_legacy_roles.sql`, `008_drop_materials.sql`.


### PR DESCRIPTION
Two new wiki pages saved via `/save` during a long build session on the Laba Production Super App.

## What was filed

- **`wiki/meta/SuperApp Access Control Model.md`** — decision record. The 15 locked design decisions behind the SuperApp's per-(email, product, project) access model: email-whitelist signup with both a server-action check and a DB trigger, hardcoded owner tier, six layers of defense-in-depth (UI / signup action / DB trigger / middleware / proxy / RLS), an owner-vs-regular toggle on the invite form, and what is deliberately NOT in the model (no groups, no per-product wildcard, no expiry, no audit log).

- **`wiki/concepts/Applying Laba Brand Book to a New Product.md`** — concept record. The canonical recipe for bolting Laba MVP Brand Book v1.0 onto a new Next.js product, including the dead end that wasted the first attempt:
  - Working stack: Tailwind v3 + Urbanist via `next/font/google` + lucide + custom token block.
  - Failed stack: Tailwind v4 on Next 14 silently drops utilities; `next build` is not enough — verify visually.
  - Paste-and-adjust `tailwind.config.ts` token block, surface rules, composition recipes for brand-surface vs function-surface, the "1% lime" rule applied to a shell, and the preview-route validation workflow.

## Supporting updates

- `wiki/index.md` — both notes linked into Concepts and Decisions sections at the top of each list.
- `wiki/log.md` — two append-only `save` entries at the top, in the existing format.
- `wiki/hot.md` — refreshed `Last Updated` with a 2026-05-22 Recent Context block summarising the SuperApp rollout (access redesign + brand pass attempts + SSO handshake).

## How to review

Read the two new notes first (they stand alone) — the three modified meta files just link to them and update the recency cache.