### PR TITLE
fix(hooks): stop SessionStart/PostCompact prompt hooks from erroring every session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to claude-obsidian. Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/). Versioning: [SemVer](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- **`SessionStart` / `PostCompact` hooks no longer error on every session** (`hooks/hooks.json`). Recent Claude Code releases reject `prompt`-type hooks on lifecycle events that have no conversation context to inject into, printing `SessionStart:startup hook error — prompt-type hooks are not supported for SessionStart events (no conversation context is available). Use a command-type hook instead.` on every startup/resume.
+  - `SessionStart`: removed the redundant `prompt` step. The command hook `[ -f wiki/hot.md ] && cat wiki/hot.md` already restores the hot cache (the README's documented "canonical safety check"), so no behavior is lost.
+  - `PostCompact`: **converted** the `prompt` step to the equivalent command hook `[ -f wiki/hot.md ] && cat wiki/hot.md` rather than dropping it, preserving post-compaction hot-cache restoration via the same STDOUT-capture path `SessionStart` already uses (subject to the existing `anthropics/claude-code#10875` caveat documented in `hooks/README.md`).
+  - `hooks/README.md` Events table and STDOUT-bug note updated to match.
+
 ## [1.9.2] - 2026-05-27 (prompt-cache hardening + path-handling robustness)
 
 Ports Anthropic prompt-caching best practices into the **one** place the plugin calls the Anthropic API directly: tier-1 contextual-prefix generation in `scripts/contextual-prefix.py`. Verified by full-repo sweep that `cache_control` and the Anthropic API surface exist nowhere else (incl. `claude-canvas/`). No change to retrieval output — API payload shape + observability only.

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -6,8 +6,8 @@ Plugin hooks for the claude-obsidian wiki vault. All hooks are defined in `hooks
 
 | Event | Type | Purpose |
 |---|---|---|
-| `SessionStart` | command + prompt | Loads `wiki/hot.md` into context. Command type runs `[ -f wiki/hot.md ] && cat wiki/hot.md` as the canonical safety check (works for non-vault sessions without erroring). Prompt type complements with semantic context restoration. Matcher: `startup\|resume`. |
-| `PostCompact` | prompt | Re-loads `wiki/hot.md` after context compaction. Hook-injected context does NOT survive compaction (only `CLAUDE.md` does), so this hook restores the hot cache mid-session. |
+| `SessionStart` | command | Loads `wiki/hot.md` into context via `[ -f wiki/hot.md ] && cat wiki/hot.md` (the canonical safety check; works for non-vault sessions without erroring). Matcher: `startup\|resume`. |
+| `PostCompact` | command | Re-loads `wiki/hot.md` after context compaction via `[ -f wiki/hot.md ] && cat wiki/hot.md`. Hook-injected context does NOT survive compaction (only `CLAUDE.md` does), so this hook restores the hot cache mid-session. |
 | `PostToolUse` | command | Auto-commits any wiki/ or .raw/ changes after Write or Edit tool calls. Guarded by `[ -d .git ]` so it never errors in non-git directories, and by `git diff --cached --quiet` so it never creates empty commits. |
 | `Stop` | prompt | Updates `wiki/hot.md` at the end of every Claude response with a brief summary of what changed. |
 
@@ -15,7 +15,7 @@ Plugin hooks for the claude-obsidian wiki vault. All hooks are defined in `hooks
 
 `anthropics/claude-code#10875` documents that **plugin hook STDOUT may not be captured** by Claude Code, while identical inline hooks in `settings.json` work correctly.
 
-**Impact**: If this bug is active in your Claude Code version, the prompt-type SessionStart and PostCompact hooks may not inject context as expected.
+**Impact**: If this bug is active in your Claude Code version, the SessionStart and PostCompact command hooks (which restore the hot cache via STDOUT) may not inject context as expected.
 
 **Workaround**: The command-type SessionStart hook (`cat wiki/hot.md`) is the canonical safety check. It relies on STDOUT capture for context injection, so test against this issue if hot cache restoration fails. As a fallback, copy the hook config from `hooks.json` into your user-level `~/.claude/settings.json` instead of relying on plugin hooks.
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -11,10 +11,6 @@
           {
             "type": "command",
             "command": "[ -x scripts/wiki-lock.sh ] && bash scripts/wiki-lock.sh clear-stale --max-age 3600 >/dev/null 2>&1 || true"
-          },
-          {
-            "type": "prompt",
-            "prompt": "If a vault is configured for this session (check CLAUDE.md for VAULT_PATH or a wiki/ folder in the current directory), silently read wiki/hot.md to restore recent context. If wiki/hot.md does not exist, do nothing. This is a non-vault session. Do not announce this. Do not report what you read. Just have the context available."
           }
         ]
       }
