### PR TITLE
feat(perimeter): opt-in privacy perimeter + graph lint + consolidation guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,9 @@ _attachments/
 # v1.8 methodology mode (host-specific by default; `git add -f` to commit if desired)
 .vault-meta/mode.json
 .vault-meta/mode.*.tmp
+# Privacy perimeter config (user's sensitive-band globs and PII regex
+# vocabulary are themselves sensitive; `git add -f` to share with a team)
+.vault-meta/perimeter-paths.txt
+.vault-meta/perimeter-patterns.txt
+.vault-meta/perimeter-whitelist.txt
+.vault-meta/perimeter-airgap

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,9 @@
 # Test runner entry points for DragonScale and vault tooling.
 
 .PHONY: test test-address test-tiling test-boundary test-bm25 test-retrieve \
-        test-lock test-concurrent test-mode test-contextual setup-dragonscale \
-        setup-retrieve setup-mode clean-test-state help
+        test-lock test-concurrent test-mode test-contextual test-graph-lint \
+        test-perimeter setup-dragonscale \
+        setup-retrieve setup-mode setup-perimeter clean-test-state help
 
 help:
 	@echo "claude-obsidian developer targets:"
@@ -17,12 +18,15 @@ help:
 	@echo "  make test-concurrent  multi-writer correctness gate (shell, hermetic)"
 	@echo "  make test-mode        scripts/wiki-mode.py tests (python, hermetic)"
 	@echo "  make test-contextual  scripts/contextual-prefix.py cache-floor tests (python, hermetic)"
+	@echo "  make test-graph-lint  scripts/graph-lint.py tests (python, hermetic)"
+	@echo "  make test-perimeter   bin/setup-perimeter.sh tests (shell, hermetic)"
 	@echo "  make setup-dragonscale Run bin/setup-dragonscale.sh against this vault"
 	@echo "  make setup-retrieve   Run bin/setup-retrieve.sh against this vault (opt-in v1.7)"
 	@echo "  make setup-mode       Run bin/setup-mode.sh to pick a methodology mode (opt-in v1.8)"
+	@echo "  make setup-perimeter  Run bin/setup-perimeter.sh to install the privacy perimeter (opt-in)"
 	@echo "  make clean-test-state Remove runtime lockfiles and tiling/embed caches"
 
-test: test-address test-tiling test-boundary test-bm25 test-retrieve test-lock test-concurrent test-mode test-contextual
+test: test-address test-tiling test-boundary test-bm25 test-retrieve test-lock test-concurrent test-mode test-contextual test-graph-lint test-perimeter
 	@echo ""
 	@echo "All tests passed."
 
@@ -62,6 +66,14 @@ test-contextual:
 	@echo "=== test_contextual_prefix.py ==="
 	@python3 tests/test_contextual_prefix.py
 
+test-graph-lint:
+	@echo "=== test_graph_lint.py ==="
+	@python3 tests/test_graph_lint.py
+
+test-perimeter:
+	@echo "=== test_setup_perimeter.sh ==="
+	@bash tests/test_setup_perimeter.sh
+
 setup-dragonscale:
 	@bash bin/setup-dragonscale.sh
 
@@ -70,6 +82,9 @@ setup-retrieve:
 
 setup-mode:
 	@bash bin/setup-mode.sh
+
+setup-perimeter:
+	@bash bin/setup-perimeter.sh
 
 clean-test-state:
 	@rm -f .vault-meta/.address.lock .vault-meta/.tiling.lock .vault-meta/.bm25.lock \

