### PR TITLE
feat(autoresearch): optional --merge mode that integrates findings into existing pages + audit log

### DIFF
--- a/commands/autoresearch.md
+++ b/commands/autoresearch.md
@@ -1,11 +1,12 @@
 ---
-description: Run an autonomous research loop on a topic. Searches the web, synthesizes findings, and files everything into the wiki as structured pages.
+description: Run an autonomous research loop on a topic. Searches the web, synthesizes findings, and files everything into the wiki as structured pages. Use `--merge` to also integrate findings into existing entity/case/concept pages with full audit log.
 ---
 
 Read the `autoresearch` skill. Then run the research loop.
 
 Usage:
 - `/autoresearch [topic]` — research a specific topic.
+- `/autoresearch --merge [topic]` — research AND auto-merge findings into existing entity/case/concept pages. Writes a full audit log to `wiki/audit/`. Use this for vaults where knowledge must compound (legal, compliance, research, journalism, due-diligence).
 - `/autoresearch` — if DragonScale Mechanism 4 (boundary-first, agenda-control, opt-in) is set up, offer the top 5 vault-frontier pages as topic candidates; you can **pick one**, **type a topic to override**, or **decline and be asked normally**. No automatic selection happens without user confirmation. If DragonScale is not set up OR the helper fails, the command falls back to "What topic should I research?"
 
 DragonScale Mechanism 4 is labeled **agenda control** in the spec because it shapes what the agent researches next; it is not pure memory. The boundary score is a heuristic surfacing candidates, not an authoritative recommendation.
@@ -16,4 +17,24 @@ If no vault is set up yet, say: "No wiki vault found. Run /wiki first to set one
 
 After research is complete, update wiki/index.md, wiki/log.md, and wiki/hot.md.
 
+If `--merge` flag was passed:
+
+1. **Identify affected existing pages** — every entity page (people, organizations, properties, events), case page, and concept/claim page that the findings materially affect.
+
+2. **Edit each affected page in-place** to integrate the new facts. Do not just add a "see also" link — write the new facts into the relevant section of the page in its existing voice and structure. Preserve a wikilink back to the canonical research page.
+
+3. **Append `## Recent Updates` section** to each edited page (create if missing) with a single line: `- YYYY-MM-DD — [[<research-page-name>]] — <one-sentence summary of what was added>`.
+
+4. **Write an audit log** at `wiki/audit/YYYY-MM-DD-autoresearch-<slug>.md` containing:
+   - Topic researched (verbatim from user)
+   - Sources fetched (URLs + brief description)
+   - New page created (path)
+   - All existing pages updated (path + what was merged into each)
+   - Open questions surfaced
+   - Confidence notes (any facts that conflict with existing vault content, any sources that were low-credibility)
+
+Use the audit log as the canonical provenance trail — every fact merged into existing pages should be traceable back to a source listed in the log.
+
 Report how many pages were created and what the key findings are.
+
+If `--merge` was used, also report: how many EXISTING pages were updated (list them), and the path to the audit log.


### PR DESCRIPTION
## Summary

Adds an opt-in `--merge` flag to `/autoresearch` that closes the "research findings → existing pages" loop. Without the flag, behavior is unchanged.

**Stock behavior today:** `/autoresearch <topic>` creates a new page in `wiki/research/` and updates `wiki/index.md` / `log.md` / `hot.md`. Existing entity / case / concept pages that are materially affected by the findings get **no update** — the new knowledge stays trapped in the research page until the user manually runs `/wiki-ingest` on it.

**With `--merge`:** the command additionally (1) identifies existing pages affected by the findings, (2) edits each one to integrate the new facts in the page's existing voice and structure, (3) appends a `## Recent Updates` line per edited page with a dated wikilink back to the research source, and (4) writes an audit log to `wiki/audit/YYYY-MM-DD-autoresearch-<slug>.md` containing every source URL + every page touched + open questions + confidence notes.

## Why

The compounding-vault thesis is that knowledge accumulates across sessions and refines existing pages. The current `/autoresearch` only does half of that — it adds new pages, but doesn't refine. Users wanting the full loop have to follow every `/autoresearch` with a manual `/wiki-ingest`, which most won't do consistently. Result: research findings end up as orphan pages that the entity / case pages don't know about.

Use cases where this matters most:
- **Legal / compliance vaults** — case pages must reflect everything learned about each matter, with citation chain back to sources
- **Research-heavy vaults** (academic, journalistic, due-diligence) — entity pages should accumulate every verified fact discovered across sessions
- **Long-running projects** — a project page that doesn't auto-incorporate research becomes stale

For one-off exploratory research (the existing default use case), the new flag is opt-in, so no behavior change.

## Behavior detail

`--merge` instructs the agent to:

1. Create the research page (as today)
2. Update vault metadata pages: `index.md`, `log.md`, `hot.md` (as today)
3. **NEW:** Identify every existing wiki page materially affected by the findings — entity pages, case pages, concept/claim pages
4. **NEW:** Edit each affected page in-place, integrating the new facts into the page's structure (not just adding a "see also" link)
5. **NEW:** Append `## Recent Updates` line: `- YYYY-MM-DD — [[<research-page>]] — <one-sentence summary>`
6. **NEW:** Write audit log at `wiki/audit/YYYY-MM-DD-autoresearch-<slug>.md` with full provenance
7. **NEW:** Report counts: new pages, existing pages updated (list), key findings, audit log path

## Test plan

- [ ] `/autoresearch <topic>` (no flag) — verify behavior unchanged
- [ ] `/autoresearch --merge <topic>` — verify new pages created AND at least one existing page updated AND audit log written
- [ ] Verify `## Recent Updates` section appended cleanly (or created if missing) on each updated page
- [ ] Verify wikilinks resolve (no broken links from the merge)
- [ ] Verify audit log is well-structured markdown with frontmatter

## Future considerations (not in this PR)

- Could promote `--merge` to default in v2.0 with `--no-merge` opt-out
- Could add `--dry-run` that reports which pages WOULD be updated without editing them (useful for review-heavy workflows)
- Could integrate with the upcoming DragonScale Mechanism 4 (boundary-first agenda control) so research that addresses high-boundary pages auto-merges back to them

🤖 Generated with [Claude Code](https://claude.com/claude-code)