### PR TITLE
fix(scripts): cross-platform fcntl import (native Windows support)

### DIFF
--- a/scripts/bm25-index.py
+++ b/scripts/bm25-index.py
@@ -46,7 +46,15 @@ Exit codes:
 """
 
 import argparse
-import fcntl
+try:
+    import fcntl
+except ModuleNotFoundError:  # Windows has no fcntl; advisory locks become no-ops (single-user vault).
+    class _NoFcntl:
+        LOCK_EX = LOCK_SH = LOCK_UN = LOCK_NB = 0
+        @staticmethod
+        def flock(*_a, **_k):
+            return None
+    fcntl = _NoFcntl()
 import json
 import math
 import os

--- a/scripts/rerank.py
+++ b/scripts/rerank.py
@@ -42,7 +42,15 @@ Exit codes:
 """
 
 import argparse
-import fcntl
+try:
+    import fcntl
+except ModuleNotFoundError:  # Windows has no fcntl; advisory locks become no-ops (single-user vault).
+    class _NoFcntl:
+        LOCK_EX = LOCK_SH = LOCK_UN = LOCK_NB = 0
+        @staticmethod
+        def flock(*_a, **_k):
+            return None
+    fcntl = _NoFcntl()
 import json
 import math
 import os

--- a/scripts/tiling-check.py
+++ b/scripts/tiling-check.py
@@ -27,7 +27,15 @@ Usage:
 """
 
 import argparse
-import fcntl
+try:
+    import fcntl
+except ModuleNotFoundError:  # Windows has no fcntl; advisory locks become no-ops (single-user vault).
+    class _NoFcntl:
+        LOCK_EX = LOCK_SH = LOCK_UN = LOCK_NB = 0
+        @staticmethod
+        def flock(*_a, **_k):
+            return None
+    fcntl = _NoFcntl()
 import hashlib
 import json
 import math


### PR DESCRIPTION
## Problem

`scripts/bm25-index.py`, `scripts/rerank.py`, and `scripts/tiling-check.py` import `fcntl` at module top level. `fcntl` is Unix-only, so on **native Windows CPython** these scripts raise `ModuleNotFoundError: No module named 'fcntl'`.

Concretely, `bash bin/setup-retrieve.sh` clears Stage 1 (contextual-prefix chunking) but dies at **Stage 2 (BM25 build)**:

```
File ".../scripts/bm25-index.py", line 49, in <module>
    import fcntl
ModuleNotFoundError: No module named 'fcntl'
```

`tiling-check.py` (DragonScale tiling lint) is unusable on Windows for the same reason. The README / `CLAUDE.md` currently document this as a hard limitation (native Windows unsupported, use WSL).

## Fix

Wrap the import in `try/except ModuleNotFoundError` with a tiny no-op `flock` shim:

```python
try:
    import fcntl
except ModuleNotFoundError:  # Windows has no fcntl; advisory locks become no-ops (single-user vault).
    class _NoFcntl:
        LOCK_EX = LOCK_SH = LOCK_UN = LOCK_NB = 0
        @staticmethod
        def flock(*_a, **_k):
            return None
    fcntl = _NoFcntl()
```

- **Unix: zero behavior change.** `import fcntl` succeeds, so the `except` branch is dead code and real `flock` advisory locking is preserved.
- **Windows: advisory locks become no-ops.** Safe for the documented single-user vault model (no concurrent index writers), and consistent with the repo's existing graceful-degradation stance (e.g. `rerank.py`'s `LOCK_NB` + fallback-to-unlocked-write on non-flock filesystems).

No public function signatures change; the lock helpers (`acquire_lock`/`release_lock`, `save_cache`, `_lock_cache`/`_unlock_cache`) keep their behavior.

## Verification

On Windows 11 / CPython with ollama + `nomic-embed-text`:

- `bash bin/setup-retrieve.sh --no-llm` now completes end to end: **337 pages -> 525 chunks**, BM25 index built (**vocab 29,868**).
- `python3 scripts/retrieve.py "<query>"` returns `strategy: bm25+rerank:cosine:nomic-embed-text` with relevant hits.
- `python3 -m py_compile` passes on all three files.

I could not run the full Unix test suite on the Windows host; the change is import-only and leaves the Unix code path identical, so existing suites should be unaffected. Happy to adjust naming/placement to match your conventions.
