### PR TITLE
Fix: remove unsupported prompt-type hook from SessionStart

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -11,10 +11,6 @@
           {
             "type": "command",
             "command": "[ -x scripts/wiki-lock.sh ] && bash scripts/wiki-lock.sh clear-stale --max-age 3600 >/dev/null 2>&1 || true"
-          },
-          {
-            "type": "prompt",
-            "prompt": "If a vault is configured for this session (check CLAUDE.md for VAULT_PATH or a wiki/ folder in the current directory), silently read wiki/hot.md to restore recent context. If wiki/hot.md does not exist, do nothing. This is a non-vault session. Do not announce this. Do not report what you read. Just have the context available."
           }
         ]
       }


### PR DESCRIPTION
The `SessionStart` hook in `hooks/hooks.json` includes a `prompt`-type step as its third action. `SessionStart` fires before any conversation exists, so Claude Code cannot run a prompt hook there and rejects it on **every** startup/resume with:

> SessionStart:startup hook error — prompt-type hooks are not supported for SessionStart events (no conversation context is available). Use a command-type hook instead.

This affects everyone who installs the plugin (reproduced on a clean 1.9.2 install).

### Fix
Removes just the invalid `prompt` step. No functionality is lost:
- The hot cache is **already** injected by the preceding `command` step (`cat wiki/hot.md`).
- Post-compaction restoration is still handled by the existing `PostCompact` prompt hook (left untouched).

### Diff
One step removed from `SessionStart`; `PostCompact`, `PostToolUse`, and `Stop` hooks are unchanged.

```
hooks/hooks.json | 4 ----
1 file changed, 4 deletions(-)
```
