### PR TITLE
Fix SessionStart hook: remove unsupported prompt-type hook

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -11,10 +11,6 @@
           {
             "type": "command",
             "command": "[ -x scripts/wiki-lock.sh ] && bash scripts/wiki-lock.sh clear-stale --max-age 3600 >/dev/null 2>&1 || true"
-          },
-          {
-            "type": "prompt",
-            "prompt": "If a vault is configured for this session (check CLAUDE.md for VAULT_PATH or a wiki/ folder in the current directory), silently read wiki/hot.md to restore recent context. If wiki/hot.md does not exist, do nothing. This is a non-vault session. Do not announce this. Do not report what you read. Just have the context available."
           }
         ]
       }


### PR DESCRIPTION
## Problem

`hooks/hooks.json` registers a `prompt`-type hook under `SessionStart`. Claude Code rejects it on every new session / resume:

> Failed to run: prompt-type hooks are not supported for SessionStart events (no conversation context is available). Use a command-type hook instead.

`SessionStart` fires before any conversation context exists, so only `command`-type hooks are valid there.

## Why it is safe

The prompt-hook is redundant. The `command`-hook directly above already streams the hot cache into context:

```json
{ "type": "command", "command": "[ -f wiki/hot.md ] && cat wiki/hot.md || true" }
```

So `cat wiki/hot.md` already restores context; the prompt-hook just asked the model to read the same file again.

## Change

Remove the `prompt` block from the `SessionStart` array only. `PostCompact` keeps its prompt-hook (valid there). JSON validated.

Fixes the per-session warning seen on v1.9.2.