### PR TITLE
fix(detect-transport): use 'version' subcommand for obsidian-cli probe

### DIFF
--- a/scripts/detect-transport.sh
+++ b/scripts/detect-transport.sh
@@ -58,7 +58,7 @@ log() { $QUIET || echo "$@" >&2; }
 # json_escape: read stdin and emit a JSON-encoded string (including the
 # surrounding double quotes). Used for any untrusted value that lands in the
 # transport.json heredoc — newlines, backslashes, control chars in upstream
-# binaries (obsidian-cli --version) would otherwise break the JSON.
+# binaries (obsidian-cli version) would otherwise break the JSON.
 json_escape() {
   python3 -c 'import json,sys; print(json.dumps(sys.stdin.read().strip()), end="")'
 }
@@ -126,7 +126,7 @@ if command -v obsidian-cli >/dev/null 2>&1; then
   # for the transport.json heredoc. CLI_VERSION below is pre-quoted (includes
   # the surrounding double quotes), so the heredoc emits ${CLI_VERSION}
   # without wrapping quotes.
-  CLI_VERSION_RAW="$(obsidian-cli --version 2>/dev/null | head -1 || echo unknown)"
+  CLI_VERSION_RAW="$(obsidian-cli version 2>/dev/null | head -1 || echo unknown)"
   CLI_VERSION="$(printf '%s' "$CLI_VERSION_RAW" | json_escape || echo '"unknown"')"
 elif command -v obsidian >/dev/null 2>&1; then
   # Obsidian 1.12+ ships `obsidian` as the CLI binary on some platforms.


### PR DESCRIPTION
## Problem

`scripts/detect-transport.sh` probes the Obsidian CLI version with `obsidian-cli --version`. Obsidian CLI 1.12 doesn't accept that flag — it expects the `version` **subcommand** — so the command errors:

```
Error: Command "--version" not found. Did you mean: version?
```

The error string is then captured verbatim into `.vault-meta/transport.json`:

```json
"version_string": "Error: Command \"--version\" not found. Did you mean: version?"
```

Transport *selection* is unaffected (it keys on binary presence, not the version string), but the snapshot records a misleading value.

## Fix

Switch the probe from `obsidian-cli --version` to `obsidian-cli version`, and update the matching comment on line 61. The snapshot now records the real version, e.g.:

```json
"version_string": "1.12.7 (installer 1.12.7)"
```

The separate `obsidian` (bare binary) fallback path is left untouched — that's a different binary with unverified flag conventions, and it only triggers when `obsidian-cli` is absent.

## Verification

```
$ obsidian-cli version
1.12.7 (installer 1.12.7)

$ bash scripts/detect-transport.sh --force
Preferred transport: cli
  CLI:        obsidian-cli (1.12.7 (installer 1.12.7))
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)