### PR TITLE
fix(detect-transport): use 'obsidian version' subcommand, not '--version' flag

### DIFF
--- a/scripts/detect-transport.sh
+++ b/scripts/detect-transport.sh
@@ -130,11 +130,11 @@ if command -v obsidian-cli >/dev/null 2>&1; then
   CLI_VERSION="$(printf '%s' "$CLI_VERSION_RAW" | json_escape || echo '"unknown"')"
 elif command -v obsidian >/dev/null 2>&1; then
   # Obsidian 1.12+ ships `obsidian` as the CLI binary on some platforms.
-  # We treat it as cli-capable if it accepts a --cli or --version flag without launching the GUI.
-  if obsidian --version >/dev/null 2>&1; then
+  # We treat it as cli-capable if `obsidian version` returns cleanly without launching the GUI.
+  if obsidian version >/dev/null 2>&1; then
     CLI_PRESENT=true
     CLI_BINARY="obsidian"
-    CLI_VERSION_RAW="$(obsidian --version 2>/dev/null | head -1 || echo unknown)"
+    CLI_VERSION_RAW="$(obsidian version 2>/dev/null | head -1 || echo unknown)"
     CLI_VERSION="$(printf '%s' "$CLI_VERSION_RAW" | json_escape || echo '"unknown"')"
   fi
 fi


### PR DESCRIPTION
## Summary

- `scripts/detect-transport.sh` calls `obsidian --version` for the `obsidian` binary path (lines 134, 137). Obsidian's native CLI (1.12+) uses `obsidian version` as a subcommand; `--version` is not a valid flag.
- The unknown flag still returns exit 0 because the CLI prints a helper hint to stdout, so `CLI_PRESENT` is correctly set to `true` — but `version_string` in `transport.json` ends up storing the literal error string: `"Error: Command \"--version\" not found. Did you mean: version?"`.
- Net effect today: `preferred: cli` is still chosen, so this is a cosmetic data-quality fix in `transport.json`, not a transport-selection bug.

## Test plan

- [x] On macOS with Obsidian 1.12.7, confirmed `obsidian version` returns `1.12.7 (installer 1.12.7)` to stdout.
- [x] `bash scripts/detect-transport.sh --peek` before the patch wrote the error string into `version_string`.
- [x] After the patch, `--peek` writes `"version_string": "1.12.7 (installer 1.12.7)"`.
- [x] `preferred: cli` and `fallback_chain: ["cli", "filesystem"]` unchanged across before/after.
- [ ] CI: needs upstream maintainer to run if the project has guarded test workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)