--- a/bin/setup-perimeter.sh
+++ b/bin/setup-perimeter.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+# setup-perimeter.sh — opt-in privacy perimeter for vaults with sensitive data.
+#
+# Installs two git hooks that enforce a deny-by-default privacy boundary:
+#
+#   pre-commit  Blocks the commit if (1) a staged path matches a sensitive
+#               band (glob list), or (2) an ADDED line in the staged diff
+#               matches an identifier/secret pattern (regex list), minus a
+#               whitelist of known false positives.
+#   pre-push    If air-gap mode is enabled, blocks EVERY push. For vaults
+#               that must never leave the machine.
+#
+# Config lives in three plain-text files under .vault-meta/ (one entry per
+# line, `#` comments), seeded with commented examples on first run:
+#
+#   perimeter-paths.txt      staged-path globs to block (e.g. private/*)
+#   perimeter-patterns.txt   regexes for added lines (secrets baseline included)
+#   perimeter-whitelist.txt  exact-token regexes to accept (false positives)
+#
+# The hooks are data-local: no network, nothing leaves the repo. Overrides
+# are single-shot and explicit:
+#
+#   PERIMETER_ALLOW=1 git commit ...       # skip the pre-commit gate once
+#   PERIMETER_ALLOW_PUSH=1 git push ...    # lift the air-gap for one push
+#
+# Usage:
+#   bash bin/setup-perimeter.sh              # interactive
+#   bash bin/setup-perimeter.sh --yes        # non-interactive (CI / scripts)
+#   bash bin/setup-perimeter.sh --air-gap    # also enable the push block
+#   bash bin/setup-perimeter.sh --check      # diagnostics only, no write
+#   bash bin/setup-perimeter.sh --uninstall  # remove managed hooks, restore backups
+#
+# Existing unmanaged hooks are backed up to <hook>.pre-perimeter.bak and
+# restored on --uninstall. Idempotent — safe to re-run.
+#
+# Exit codes: 0 success, 2 usage error, 3 not a git repository.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VAULT="$(dirname "$SCRIPT_DIR")"
+MARKER="managed-by: claude-obsidian setup-perimeter"
+
+ASSUME_YES=false
+AIR_GAP=false
+CHECK_ONLY=false
+UNINSTALL=false
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --yes)       ASSUME_YES=true; shift ;;
+    --air-gap)   AIR_GAP=true; shift ;;
+    --check)     CHECK_ONLY=true; shift ;;
+    --uninstall) UNINSTALL=true; shift ;;
+    -h|--help)   sed -n '2,38p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) echo "ERR: unknown flag: $1" >&2; exit 2 ;;
+  esac
+done
+
+say()  { printf '%s\n' "$@"; }
+warn() { printf 'WARN: %s\n' "$@" >&2; }
+
+GIT_DIR="$(cd "$VAULT" && git rev-parse --git-dir 2>/dev/null || true)"
+if [ -z "$GIT_DIR" ]; then
+  warn "not a git repository: $VAULT — the perimeter needs git hooks."
+  exit 3
+fi
+case "$GIT_DIR" in
+  /*|[A-Za-z]:*) HOOKS="$GIT_DIR/hooks" ;;
+  *)             HOOKS="$VAULT/$GIT_DIR/hooks" ;;
+esac
+META="$VAULT/.vault-meta"
+
+is_managed() { [ -f "$1" ] && grep -q "$MARKER" "$1"; }
+
+hook_status() {
+  local h="$1"
+  if is_managed "$HOOKS/$h"; then echo "managed"
+  elif [ -f "$HOOKS/$h" ]; then echo "unmanaged"
+  else echo "absent"; fi
+}
+
+say "═══ privacy perimeter setup ═══"
+say "Vault: $VAULT"
+say ""
+
+if [ "$CHECK_ONLY" = true ]; then
+  say "pre-commit:  $(hook_status pre-commit)"
+  say "pre-push:    $(hook_status pre-push)"
+  [ -f "$META/perimeter-airgap" ] && say "air-gap:     ENABLED (pushes blocked)" \
+                                   || say "air-gap:     disabled"
+  for cfg in perimeter-paths.txt perimeter-patterns.txt perimeter-whitelist.txt; do
+    if [ -f "$META/$cfg" ]; then
+      n=$(grep -cvE '^[[:space:]]*(#|$)' "$META/$cfg" || true)
+      say "config:      $cfg ($n active entries)"
+    else
+      say "config:      $cfg (missing)"
+    fi
+  done
+  exit 0
+fi
+
+if [ "$UNINSTALL" = true ]; then
+  for h in pre-commit pre-push; do
+    if is_managed "$HOOKS/$h"; then
+      rm -f "$HOOKS/$h"
+      say "removed managed hook: $h"
+      if [ -f "$HOOKS/$h.pre-perimeter.bak" ]; then
+        mv "$HOOKS/$h.pre-perimeter.bak" "$HOOKS/$h"
+        say "restored backup:      $h.pre-perimeter.bak -> $h"
+      fi
+    else
+      say "skip $h: $(hook_status "$h") (not managed by this setup)"
+    fi
+  done
+  rm -f "$META/perimeter-airgap"
+  say "air-gap flag removed. Config files under .vault-meta/ kept (delete manually if unwanted)."
+  exit 0
+fi
+
+# ── Consent ─────────────────────────────────────────────────────────────────
+say "This installs git pre-commit + pre-push hooks in this repository."
+say "They run locally on every commit/push; nothing leaves your machine."
+if [ "$ASSUME_YES" != true ]; then
+  printf 'Proceed? [y/N] '
+  read -r reply
+  case "$reply" in y|Y|yes|YES) ;; *) say "Aborted. Nothing written."; exit 0 ;; esac
+fi
+
+mkdir -p "$META" "$HOOKS"
+
+# ── Seed config files (never overwrite user edits) ──────────────────────────
+if [ ! -f "$META/perimeter-paths.txt" ]; then
+  cat > "$META/perimeter-paths.txt" <<'EOF'
+# perimeter-paths.txt — staged-path globs that must NEVER be committed.
+# One glob per line, matched against the repo-relative staged path.
+# Examples (uncomment / adapt):
+#   private/*
+#   journal/*
+#   */secrets/*
+#   *.db
+EOF
+  say "seeded: .vault-meta/perimeter-paths.txt (edit to add your sensitive bands)"
+fi
+
+if [ ! -f "$META/perimeter-patterns.txt" ]; then
+  cat > "$META/perimeter-patterns.txt" <<'EOF'
+# perimeter-patterns.txt — regexes checked against ADDED lines in the staged
+# diff (grep -E syntax). One per line. A generic secrets baseline is always
+# active in the hook itself; add identifier formats for your jurisdiction here.
+# Examples (uncomment / adapt):
+# Spanish national ID (DNI/NIE) and company ID (CIF):
+#   \b[0-9]{8}[A-Za-z]\b
+#   \b[XYZxyz][0-9]{7}[A-Za-z]\b
+#   \b[A-HJNPQRSUVWa-hjnpqrsuvw][0-9]{7}[0-9A-Ja-j]\b
+# US Social Security number:
+#   \b[0-9]{3}-[0-9]{2}-[0-9]{4}\b
+EOF
+  say "seeded: .vault-meta/perimeter-patterns.txt (edit to add PII formats)"
+fi
+
+if [ ! -f "$META/perimeter-whitelist.txt" ]; then
+  cat > "$META/perimeter-whitelist.txt" <<'EOF'
+# perimeter-whitelist.txt — exact-token regexes that are known false
+# positives (public registry codes, documented test IDs). One per line.
+# Example:
+#   ^12345678Z$
+EOF
+  say "seeded: .vault-meta/perimeter-whitelist.txt"
+fi
+
+# ── Back up unmanaged hooks, then install ───────────────────────────────────
+for h in pre-commit pre-push; do
+  if [ -f "$HOOKS/$h" ] && ! is_managed "$HOOKS/$h"; then
+    cp "$HOOKS/$h" "$HOOKS/$h.pre-perimeter.bak"
+    warn "existing $h hook backed up to $h.pre-perimeter.bak (restored on --uninstall)"
+  fi
+done
+
+cat > "$HOOKS/pre-commit" <<'HOOK'
+#!/usr/bin/env bash
+# managed-by: claude-obsidian setup-perimeter v1
+# Privacy perimeter — blocks committing sensitive paths and leaked identifiers.
+# Single-shot override (use with eyes open):  PERIMETER_ALLOW=1 git commit ...
+set -euo pipefail
+[ "${PERIMETER_ALLOW:-0}" = "1" ] && { echo "perimeter: override active — commit allowed." >&2; exit 0; }
+
+ROOT="$(git rev-parse --show-toplevel)"
+META="$ROOT/.vault-meta"
+staged=$(git diff --cached --name-only --diff-filter=ACM)
+[ -z "$staged" ] && exit 0
+viol=0
+
+# (1) Sensitive path bands — name check only, cheap even on huge commits.
+if [ -f "$META/perimeter-paths.txt" ]; then
+  while IFS= read -r pat; do
+    pat="${pat%%#*}"
+    pat="$(printf '%s' "$pat" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')"
+    [ -z "$pat" ] && continue
+    while IFS= read -r f; do
+      # shellcheck disable=SC2254  # unquoted on purpose: config line is a glob
+      case "$f" in
+        $pat)
+          echo "BLOCK: sensitive path staged: $f  (matches '$pat')" >&2
+          viol=1 ;;
+      esac
+    done <<< "$staged"
+  done < "$META/perimeter-paths.txt"
+fi
+
+# (2) Identifier/secret patterns in ADDED lines — one pass over the whole diff.
+SECRET_RE='BEGIN [A-Z ]*PRIVATE KEY|AKIA[0-9A-Z]{16}|(^|[^A-Za-z])(password|passwd|api[_-]?key|secret|token)[[:space:]]*[:=][[:space:]]*[^[:space:]]'
+user_re=""
+if [ -f "$META/perimeter-patterns.txt" ]; then
+  user_re="$(grep -vE '^[[:space:]]*(#|$)' "$META/perimeter-patterns.txt" | sed 's/^[[:space:]]*//' | paste -sd'|' -)"
+fi
+pat_re="$SECRET_RE"
+[ -n "$user_re" ] && pat_re="$pat_re|$user_re"
+
+wl_re='^$'
+if [ -f "$META/perimeter-whitelist.txt" ]; then
+  wl="$(grep -vE '^[[:space:]]*(#|$)' "$META/perimeter-whitelist.txt" | sed 's/^[[:space:]]*//' | paste -sd'|' -)"
+  [ -n "$wl" ] && wl_re="$wl"
+fi
+
+hits=$(git diff --cached -U0 --diff-filter=ACM 2>/dev/null \
+        | grep -E '^\+' | grep -vE '^\+\+\+' \
+        | grep -oE "$pat_re" 2>/dev/null | sort -u | grep -vE "$wl_re" || true)
+if [ -n "$hits" ]; then
+  echo "BLOCK: possible identifier/secret in staged additions:" >&2
+  echo "$hits" | head -10 | sed 's/^/    /' >&2
+  viol=1
+fi
+
+if [ "$viol" = "1" ]; then
+  echo "" >&2
+  echo "Commit blocked by the privacy perimeter. Redact/anonymize, adjust" >&2
+  echo ".vault-meta/perimeter-*.txt, or (known false positive, single shot):" >&2
+  echo "  PERIMETER_ALLOW=1 git commit ..." >&2
+  exit 1
+fi
+exit 0
+HOOK
+chmod +x "$HOOKS/pre-commit"
+say "installed: pre-commit (path bands + identifier scan)"
+
+cat > "$HOOKS/pre-push" <<'HOOK'
+#!/usr/bin/env bash
+# managed-by: claude-obsidian setup-perimeter v1
+# Air-gap guard — when enabled, this repository never pushes to any remote.
+# Single-shot override:  PERIMETER_ALLOW_PUSH=1 git push ...
+if [ "${PERIMETER_ALLOW_PUSH:-0}" = "1" ]; then
+  echo "perimeter: air-gap override active — allowing this push." >&2
+  exit 0
+fi
+ROOT="$(git rev-parse --show-toplevel)"
+if [ -f "$ROOT/.vault-meta/perimeter-airgap" ]; then
+  echo "" >&2
+  echo "AIR-GAP: push blocked. This vault is air-gapped by design." >&2
+  echo "  One push only:  PERIMETER_ALLOW_PUSH=1 git push <...>" >&2
+  echo "  Disable:        rm .vault-meta/perimeter-airgap" >&2
+  echo "" >&2
+  exit 1
+fi
+exit 0
+HOOK
+chmod +x "$HOOKS/pre-push"
+say "installed: pre-push (air-gap guard)"
+
+if [ "$AIR_GAP" = true ]; then
+  printf 'enabled %s\n' "$(date '+%Y-%m-%d')" > "$META/perimeter-airgap"
+  say "air-gap: ENABLED — every push from this repo is now blocked."
+else
+  say "air-gap: not enabled (pass --air-gap for vaults that must never push)."
+fi
+
+say ""
+say "Done. Edit .vault-meta/perimeter-paths.txt and perimeter-patterns.txt to"
+say "match your vault's sensitive bands, then test with a dummy commit."
+exit 0

