### PR TITLE
fix(rerank): send nomic search_query/search_document task prefixes

### DIFF
--- a/scripts/rerank.py
+++ b/scripts/rerank.py
@@ -6,9 +6,12 @@ upstream stage) and reorders them using semantic similarity.
 
 v1.7 strategy (in preference order, automatically chosen at runtime):
   1. If ollama is reachable AND nomic-embed-text is pulled
-       → embed the query, embed each candidate's contextualized_text,
-         rank by cosine. Caches per-chunk embeddings in
-         .vault-meta/embed-cache.json keyed by body_hash.
+       → embed the query (with the "search_query:" task prefix) and each
+         candidate's contextualized_text (with the "search_document:" prefix),
+         rank by cosine. The nomic task prefixes are required for correct
+         asymmetric retrieval; omitting them degrades ranking quality.
+         Caches per-chunk embeddings in .vault-meta/embed-cache.json keyed by
+         body_hash + EMBED_SCHEME (so a convention change invalidates old vectors).
   2. Otherwise
        → no-op rerank: return candidates in input order with a synthesized
          note. Caller (retrieve.py) still gets a useful result; downstream
@@ -65,6 +68,39 @@ DEFAULT_MODEL = "nomic-embed-text"
 OLLAMA_TIMEOUT_SEC = 3
 EMBED_TIMEOUT_SEC = 30
 MAX_RESPONSE_BYTES = 4 * 1024 * 1024
+
+# Nomic task prefixes. nomic-embed-text is trained with asymmetric task
+# instruction prefixes ("search_query:" for the query, "search_document:" for
+# the indexed text). Omitting them places query and document in a sub-optimal
+# region of the embedding space and measurably degrades retrieval quality — see
+# https://huggingface.co/nomic-ai/nomic-embed-text-v1.5#task-instruction-prefixes
+# We only apply them for nomic-* models; other embedding models (mxbai, bge, …)
+# either use different prefixes or none, so for those with_task_prefix() is a
+# no-op and the raw text is embedded as before.
+QUERY_TASK_PREFIX = "search_query: "
+DOC_TASK_PREFIX = "search_document: "
+
+# Bump when the embedding *input* convention changes (e.g. adding the task
+# prefixes above). It is part of the embed-cache key, so changing it transparently
+# invalidates vectors produced under the old convention instead of silently mixing
+# prefixed and prefix-less embeddings in the same cosine space.
+EMBED_SCHEME = "nomic-prefix-v1"
+
+
+def with_task_prefix(text, role, model=None):
+    """Prepend the nomic task-instruction prefix for `role` ('query'|'document').
+
+    No-op (returns text unchanged) for non-nomic models, so swapping DEFAULT_MODEL
+    to an embedder with a different convention stays correct.
+    """
+    model = model or DEFAULT_MODEL
+    if not model.lower().startswith("nomic"):
+        return text
+    if role == "query":
+        return QUERY_TASK_PREFIX + text
+    if role == "document":
+        return DOC_TASK_PREFIX + text
+    raise ValueError(f"role must be 'query' or 'document', got {role!r}")
 
 EXIT_OK = 0
 EXIT_USAGE = 2
@@ -217,7 +253,7 @@ def rerank(query, candidates, top_k=5, allow_remote=False):
     cache = load_cache()
     cache_dirty = False
     try:
-        q_emb = embed_one(url, DEFAULT_MODEL, query)
+        q_emb = embed_one(url, DEFAULT_MODEL, with_task_prefix(query, "query"))
     except Exception as e:
         log(f"query embed failed: {e}")
         for c in candidates:
@@ -232,12 +268,12 @@ def rerank(query, candidates, top_k=5, allow_remote=False):
             c["rerank_source"] = "missing-chunk"
             continue
         body_hash = chunk.get("body_hash", "")
-        cache_key = f"{DEFAULT_MODEL}:{body_hash}"
+        cache_key = f"{DEFAULT_MODEL}:{EMBED_SCHEME}:{body_hash}"
         emb = cache.get(cache_key)
         if not emb:
             text = chunk.get("contextualized_text") or chunk.get("raw_text", "")
             try:
-                emb = embed_one(url, DEFAULT_MODEL, text)
+                emb = embed_one(url, DEFAULT_MODEL, with_task_prefix(text, "document"))
             except Exception as e:
                 log(f"embed failed for {c.get('chunk_id')}: {e}")
                 c["rerank_score"] = float(c.get("score", 0.0))

