### PR TITLE
fix: remove unsupported prompt lifecycle hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to claude-obsidian. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [SemVer](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- Removed unsupported prompt-type `SessionStart` and `PostCompact` plugin hooks from `hooks/hooks.json`. Claude Code v2.1.140+ rejects prompt hooks on these lifecycle events, creating a validation banner on every configured vault session. The command-type `SessionStart` hot-cache hook remains the canonical context restore path.
+
 ## [1.9.2] - 2026-05-27 (prompt-cache hardening + path-handling robustness)
 
 Ports Anthropic prompt-caching best practices into the **one** place the plugin calls the Anthropic API directly: tier-1 contextual-prefix generation in `scripts/contextual-prefix.py`. Verified by full-repo sweep that `cache_control` and the Anthropic API surface exist nowhere else (incl. `claude-canvas/`). No change to retrieval output — API payload shape + observability only.

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -6,8 +6,7 @@ Plugin hooks for the claude-obsidian wiki vault. All hooks are defined in `hooks
 
 | Event | Type | Purpose |
 |---|---|---|
-| `SessionStart` | command + prompt | Loads `wiki/hot.md` into context. Command type runs `[ -f wiki/hot.md ] && cat wiki/hot.md` as the canonical safety check (works for non-vault sessions without erroring). Prompt type complements with semantic context restoration. Matcher: `startup\|resume`. |
-| `PostCompact` | prompt | Re-loads `wiki/hot.md` after context compaction. Hook-injected context does NOT survive compaction (only `CLAUDE.md` does), so this hook restores the hot cache mid-session. |
+| `SessionStart` | command | Loads `wiki/hot.md` into context and clears stale locks. The hot-cache command runs `[ -f wiki/hot.md ] && cat wiki/hot.md` as the canonical safety check (works for non-vault sessions without erroring). Matcher: `startup\|resume`. |
 | `PostToolUse` | command | Auto-commits any wiki/ or .raw/ changes after Write or Edit tool calls. Guarded by `[ -d .git ]` so it never errors in non-git directories, and by `git diff --cached --quiet` so it never creates empty commits. |
 | `Stop` | prompt | Updates `wiki/hot.md` at the end of every Claude response with a brief summary of what changed. |
 
@@ -15,7 +14,7 @@ Plugin hooks for the claude-obsidian wiki vault. All hooks are defined in `hooks
 
 `anthropics/claude-code#10875` documents that **plugin hook STDOUT may not be captured** by Claude Code, while identical inline hooks in `settings.json` work correctly.
 
-**Impact**: If this bug is active in your Claude Code version, the prompt-type SessionStart and PostCompact hooks may not inject context as expected.
+**Impact**: If this bug is active in your Claude Code version, rely on the command-type SessionStart hook as the canonical hot-cache path; prompt-type SessionStart/PostCompact hooks have been removed because recent Claude Code builds reject them for these lifecycle events.
 
 **Workaround**: The command-type SessionStart hook (`cat wiki/hot.md`) is the canonical safety check. It relies on STDOUT capture for context injection, so test against this issue if hot cache restoration fails. As a fallback, copy the hook config from `hooks.json` into your user-level `~/.claude/settings.json` instead of relying on plugin hooks.
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -11,21 +11,6 @@
           {
             "type": "command",
             "command": "[ -x scripts/wiki-lock.sh ] && bash scripts/wiki-lock.sh clear-stale --max-age 3600 >/dev/null 2>&1 || true"
-          },
-          {
-            "type": "prompt",
-            "prompt": "If a vault is configured for this session (check CLAUDE.md for VAULT_PATH or a wiki/ folder in the current directory), silently read wiki/hot.md to restore recent context. If wiki/hot.md does not exist, do nothing. This is a non-vault session. Do not announce this. Do not report what you read. Just have the context available."
-          }
-        ]
-      }
-    ],
-    "PostCompact": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "prompt",
-            "prompt": "Hook-injected context does not survive context compaction. If wiki/hot.md exists in the current directory, silently re-read it now to restore the hot cache. Do not announce this."
           }
         ]
       }


### PR DESCRIPTION
## Summary

Removes the prompt-type `SessionStart` and `PostCompact` hooks from `hooks/hooks.json` and updates the hook docs/changelog.

Claude Code v2.1.140+ rejects prompt hooks on these lifecycle events, which creates a validation banner on every configured vault session even though the command-type `SessionStart` hook still restores `wiki/hot.md`.

This follows the Option 1 path proposed in #45: keep the command hot-cache restore path, remove the unsupported prompt blocks, and avoid changing the plugin's per-turn semantics by not moving this to `UserPromptSubmit`.

## Verification

- `python3 -m json.tool hooks/hooks.json >/dev/null`
- `make test`
- `git diff --check`
- Contract smoke: asserted no prompt-type hooks remain under `SessionStart`, and `PostCompact` is no longer present in `hooks/hooks.json`.

Closes #45.