--- a/docs/consolidation-guide.md
+++ b/docs/consolidation-guide.md
@@ -1,0 +1,132 @@
+# Multi-Source Consolidation Guide
+
+How to merge several vaults (or one vault plus a pile of external sources)
+into a single compounding wiki without losing data, leaking data, or breaking
+the link graph. These patterns were battle-tested consolidating four live
+vaults (~10,000 files) into one, and they generalize to any migration where
+the sources contain anything you would not publish.
+
+Three tools in this repo back the guide:
+
+| Tool | Role |
+|---|---|
+| `bin/setup-perimeter.sh` | deny-by-default privacy boundary (git hooks) |
+| `scripts/graph-lint.py` | link-graph health check after every merge wave |
+| `scripts/wiki-lock.sh` | per-file locks when several writers ingest at once |
+
+## The consolidation loop
+
+Each source (a vault, an export, a folder of documents) goes through the same
+loop. Run it per source, never "all sources at once" — a failed wave should be
+one revert, not an archaeology project.
+
+```
+import (copy-forward) → dedup → weave → lint → commit
+```
+
+1. **Import, copy-forward only.** The source is read, never modified. Before
+   copying, hash the whole source tree (`find ... | sha256sum`) and hash it
+   again after: byte-identical manifests are your proof the source survived.
+   Keep sources intact until the migration is verified end to end — they are
+   your rollback anchor.
+
+2. **Dedup by normalized name, not by identifier.** Two vaults describing the
+   same thing rarely share an ID, but they usually share a title. Normalize
+   (lowercase, strip diacritics/punctuation) and compare. For candidate pairs,
+   diff the content — and normalize line endings first: CRLF/LF noise routinely
+   shows up as ">1% divergence" between files that are actually identical
+   (`diff <(tr -d '\r' < a) <(tr -d '\r' < b)`).
+
+3. **Weave, don't just copy.** A page that lands without inbound links is
+   invisible to future retrieval. Every imported page gets: a link from the
+   relevant MOC or `_index.md`, and (if your vault uses hierarchy frontmatter)
+   an `up:` pointing at an existing note — never at a folder name.
+
+4. **Lint the graph after every wave.** `python3 scripts/graph-lint.py --root wiki`
+   reports broken links, broken `up:`, and orphans. Classify before you fix:
+   calendar dates and planned-but-unwritten pages are *legitimate* dangling
+   links — whitelist them (`.vault-meta/graph-lint-whitelist.txt`) instead of
+   editing the files that mention them. What remains is either genuinely
+   broken (fix it) or a creation backlog (document it).
+
+5. **Commit per wave, with a reversible map.** One commit per source/wave,
+   and a machine-readable map (CSV of `old-path,new-path`) committed alongside.
+   Reversibility is what makes an aggressive migration safe.
+
+## Hardened migration (for sensitive sources)
+
+When a source contains anything private — personal notes, client data,
+identifiers — the import step needs teeth. The pattern, in order of the
+guarantees it gives you:
+
+- **Dry-run by default.** The migration script copies nothing unless invoked
+  with an explicit `--apply`. The default run prints what *would* happen.
+- **Scan before add.** After copying, scan every copied file (secrets baseline
+  plus your own identifier patterns) *before* any `git add`. A file that fails
+  the scan is deleted from the destination, not committed "to fix later".
+- **Index-only tier.** Version taxonomy/index files; leave verbatim sensitive
+  content untracked (or in a gitignored band). Most retrieval value lives in
+  the index layer anyway.
+- **Manifest proof.** Source hashed before and after (see loop step 1).
+- **Anti-operator brakes.** The failure mode is not the script — it is the
+  operator approving zone after zone in one sitting. Two deterministic brakes:
+  (a) *retype confirmation*: committing a sensitive zone requires re-typing the
+  zone name exactly (no blind re-runs); (b) *cooldown*: refuse to commit a
+  second sensitive zone within N hours of the previous one.
+
+And the lesson that motivates all of it: **pattern-based PII scanning is not
+sufficient.** Regexes catch well-formed identifiers; they miss hyphenated
+variants, names, addresses, and — worst of all — real data disguised as
+"examples" inside templates and course material. For anything you publish or
+back up off-machine, exclude the entire example/case layer wholesale rather
+than trusting a scrub. The perimeter (below) is the last line of defense, not
+the only one.
+
+## The privacy perimeter
+
+`bash bin/setup-perimeter.sh` installs two git hooks (opt-in, local-only,
+nothing leaves your machine):
+
+- **pre-commit** blocks the commit if a staged path matches a sensitive band
+  glob (`.vault-meta/perimeter-paths.txt`) or an added line matches an
+  identifier/secret regex (`.vault-meta/perimeter-patterns.txt`), minus a
+  whitelist of known false positives (`.vault-meta/perimeter-whitelist.txt`).
+- **pre-push** (with `--air-gap`) blocks *every* push, for vaults that must
+  never leave the machine.
+
+Overrides exist and are single-shot on purpose (`PERIMETER_ALLOW=1`,
+`PERIMETER_ALLOW_PUSH=1`): a human types them per incident, scripts don't.
+Run `bash bin/setup-perimeter.sh --check` for a status readout and
+`--uninstall` to remove the hooks (pre-existing hooks are backed up and
+restored automatically).
+
+Two operational notes, both learned the hard way:
+
+- gitignore a *future* sensitive directory with both forms (`x` and `x/`):
+  directory-only patterns don't match `git check-ignore x` while the
+  directory doesn't exist yet.
+- third-party installers and CLIs can run `git init` or add remotes over the
+  current directory — never run them from inside an air-gapped vault.
+
+## Merge governance
+
+Interpretive decisions (which duplicate wins, what gets renamed, what gets
+quarantined) need provenance, or the second migration relitigates the first.
+Two small documents, kept in the vault and committed with each wave:
+
+- **A dedup ledger.** One line per merge decision: the pair, the winner, the
+  tie-break rule applied, the date. When sources conflict, declare the
+  precedence order *once* at the top (`source A > source B > source C`) and
+  mark canonical pages with `ssot: true` frontmatter so later ingests defer
+  to them.
+- **A pending-decisions quarantine.** Anything requiring human judgment
+  (ambiguous PII, conflicting versions of the same reference, bulk moves of
+  sensitive records) gets parked in a `decisions-pending.md` with enough
+  context to decide later. The loop continues; the human decides on their own
+  schedule; each resolved item records who decided and why. An empty
+  quarantine is the definition of "consolidation done".
+
+If multiple agents write during a merge wave, guard every page write with
+`scripts/wiki-lock.sh acquire`/`release` (see the concurrency section in
+`CLAUDE.md`) — the loop above is safe for parallel ingest as long as writers
+lock per file.