--- a/tests/test_retrieve.py
+++ b/tests/test_retrieve.py
@@ -139,6 +139,93 @@ def test_rerank_truncates_to_top_k():
         assert_eq("rerank truncates to top_k", 3, len(out))
 
 
+# ─── nomic task prefixes (search_query:/search_document:) ────────────────────
+def test_with_task_prefix_query():
+    """nomic models must get the 'search_query:' instruction prefix."""
+    out = rerank.with_task_prefix("how does locking work", "query", model="nomic-embed-text")
+    assert_eq("query prefix applied", "search_query: how does locking work", out)
+
+
+def test_with_task_prefix_document():
+    """nomic models must get the 'search_document:' instruction prefix."""
+    out = rerank.with_task_prefix("the lock is age-based", "document", model="nomic-embed-text")
+    assert_eq("document prefix applied", "search_document: the lock is age-based", out)
+
+
+def test_with_task_prefix_noop_for_non_nomic():
+    """Non-nomic embedders use a different convention — leave text untouched."""
+    out = rerank.with_task_prefix("some text", "query", model="mxbai-embed-large")
+    assert_eq("non-nomic prefix is a no-op", "some text", out)
+
+
+def test_with_task_prefix_rejects_bad_role():
+    try:
+        rerank.with_task_prefix("x", "passage", model="nomic-embed-text")
+    except ValueError:
+        print("OK   with_task_prefix rejects unknown role")
+        return
+    raise Fail("FAIL with_task_prefix should reject unknown role")
+
+
+def test_rerank_sends_task_prefixes_to_embedder():
+    """End-to-end through rerank(): the query is embedded with 'search_query:' and
+    the chunk body with 'search_document:'. We capture every text sent to embed_one."""
+    sent = []
+
+    def fake_embed_one(url, model, text):
+        sent.append(text)
+        # Return a deterministic non-zero vector so cosine() is well-defined.
+        return [float(len(text) % 7) + 1.0, 2.0, 3.0]
+
+    chunk = {
+        "body_hash": "sha256:deadbeef",
+        "contextualized_text": "advisory locks are age-based",
+        "raw_text": "advisory locks are age-based",
+    }
+    with unittest.mock.patch.object(rerank, "ollama_alive", return_value=(True, ["nomic-embed-text"])), \
+         unittest.mock.patch.object(rerank, "ollama_url", return_value="http://127.0.0.1:11434"), \
+         unittest.mock.patch.object(rerank, "embed_one", side_effect=fake_embed_one), \
+         unittest.mock.patch.object(rerank, "load_chunk", return_value=chunk), \
+         unittest.mock.patch.object(rerank, "load_cache", return_value={}), \
+         unittest.mock.patch.object(rerank, "save_cache"):
+        candidates = [{"chunk_id": "c-001:0", "score": 5.0, "path": "x.json"}]
+        rerank.rerank("how does locking work", candidates, top_k=1)
+
+    assert_true("query embedded with search_query: prefix",
+                "search_query: how does locking work" in sent, hint=f"sent={sent}")
+    assert_true("document embedded with search_document: prefix",
+                "search_document: advisory locks are age-based" in sent, hint=f"sent={sent}")
+    assert_true("no un-prefixed text leaked to embedder",
+                all(t.startswith("search_query: ") or t.startswith("search_document: ") for t in sent),
+                hint=f"sent={sent}")
+
+
+def test_rerank_cache_key_includes_scheme():
+    """Old prefix-less cache entries (keyed without EMBED_SCHEME) must be ignored,
+    so we never mix prefixed and prefix-less vectors in the same cosine space."""
+    body_hash = "sha256:deadbeef"
+    stale_key = f"{rerank.DEFAULT_MODEL}:{body_hash}"  # pre-fix key shape
+    poisoned_cache = {stale_key: [99.0, 99.0, 99.0]}   # would be reused if key unchanged
+    embedded = []
+
+    def fake_embed_one(url, model, text):
+        embedded.append(text)
+        return [1.0, 2.0, 3.0]
+
+    chunk = {"body_hash": body_hash, "contextualized_text": "x", "raw_text": "x"}
+    with unittest.mock.patch.object(rerank, "ollama_alive", return_value=(True, ["nomic-embed-text"])), \
+         unittest.mock.patch.object(rerank, "ollama_url", return_value="http://127.0.0.1:11434"), \
+         unittest.mock.patch.object(rerank, "embed_one", side_effect=fake_embed_one), \
+         unittest.mock.patch.object(rerank, "load_chunk", return_value=chunk), \
+         unittest.mock.patch.object(rerank, "load_cache", return_value=poisoned_cache), \
+         unittest.mock.patch.object(rerank, "save_cache"):
+        candidates = [{"chunk_id": "c-001:0", "score": 5.0, "path": "x.json"}]
+        rerank.rerank("q", candidates, top_k=1)
+
+    assert_true("stale prefix-less cache entry is NOT reused (doc re-embedded)",
+                any(t.startswith("search_document: ") for t in embedded), hint=f"embedded={embedded}")
+
+
 # ─── retrieve.py CLI: exit 10 when not provisioned ────────────────────────────
 def test_retrieve_exits_10_without_index():
     """End-to-end CLI test: with no .vault-meta/bm25/index.json, retrieve.py must exit 10."""
