### PR TITLE
Fix: replace unsupported prompt-type SessionStart/PostCompact hooks with command hooks

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -6,16 +6,32 @@ Plugin hooks for the claude-obsidian wiki vault. All hooks are defined in `hooks
 
 | Event | Type | Purpose |
 |---|---|---|
-| `SessionStart` | command + prompt | Loads `wiki/hot.md` into context. Command type runs `[ -f wiki/hot.md ] && cat wiki/hot.md` as the canonical safety check (works for non-vault sessions without erroring). Prompt type complements with semantic context restoration. Matcher: `startup\|resume`. |
-| `PostCompact` | prompt | Re-loads `wiki/hot.md` after context compaction. Hook-injected context does NOT survive compaction (only `CLAUDE.md` does), so this hook restores the hot cache mid-session. |
+| `SessionStart` | command | Loads `wiki/hot.md` into context via `[ -f wiki/hot.md ] && cat wiki/hot.md` (the canonical safety check; works for non-vault sessions without erroring). Matcher: `startup\|resume`. Note: `SessionStart` runs before any conversation exists, so prompt-type hooks are not valid for this event — see below. |
+| `PostCompact` | command | Re-loads `wiki/hot.md` after context compaction via `[ -f wiki/hot.md ] && cat wiki/hot.md`. Hook-injected context does NOT survive compaction (only `CLAUDE.md` does), so this hook restores the hot cache mid-session. Must be a command hook — see below. |
 | `PostToolUse` | command | Auto-commits any wiki/ or .raw/ changes after Write or Edit tool calls. Guarded by `[ -d .git ]` so it never errors in non-git directories, and by `git diff --cached --quiet` so it never creates empty commits. |
 | `Stop` | prompt | Updates `wiki/hot.md` at the end of every Claude response with a brief summary of what changed. |
+
+## Why `SessionStart` and `PostCompact` use command hooks, not prompt hooks
+
+Neither lifecycle event supports prompt-type hooks in current Claude Code, but they fail in two *different* ways:
+
+- **`SessionStart`** is dispatched by the in-REPL hook runner, which requires a conversation context (`toolUseContext`) for prompt hooks. `SessionStart` fires before any conversation exists, so the runner throws — a visible error banner on **every** startup/resume:
+
+  ```
+  SessionStart:startup hook error
+  Failed to run: prompt-type hooks are not supported for SessionStart events
+  (no conversation context is available). Use a command-type hook instead.
+  ```
+
+- **`PostCompact`** is dispatched by `executeHooksOutsideREPL`, which supports only `command`/`callback`/`mcp_tool` hooks. A prompt hook there returns `succeeded: false` ("Prompt … hooks are not yet supported outside REPL") and the result is silently dropped — **no error, but no effect either**. The previous prompt-type `PostCompact` hook never actually restored the hot cache.
+
+The fix for both is the same: use the `command` hook `[ -f wiki/hot.md ] && cat wiki/hot.md`, whose STDOUT is injected into context. For `SessionStart` this was already covered by an existing command hook (the prompt entry was redundant and is removed); for `PostCompact` the prompt entry is **converted** to the command form so post-compaction restoration works for the first time.
 
 ## Known Issue: Plugin Hooks STDOUT Bug
 
 `anthropics/claude-code#10875` documents that **plugin hook STDOUT may not be captured** by Claude Code, while identical inline hooks in `settings.json` work correctly.
 
-**Impact**: If this bug is active in your Claude Code version, the prompt-type SessionStart and PostCompact hooks may not inject context as expected.
+**Impact**: If this bug is active in your Claude Code version, the SessionStart and PostCompact command hooks (which restore the hot cache via STDOUT) may not inject context as expected.
 
 **Workaround**: The command-type SessionStart hook (`cat wiki/hot.md`) is the canonical safety check. It relies on STDOUT capture for context injection, so test against this issue if hot cache restoration fails. As a fallback, copy the hook config from `hooks.json` into your user-level `~/.claude/settings.json` instead of relying on plugin hooks.
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -11,10 +11,6 @@
           {
             "type": "command",
             "command": "[ -x scripts/wiki-lock.sh ] && bash scripts/wiki-lock.sh clear-stale --max-age 3600 >/dev/null 2>&1 || true"
-          },
-          {
-            "type": "prompt",
-            "prompt": "If a vault is configured for this session (check CLAUDE.md for VAULT_PATH or a wiki/ folder in the current directory), silently read wiki/hot.md to restore recent context. If wiki/hot.md does not exist, do nothing. This is a non-vault session. Do not announce this. Do not report what you read. Just have the context available."
           }
         ]
       }