--- a/scripts/graph-lint.py
+++ b/scripts/graph-lint.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""graph-lint.py — wikilink graph health check for an Obsidian vault.
+
+Scans one or more content roots for [[wikilinks]], resolves them the way
+Obsidian does (basename match plus frontmatter aliases), and reports:
+
+  - broken links: targets that resolve to no page
+  - broken ``up:`` links: the frontmatter hierarchy field many vaults use
+    to point a note at its parent MOC / index
+  - orphan pages: pages with zero inbound links
+
+Not every dangling link is an error. Calendar dates, planned-but-unwritten
+pages, and placeholders in example blocks are legitimate. Instead of editing
+those files, accept them via a whitelist file — one regex per line, ``#``
+comments — and the report counts them separately as ACCEPTED-DANGLING.
+Classify first (legitimate dangling vs genuinely broken), then fix only
+what is genuinely broken.
+
+Usage:
+  python3 scripts/graph-lint.py                       # scan wiki/ (default)
+  python3 scripts/graph-lint.py --root wiki --root notes
+  python3 scripts/graph-lint.py --json report.json    # machine-readable dump
+  python3 scripts/graph-lint.py --strict              # exit 1 on broken links
+  python3 scripts/graph-lint.py --top 20              # show top-N broken targets
+
+Whitelist file: .vault-meta/graph-lint-whitelist.txt (override with
+--whitelist PATH). Missing whitelist is fine — nothing is accepted.
+
+Exit codes: 0 clean (or non-strict), 1 strict violation, 2 usage error.
+Hermetic: stdlib only, no network.
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from collections import Counter
+
+FRONTMATTER_HEAD = 4096  # aliases live in frontmatter; reading 4KB is enough
+
+ALIAS_INLINE_RE = re.compile(r"^aliases?:\s*\[([^\]]*)\]", re.M)
+ALIAS_BLOCK_RE = re.compile(r"^aliases?:\s*\n((?:\s+-\s+.*\n?)+)", re.M)
+ALIAS_ITEM_RE = re.compile(r"^\s+-\s+(.*)$", re.M)
+LINK_RE = re.compile(r"\[\[([^\]\|#]+)(?:[#\|][^\]]*)?\]\]")
+UP_RE = re.compile(r'^up:\s*"?\[\[([^\]\|#]+)', re.M)
+
+
+def collect_files(roots):
+    files = []
+    for root in roots:
+        if not os.path.isdir(root):
+            print(f"WARN: root not found, skipping: {root}", file=sys.stderr)
+            continue
+        # followlinks stays False (the default) on purpose: a vault with a
+        # symlink loop must not hang the lint.
+        for dirpath, _dirnames, filenames in os.walk(root):
+            for name in filenames:
+                if name.endswith(".md"):
+                    files.append(os.path.join(dirpath, name).replace(os.sep, "/"))
+    return sorted(files)
+
+
+def parse_aliases(head):
+    """Extract frontmatter aliases: inline list or YAML block list."""
+    aliases = []
+    m = ALIAS_INLINE_RE.search(head)
+    if m:
+        for item in m.group(1).split(","):
+            item = item.strip().strip("\"'")
+            if item:
+                aliases.append(item)
+    m = ALIAS_BLOCK_RE.search(head)
+    if m:
+        for item in ALIAS_ITEM_RE.findall(m.group(1)):
+            item = item.strip().strip("\"'")
+            if item:
+                aliases.append(item)
+    return aliases
+
+
+def build_resolver(files):
+    """Map every resolvable name (basename or alias) to its file(s)."""
+    names = {}
+    for f in files:
+        base = os.path.basename(f)[:-3]
+        names.setdefault(base, []).append(f)
+    for f in files:
+        try:
+            with open(f, encoding="utf-8", errors="replace") as fh:
+                head = fh.read(FRONTMATTER_HEAD)
+        except OSError:
+            continue
+        for alias in parse_aliases(head):
+            names.setdefault(alias, []).append(f)
+    return names
+
+
+def load_whitelist(path):
+    patterns = []
+    if not path or not os.path.exists(path):
+        return patterns
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.split("#")[0].strip()
+            if not line:
+                continue
+            try:
+                patterns.append(re.compile(line))
+            except re.error as exc:
+                print(f"WARN: bad whitelist regex skipped: {line!r} ({exc})",
+                      file=sys.stderr)
+    return patterns
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(
+        description="Wikilink graph health check for an Obsidian vault.")
+    ap.add_argument("--root", action="append", default=None, metavar="DIR",
+                    help="content root to scan (repeatable; default: wiki)")
+    ap.add_argument("--whitelist", default=".vault-meta/graph-lint-whitelist.txt",
+                    metavar="PATH", help="accepted-dangling regex file")
+    ap.add_argument("--json", default=None, metavar="PATH",
+                    help="write full machine-readable report to PATH")
+    ap.add_argument("--strict", action="store_true",
+                    help="exit 1 if any broken link or broken up: remains")
+    ap.add_argument("--top", type=int, default=25, metavar="N",
+                    help="show top-N broken targets (default 25)")
+    args = ap.parse_args(argv)
+
+    roots = args.root or ["wiki"]
+    files = collect_files(roots)
+    if not files:
+        print(f"ERR: no .md files under roots: {', '.join(roots)}",
+              file=sys.stderr)
+        return 2
+
+    names = build_resolver(files)
+    whitelist = load_whitelist(args.whitelist)
+
+    def resolve(target):
+        target = target.strip()
+        # Obsidian resolves path-style links by their last segment too.
+        return names.get(target.split("/")[-1]) or names.get(target)
+
+    def whitelisted(target):
+        tail = target.strip().split("/")[-1]
+        return any(p.search(tail) for p in whitelist)
+
+    inbound = {f: 0 for f in files}
+    broken = {}
+    accepted = 0
+    total_links = up_links = up_resolved = 0
+
+    for f in files:
+        try:
+            with open(f, encoding="utf-8", errors="replace") as fh:
+                text = fh.read()
+        except OSError:
+            continue
+        for m in UP_RE.finditer(text):
+            up_links += 1
+            if resolve(m.group(1)):
+                up_resolved += 1
+        for m in LINK_RE.finditer(text):
+            target = m.group(1)
+            total_links += 1
+            candidates = resolve(target)
+            if candidates:
+                for c in candidates:
+                    if c != f:
+                        inbound[c] += 1
+            elif whitelisted(target):
+                accepted += 1
+            else:
+                broken.setdefault(f, []).append(target)
+
+    orphans = [f for f in files if inbound[f] == 0]
+    orphan_content = [f for f in orphans
+                      if not os.path.basename(f).startswith("_")]
+    orphan_system = [f for f in orphans if os.path.basename(f).startswith("_")]
+    broken_instances = sum(len(v) for v in broken.values())
+    broken_up = up_links - up_resolved
+
+    print("SCANNED FILES:", len(files))
+    print("TOTAL WIKILINKS:", total_links)
+    print("UP LINKS:", up_links, "RESOLVED:", up_resolved,
+          "BROKEN_UP:", broken_up)
+    print("FILES WITH BROKEN LINKS:", len(broken),
+          "TOTAL BROKEN INSTANCES:", broken_instances,
+          "| ACCEPTED-DANGLING:", accepted)
+    print("ORPHANS total:", len(orphans),
+          "| content:", len(orphan_content),
+          "| index/system:", len(orphan_system))
+
+    if broken:
+        counter = Counter()
+        for targets in broken.values():
+            for t in targets:
+                counter[t.split("/")[-1]] += 1
+        print("\nTOP BROKEN TARGETS:")
+        for target, n in counter.most_common(args.top):
+            print("  %4d  %s" % (n, target))
+
+    if args.json:
+        report = {
+            "orphans": orphans,
+            "orphan_content": orphan_content,
+            "orphan_system": orphan_system,
+            "broken": broken,
+            "stats": {
+                "files": len(files),
+                "links": total_links,
+                "up": up_links,
+                "up_resolved": up_resolved,
+                "broken_up": broken_up,
+                "broken_files": len(broken),
+                "broken_instances": broken_instances,
+                "accepted_dangling": accepted,
+                "orphans": len(orphans),
+                "orphan_content": len(orphan_content),
+            },
+        }
+        with open(args.json, "w", encoding="utf-8") as fh:
+            json.dump(report, fh, ensure_ascii=False, indent=1)
+        print(f"\nJSON report: {args.json}")
+
+    if args.strict and (broken_instances or broken_up):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_graph_lint.py
+++ b/tests/test_graph_lint.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+"""test_graph_lint.py — unit tests for scripts/graph-lint.py.
+
+Hermetic: builds a throwaway vault under tempfile, no network, stdlib only.
+Covers:
+  - basename resolution and inbound counting
+  - frontmatter alias resolution (inline AND block YAML list styles)
+  - path-style links resolve by last segment
+  - broken links reported; whitelisted dangling counted as accepted
+  - broken up: detection
+  - orphan classification (content vs _system)
+  - --strict exit code, --json report contents
+  - missing root exits 2
+
+Usage: python3 tests/test_graph_lint.py
+"""
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+SCRIPT = os.path.join(ROOT, "scripts", "graph-lint.py")
+
+PASS = 0
+FAIL = 0
+
+
+def check(label, cond, detail=""):
+    global PASS, FAIL
+    if cond:
+        print(f"OK   {label}")
+        PASS += 1
+    else:
+        print(f"FAIL {label} {detail}")
+        FAIL += 1
+
+
+def write(base, rel, text):
+    path = os.path.join(base, rel)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(text)
+
+
+def run(cwd, *args):
+    return subprocess.run(
+        [sys.executable, SCRIPT, *args],
+        cwd=cwd, capture_output=True, text=True)
+
+
+def main():
+    with tempfile.TemporaryDirectory() as tmp:
+        # A links to B by basename and to C by alias; C declares block alias.
+        write(tmp, "wiki/A.md",
+              "---\ntitle: A\n---\nSee [[B]] and [[Sea Note]].\n")
+        write(tmp, "wiki/B.md",
+              "---\naliases: [Bee, Buzz]\nup: \"[[A]]\"\n---\nBack to [[A]].\n")
+        write(tmp, "wiki/C.md",
+              "---\naliases:\n  - Sea Note\nup: \"[[Missing Parent]]\"\n---\n"
+              "Inline alias link: [[Bee]]. Path link: [[wiki/A]].\n"
+              "Broken: [[Nowhere]]. Dated: [[2026-07-02]].\n")
+        # System orphan (underscore prefix) and content orphan.
+        write(tmp, "wiki/_index.md", "index, links to nothing resolvable\n")
+        write(tmp, "wiki/Lonely.md", "no inbound links\n")
+        write(tmp, ".vault-meta/graph-lint-whitelist.txt",
+              "# calendar dates are legitimate dangling\n^\\d{4}-\\d{2}-\\d{2}$\n")
+
+        json_path = os.path.join(tmp, "report.json")
+        r = run(tmp, "--json", json_path)
+        check("exit 0 without --strict", r.returncode == 0, r.stderr)
+
+        with open(json_path, encoding="utf-8") as fh:
+            rep = json.load(fh)
+        stats = rep["stats"]
+
+        check("scanned 5 files", stats["files"] == 5, str(stats))
+        # The up: line is itself a wikilink, so it counts in both categories.
+        check("two broken instances (Nowhere + up target)",
+              stats["broken_instances"] == 2, str(rep["broken"]))
+        broken_targets = {t for v in rep["broken"].values() for t in v}
+        check("broken targets are Nowhere and Missing Parent",
+              broken_targets == {"Nowhere", "Missing Parent"},
+              str(broken_targets))
+        check("date accepted via whitelist",
+              stats["accepted_dangling"] == 1, str(stats))
+        check("up: A resolved, Missing Parent broken",
+              stats["up"] == 2 and stats["broken_up"] == 1, str(stats))
+        check("Lonely.md is a content orphan",
+              any(p.endswith("Lonely.md") for p in rep["orphan_content"]),
+              str(rep["orphan_content"]))
+        check("_index.md is a system orphan",
+              any(p.endswith("_index.md") for p in rep["orphan_system"]),
+              str(rep["orphan_system"]))
+        check("A/B/C are not orphans",
+              not any(p.endswith(("A.md", "B.md", "C.md"))
+                      for p in rep["orphans"]), str(rep["orphans"]))
+
+        r = run(tmp, "--strict")
+        check("--strict exits 1 while broken links remain",
+              r.returncode == 1, str(r.returncode))
+
+        # Fix the breakages: create the missing pages; strict goes green.
+        write(tmp, "wiki/Nowhere.md", "now exists, links [[A]]\n")
+        write(tmp, "wiki/Missing Parent.md", "parent MOC, links [[A]]\n")
+        r = run(tmp, "--strict")
+        check("--strict exits 0 once fixed", r.returncode == 0,
+              r.stdout + r.stderr)
+
+        r = run(tmp, "--root", "no-such-dir")
+        check("missing root exits 2", r.returncode == 2, str(r.returncode))
+
+    print()
+    print(f"{PASS} passed, {FAIL} failed")
+    return 1 if FAIL else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_setup_perimeter.sh
+++ b/tests/test_setup_perimeter.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# test_setup_perimeter.sh — unit tests for bin/setup-perimeter.sh.
+#
+# Hermetic: creates a throwaway git repo under mktemp, no network. Covers:
+#   - install (--yes) writes both managed hooks + seeds config files
+#   - clean commit passes
+#   - staged sensitive path is blocked
+#   - added identifier matching a configured pattern is blocked
+#   - whitelisted token passes
+#   - PERIMETER_ALLOW=1 single-shot override works
+#   - air-gap OFF: pre-push hook exits 0; air-gap ON: exits 1;
+#     PERIMETER_ALLOW_PUSH=1 overrides
+#   - existing unmanaged hook is backed up and restored on --uninstall
+#   - --check runs read-only; re-run is idempotent
+#
+# Usage: bash tests/test_setup_perimeter.sh
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SETUP="$ROOT/bin/setup-perimeter.sh"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    echo "OK   $label"; PASS=$((PASS + 1))
+  else
+    echo "FAIL $label: expected '$expected', got '$actual'"; FAIL=$((FAIL + 1))
+  fi
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+cd "$TMP"
+
+git init -q .
+git config user.email test@example.com
+git config user.name "Perimeter Test"
+
+# Pre-existing unmanaged hook: must be backed up, then restored on uninstall.
+mkdir -p .git/hooks
+printf '#!/bin/sh\nexit 0\n' > .git/hooks/pre-commit
+chmod +x .git/hooks/pre-commit
+
+# The setup script derives the vault root from its own location, so run a
+# copy from inside the temp repo (mirrors a vault that vendors the plugin).
+mkdir -p bin
+cp "$SETUP" bin/setup-perimeter.sh
+
+bash bin/setup-perimeter.sh --yes >/dev/null 2>&1
+assert_eq "install exit code" "0" "$?"
+
+grep -q "managed-by: claude-obsidian setup-perimeter" .git/hooks/pre-commit \
+  && assert_eq "pre-commit is managed" "0" "0" \
+  || assert_eq "pre-commit is managed" "0" "1"
+[ -f .git/hooks/pre-commit.pre-perimeter.bak ] \
+  && assert_eq "unmanaged hook backed up" "0" "0" \
+  || assert_eq "unmanaged hook backed up" "0" "1"
+[ -f .vault-meta/perimeter-paths.txt ] \
+  && assert_eq "config seeded" "0" "0" \
+  || assert_eq "config seeded" "0" "1"
+
+# Activate a path band and a pattern (Spanish DNI-style: 8 digits + letter).
+printf 'private/*\n' >> .vault-meta/perimeter-paths.txt
+printf '\\b[0-9]{8}[A-Za-z]\\b\n' >> .vault-meta/perimeter-patterns.txt
+printf '^11111111H$\n' >> .vault-meta/perimeter-whitelist.txt
+
+# Clean commit passes.
+echo "just a note" > note.md
+git add note.md
+git commit -q -m "clean" >/dev/null 2>&1
+assert_eq "clean commit passes" "0" "$?"
+
+# Sensitive path blocked.
+mkdir -p private
+echo "diary" > private/journal.md
+git add -f private/journal.md
+git commit -q -m "leak path" >/dev/null 2>&1
+assert_eq "sensitive path blocked" "1" "$?"
+git reset -q HEAD private/journal.md && rm -rf private
+
+# Identifier pattern blocked.
+echo "client id 43215678Z appears here" > leak.md
+git add leak.md
+git commit -q -m "leak id" >/dev/null 2>&1
+assert_eq "identifier blocked" "1" "$?"
+
+# Single-shot override lets it through.
+PERIMETER_ALLOW=1 git commit -q -m "allowed leak" >/dev/null 2>&1
+assert_eq "PERIMETER_ALLOW=1 override" "0" "$?"
+
+# Whitelisted token passes without override.
+echo "public registry code 11111111H is documented" > public.md
+git add public.md
+git commit -q -m "whitelisted" >/dev/null 2>&1
+assert_eq "whitelisted token passes" "0" "$?"
+
+# Air-gap: off by default -> pre-push exits 0.
+bash .git/hooks/pre-push origin https://example.invalid/repo.git </dev/null >/dev/null 2>&1
+assert_eq "pre-push open when air-gap off" "0" "$?"
+
+# Enable air-gap -> pre-push blocks; override lifts it once.
+echo enabled > .vault-meta/perimeter-airgap
+bash .git/hooks/pre-push origin https://example.invalid/repo.git </dev/null >/dev/null 2>&1
+assert_eq "pre-push blocked when air-gap on" "1" "$?"
+PERIMETER_ALLOW_PUSH=1 bash .git/hooks/pre-push origin https://example.invalid/repo.git </dev/null >/dev/null 2>&1
+assert_eq "PERIMETER_ALLOW_PUSH=1 override" "0" "$?"
+
+# --check is read-only and succeeds.
+bash bin/setup-perimeter.sh --check >/dev/null 2>&1
+assert_eq "--check exit code" "0" "$?"
+
+# Re-run is idempotent (config not clobbered: our appended band survives).
+bash bin/setup-perimeter.sh --yes >/dev/null 2>&1
+grep -q 'private/\*' .vault-meta/perimeter-paths.txt \
+  && assert_eq "re-run keeps user config" "0" "0" \
+  || assert_eq "re-run keeps user config" "0" "1"
+
+# Uninstall removes managed hooks and restores the original unmanaged hook.
+bash bin/setup-perimeter.sh --uninstall >/dev/null 2>&1
+assert_eq "uninstall exit code" "0" "$?"
+if [ -f .git/hooks/pre-commit ] \
+   && ! grep -q "managed-by: claude-obsidian setup-perimeter" .git/hooks/pre-commit; then
+  assert_eq "original hook restored" "0" "0"
+else
+  assert_eq "original hook restored" "0" "1"
+fi
+[ ! -f .git/hooks/pre-push ] \
+  && assert_eq "managed pre-push removed" "0" "0" \
+  || assert_eq "managed pre-push removed" "0" "1"
+
+echo ""
+echo "$PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
Implements https://github.com/AgriciDaniel/claude-obsidian/issues/108 — privacy perimeter + graph lint + consolidation guide.