@@ -332,6 +419,12 @@ def main():
     test_rerank_noop_when_ollama_unreachable()
     test_rerank_noop_when_model_missing()
     test_rerank_truncates_to_top_k()
+    test_with_task_prefix_query()
+    test_with_task_prefix_document()
+    test_with_task_prefix_noop_for_non_nomic()
+    test_with_task_prefix_rejects_bad_role()
+    test_rerank_sends_task_prefixes_to_embedder()
+    test_rerank_cache_key_includes_scheme()
     test_retrieve_exits_10_without_index()
     test_end_to_end_with_synthetic_chunks()
     test_explain_flag_adds_diagnostics_block()


### PR DESCRIPTION
# fix(rerank): send nomic `search_query:` / `search_document:` task prefixes

## Summary

`nomic-embed-text` is trained with **asymmetric task-instruction prefixes**:
queries must be embedded as `search_query: <text>` and indexed documents as
`search_document: <text>`. The reranker currently embeds both the query and the
chunk text **raw**, with no prefix:

```python
# scripts/rerank.py (before)
q_emb = embed_one(url, DEFAULT_MODEL, query)
...
emb   = embed_one(url, DEFAULT_MODEL, text)
```

Without the prefixes, query and document vectors land in a sub-optimal region of
the embedding space and cosine ranking quality measurably degrades. This is
documented by Nomic as required, not optional:
https://huggingface.co/nomic-ai/nomic-embed-text-v1.5#task-instruction-prefixes

Note: the `prefix` machinery in `contextual-prefix.py` is a *different* concept
(Anthropic contextual-retrieval context sentences) and is unaffected. The BM25
index also intentionally stays prefix-free — prefixes are an embedding-only
concern, so this change is scoped to `rerank.py`.

## What changed

- Added `with_task_prefix(text, role, model)` helper that prepends
  `search_query: ` / `search_document: ` for nomic-family models and is a
  **no-op for non-nomic embedders** (so swapping `DEFAULT_MODEL` to mxbai/bge
  stays correct).
- Applied it at both `embed_one` call sites in `rerank()`.
- Bumped the embed-cache key to include an `EMBED_SCHEME` token
  (`{model}:{EMBED_SCHEME}:{body_hash}`). This **transparently invalidates**
  vectors produced under the old prefix-less convention, so prefixed and
  prefix-less embeddings are never mixed in the same cosine space. No manual
  cache wipe needed — old entries simply miss and get re-embedded once.

## Tests

Added to `tests/test_retrieve.py` (hermetic, no network/ollama):

- `with_task_prefix` applies the correct prefix for query/document
- `with_task_prefix` is a no-op for non-nomic models
- `with_task_prefix` rejects unknown roles
- `rerank()` actually sends `search_query:` / `search_document:` to the embedder
  (captured via a mocked `embed_one`)
- stale prefix-less cache entries are no longer reused after the scheme bump

All existing tests still pass (`make test`).

## Compatibility / risk

- Backwards compatible: behaviour for non-nomic models is unchanged; the only
  one-time cost is a single re-embed of cached chunks on first run after upgrade.
- No API/CLI surface changes.