@@ -24,8 +20,8 @@
         "matcher": "",
         "hooks": [
           {
-            "type": "prompt",
-            "prompt": "Hook-injected context does not survive context compaction. If wiki/hot.md exists in the current directory, silently re-read it now to restore the hot cache. Do not announce this."
+            "type": "command",
+            "command": "[ -f wiki/hot.md ] && cat wiki/hot.md || true"
           }
         ]
       }


### PR DESCRIPTION
## Problem

Current Claude Code does not support prompt-type hooks on the `SessionStart` or `PostCompact` lifecycle events. `hooks/hooks.json` registers a prompt hook on each, and they fail in **two different ways** — verified by tracing the Claude Code `2.1.186` binary.

### `SessionStart` — hard error on every startup
Dispatched by the in-REPL hook runner, which requires a conversation context (`toolUseContext`) for prompt hooks. `SessionStart` fires before any conversation exists, so the runner throws:

```js
if (N.type === "prompt") {
  if (!i) throw Error(`prompt-type hooks are not supported for ${d} events
                       (no conversation context is available)...`);
```

Result — a visible banner on **every** startup/resume for anyone with the plugin enabled globally:

```
SessionStart:startup hook error
Failed to run: prompt-type hooks are not supported for SessionStart events
(no conversation context is available). Use a command-type hook instead.
```

### `PostCompact` — silent no-op
Dispatched by `executeHooksOutsideREPL`, which supports only `command`/`callback`/`mcp_tool`. A prompt hook there returns:

```js
if (h.type === "prompt") return { succeeded: false,
    output: "Prompt stop hooks are not yet supported outside REPL" };
```

and the `PostCompact` caller only surfaces `succeeded:true` results, so the failure is swallowed. No banner — **but the hot cache was never actually restored after compaction.** This hook has been a dead no-op.

## Fix

Use the command hook `[ -f wiki/hot.md ] && cat wiki/hot.md`, whose STDOUT is injected into context (command hooks are supported by both dispatchers).

- **`SessionStart`**: the prompt entry was redundant with the existing `cat wiki/hot.md` command hook, so it is **removed**.
- **`PostCompact`**: the prompt entry is **converted** to the command form, so post-compaction restoration works for the first time.

`Stop` / `SubagentStop` / `UserPromptSubmit` prompt hooks are untouched — those run in-REPL with a conversation context, so prompt hooks are valid there.

## Changes
- `hooks/hooks.json` — remove the `SessionStart` prompt hook; convert the `PostCompact` prompt hook to a command hook.
- `hooks/README.md` — events table updated (both now command), plus a section documenting the two distinct failure modes and the STDOUT-bug note corrected.

## Testing
- `hooks/hooks.json` validated as well-formed JSON; `SessionStart` → `[command, command]`, `PostCompact` → `[command]`.
- Failure modes traced directly in the `2.1.186` bundle (`cv` REPL runner vs `executeHooksOutsideREPL`).

---

## How this compares to the other open PRs for this bug

At the time of writing, five PRs (incl. this one) address the same prompt-hook issue. They split by **scope**:

| PR | SessionStart | PostCompact | Docs | Notes |
|----|--------------|-------------|------|-------|
| **this PR (#100)** | removes prompt | **converts → command** | README (table + failure-mode writeup) | Silences SessionStart **and** makes PostCompact restore actually work |
| #68 | removes prompt | left as prompt | none | Minimal; identical hooks.json to #99 |
| #99 | removes prompt | left as prompt | none | Minimal; identical hooks.json to #68 |
| #90 | removes prompt | **converts → command** | README + CHANGELOG | Same functional fix as this PR; this PR adds the binary-traced failure-mode explanation |
| #71 | removes prompt | **removes entirely** | README + CHANGELOG | Drops PostCompact rather than fixing it |

**Why the PostCompact decision matters.** The three minimal PRs (#68/#99 and the original version of this one) silence the visible SessionStart error but leave the PostCompact prompt hook in place — and per the binary trace above, that hook is a silent no-op, so post-compaction hot-cache restoration silently never happens. #71 removes PostCompact, which is harmless (it was already dead) but discards the author's intent. **Converting it to a command hook (this PR and #90) is the only approach that makes post-compaction restoration actually function.**

This PR is functionally equivalent to #90; the difference is the binary-level root-cause writeup (two distinct dispatchers / failure modes) in the description and `hooks/README.md`. Happy to consolidate with #90 in whatever way is easiest for the maintainer — the important thing is that **PostCompact gets converted, not just SessionStart removed.**