## What

Five reusable patterns from consolidating four live vaults (~10k files) into one air-gapped vault. Two land as opt-in tools, three as a methodology guide:

- **`bin/setup-perimeter.sh`** — opt-in privacy perimeter. Installs a git `pre-commit` hook (blocks staged paths matching sensitive-band globs; scans ADDED diff lines against an identifier/secret regex list, minus a false-positive whitelist) and a `pre-push` hook (optional `--air-gap` blocks every push). Config is three plain-text files under `.vault-meta/` seeded with commented examples. Consent prompt (or `--yes`), `--check` diagnostics, `--uninstall` restores any pre-existing hooks from backup. Everything runs locally; nothing leaves the machine.
- **`scripts/graph-lint.py`** — wikilink graph health check. Resolves links the way Obsidian does (basename + frontmatter aliases, inline `[a, b]` and block `- a` styles, path-style links by last segment). Reports broken links, broken `up:` hierarchy fields, and orphans (content vs `_system`). Legitimate dangling links (calendar dates, planned pages) are accepted via a whitelist regex file and counted separately. `--json` report, `--strict` exit code for CI/gates. Stdlib only.
- **`docs/consolidation-guide.md`** — the methodology the tools serve: the per-source consolidation loop, hardened migration for sensitive sources (dry-run default, manifest proof, scan-before-add, index-only tier, anti-operator brakes), and merge governance (dedup ledger + pending-decisions quarantine).
- **`tests/test_graph_lint.py`** (12 assertions) + **`tests/test_setup_perimeter.sh`** (17 assertions) — hermetic, no network, wired into `make test` via two new Makefile targets.