@@ -24,8 +20,8 @@
         "matcher": "",
         "hooks": [
           {
-            "type": "prompt",
-            "prompt": "Hook-injected context does not survive context compaction. If wiki/hot.md exists in the current directory, silently re-read it now to restore the hot cache. Do not announce this."
+            "type": "command",
+            "command": "[ -f wiki/hot.md ] && cat wiki/hot.md || true"
           }
         ]
       }


### PR DESCRIPTION
## Summary

`hooks/hooks.json` registers `prompt`-type hooks on two lifecycle events — `SessionStart` (matcher `startup|resume`) and `PostCompact`. Recent Claude Code releases reject `prompt`-type hooks on lifecycle events that have no conversation context to inject into, so **every** startup/resume now prints:

```
SessionStart:startup hook error
Failed to run: prompt-type hooks are not supported for SessionStart events
(no conversation context is available). Use a command-type hook instead.
```

Reproduced on a clean install of **v1.9.2** with **Claude Code v2.1.173**. Non-fatal, but it fires on every session and is alarming to users (see the cluster of reports: #88, #87, #61, #48, #47, #45, #40, #29, #7).

## Fix

Both lifecycle hooks become `command`-type, so no `prompt` hooks remain on any lifecycle event:

| Event | Before | After | Rationale |
|---|---|---|---|
| `SessionStart` | command + command + **prompt** | command + command | The `prompt` step was a redundant duplicate — the `[ -f wiki/hot.md ] && cat wiki/hot.md` command hook already restores the hot cache, and `hooks/README.md` itself calls that the "canonical safety check." Removing it loses nothing. |
| `PostCompact` | **prompt** | command | **Converted, not deleted.** The intent (re-read `wiki/hot.md` after compaction) is real and has no existing command-hook equivalent, so I replaced it with `[ -f wiki/hot.md ] && cat wiki/hot.md` — the same STDOUT-capture restore path `SessionStart` already uses — rather than dropping the behavior. |

`hooks/README.md` (events table + STDOUT-bug note) and `CHANGELOG.md` are updated to match. The `Stop` hook is untouched (it's already command-type and fires with conversation context).

## Why convert `PostCompact` instead of removing it

Hook-injected context does not survive compaction, so `PostCompact` is the one place the plugin re-hydrates the hot cache mid-session. Simply deleting it silently removes that behavior. Converting it to the command form preserves it using a supported hook type, consistent with the existing `SessionStart` command hook. It remains subject to the pre-existing plugin-STDOUT caveat already documented in `hooks/README.md` (`anthropics/claude-code#10875`) — this PR doesn't change that, and notes it honestly in the changelog.

## Verification

```
$ jq empty hooks/hooks.json && echo "valid JSON"
valid JSON

# No prompt-type hooks remain on any lifecycle event:
$ jq -r '.hooks | to_entries[] | "\(.key): \([.value[].hooks[].type] | unique | join(", "))"' hooks/hooks.json
SessionStart: command
PostCompact: command
PostToolUse: command
Stop: command
```

After applying locally, the `SessionStart:startup hook error` banner no longer appears on startup or resume.

## Notes

This overlaps with #68 (SessionStart only) and #71 (removes both, but deletes the `PostCompact` behavior). This PR's distinction is preserving the `PostCompact` restore via conversion rather than deletion, plus keeping the docs/changelog in sync. Happy to rebase or trim scope to whatever you'd prefer to merge.