## Why

The README's promise is "keeps your data yours". For vaults holding data the owner would never publish, that needs a deny-by-default boundary at the git layer — regex scanning alone provably misses real data disguised as "examples". And once a vault grows past a few hundred pages (or merges several sources), link-graph rot is invisible without a whole-vault pass that can tell *broken* apart from *legitimately dangling*.

## Testing

- `python3 tests/test_graph_lint.py` → 12 passed, 0 failed
- `bash tests/test_setup_perimeter.sh` → 17 passed, 0 failed
- Both suites are hermetic (mktemp sandboxes, stdlib/POSIX utilities only, no network).
- Developed and verified on Windows git-bash. POSIX portability explicitly reviewed (no bashisms beyond `#!/usr/bin/env bash`, `[[:space:]]` instead of `\s`, standard `grep -E`/`sed`/`paste` usage); a Linux/macOS `make test` run before merge is welcome.
- Pre-commit verifier agent (`agents/verifier.md`) run on the staged diff before commit; findings addressed.

## Blast radius / undo

- Both tools are new and opt-in; no existing file's behavior changes (Makefile only appends targets).
- The perimeter writes to `.git/hooks/` (untracked, per-clone): managed hooks carry a marker line; pre-existing unmanaged hooks are backed up to `<hook>.pre-perimeter.bak` and restored on `--uninstall`. Undo = `bash bin/setup-perimeter.sh --uninstall`.
- Failure modes handled: not-a-git-repo (exit 3), empty/missing config files (hook degrades to secrets baseline), bad whitelist regex (skipped with WARN), missing scan root (exit 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
