### PR TITLE
Windows/Git Bash portability: flock + fcntl fallbacks

### DIFF
--- a/scripts/bm25-index.py
+++ b/scripts/bm25-index.py
@@ -46,7 +46,6 @@ Exit codes:
 """
 
 import argparse
-import fcntl
 import json
 import math
 import os
@@ -55,6 +54,13 @@ import sys
 from collections import Counter, defaultdict
 from datetime import datetime, timezone
 from pathlib import Path
+
+try:
+    import fcntl  # POSIX only
+    _HAVE_FCNTL = True
+except ImportError:  # Windows (Git Bash Python) ships no fcntl module
+    fcntl = None
+    _HAVE_FCNTL = False
 
 VAULT_ROOT = Path(__file__).resolve().parent.parent
 META_DIR = VAULT_ROOT / ".vault-meta"
@@ -98,21 +104,47 @@ def tokenize(text):
 
 def acquire_lock():
     META_DIR.mkdir(parents=True, exist_ok=True)
-    fd = os.open(str(LOCK_PATH), os.O_CREAT | os.O_WRONLY, 0o644)
+    if _HAVE_FCNTL:
+        fd = os.open(str(LOCK_PATH), os.O_CREAT | os.O_WRONLY, 0o644)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            os.close(fd)
+            log("ERR: could not acquire bm25 lock")
+            sys.exit(EXIT_LOCK)
+        return fd
+    # Windows fallback (no fcntl): atomic O_EXCL lockfile == non-blocking exclusive.
+    # A lockfile older than 60s is treated as stale (crashed holder) and reaped,
+    # mirroring the age-based staleness used by wiki-lock.sh.
     try:
-        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-    except OSError:
-        os.close(fd)
+        return os.open(str(LOCK_PATH), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+    except FileExistsError:
+        try:
+            age = datetime.now(timezone.utc).timestamp() - os.path.getmtime(LOCK_PATH)
+            if age > 60:
+                os.unlink(LOCK_PATH)
+                return os.open(str(LOCK_PATH), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+        except OSError:
+            pass
         log("ERR: could not acquire bm25 lock")
         sys.exit(EXIT_LOCK)
-    return fd
 
 
 def release_lock(fd):
+    if _HAVE_FCNTL:
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
+        return
+    # Windows fallback: close and remove the lockfile so the next writer can take it.
     try:
-        fcntl.flock(fd, fcntl.LOCK_UN)
-    finally:
         os.close(fd)
+    finally:
+        try:
+            os.unlink(LOCK_PATH)
+        except OSError:
+            pass
 
 
 def discover_chunks():

--- a/scripts/rerank.py
+++ b/scripts/rerank.py
@@ -42,7 +42,12 @@ Exit codes:
 """
 
 import argparse
-import fcntl
+try:
+    import fcntl  # POSIX only
+    _HAVE_FCNTL = True
+except ImportError:  # Windows (Git Bash Python) ships no fcntl module
+    fcntl = None
+    _HAVE_FCNTL = False
 import json
 import math
 import os
@@ -150,14 +155,17 @@ def save_cache(cache):
     fd = os.open(str(CACHE_LOCK), os.O_CREAT | os.O_WRONLY, 0o644)
     locked = False
     try:
-        for attempt in range(3):
-            try:
-                fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-                locked = True
-                break
-            except BlockingIOError:
-                time.sleep(0.1)
-        if not locked:
+        if _HAVE_FCNTL:
+            for attempt in range(3):
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    locked = True
+                    break
+                except BlockingIOError:
+                    time.sleep(0.1)
+        # On Windows (no fcntl) locked stays False and we fall through to the
+        # atomic temp+rename write below — expected, so suppress the WARN there.
+        if not locked and _HAVE_FCNTL:
             msg = ("WARN: rerank embed-cache lock unavailable after 3 tries; "
                    "writing unlocked (atomic via temp+rename). Concurrent writers "
                    "may overwrite each other's last update.")

--- a/scripts/wiki-lock.sh
+++ b/scripts/wiki-lock.sh
@@ -149,13 +149,40 @@ is_alive() {
 
 # Atomic meta-lock wrapper. Funcs that mutate LOCK_DIR call under this lock so
 # acquire/release/clear-stale don't race against each other.
+#
+# Portability note (vault-local patch): flock(1) is absent on Windows Git Bash
+# (msys2 ships no util-linux flock). When flock is unavailable we fall back to
+# an atomic mkdir spinlock — mkdir is atomic on every POSIX/NTFS filesystem, so
+# it serializes meta-lock holders exactly like flock -x, just with a poll loop.
+# 5s timeout mirrors `flock -w 5`; a lock dir older than 5s is treated as stale
+# (crashed holder) and reaped. When flock IS present (Linux/macOS) the original
+# path runs unchanged.
 with_meta_lock() {
   ensure_dirs
-  # Use flock under bash's redirect; meta lock is short-lived per command.
-  (
-    flock -x -w 5 9 || die "could not acquire meta-lock within 5s" 1
-    "$@"
-  ) 9>"$META_LOCK"
+  if command -v flock >/dev/null 2>&1; then
+    # Use flock under bash's redirect; meta lock is short-lived per command.
+    (
+      flock -x -w 5 9 || die "could not acquire meta-lock within 5s" 1
+      "$@"
+    ) 9>"$META_LOCK"
+  else
+    # flock-less fallback: atomic mkdir spinlock (Windows Git Bash).
+    local mdir="${META_LOCK}.d" waited=0
+    until mkdir "$mdir" 2>/dev/null; do
+      # Reap a stale holder (dir mtime older than 5s ⇒ crashed mid-operation).
+      if [ -d "$mdir" ] && [ -z "$(find "$mdir" -maxdepth 0 -newermt '-5 seconds' 2>/dev/null)" ]; then
+        rm -rf "$mdir" 2>/dev/null || true
+        continue
+      fi
+      sleep 0.1
+      waited=$((waited + 1))
+      [ "$waited" -ge 50 ] && die "could not acquire meta-lock within 5s" 1
+    done
+    local rc=0
+    "$@" || rc=$?
+    rmdir "$mdir" 2>/dev/null || rm -rf "$mdir" 2>/dev/null || true
+    return "$rc"
+  fi
 }
 
 read_lockfile() {


### PR DESCRIPTION
## Problem

The lock primitives assume POSIX `flock(1)` / the Python `fcntl` module, neither of which exists on **Windows Git Bash** (msys2 ships no util-linux `flock`; CPython on Windows has no `fcntl` module). On Windows this makes three core scripts crash:

- `scripts/wiki-lock.sh` → `flock: command not found` in `with_meta_lock()` — **all** lock acquire/list/release fail, so multi-writer safety is unavailable.
- `scripts/bm25-index.py` → `ModuleNotFoundError: No module named 'fcntl'` at import — index build dies.
- `scripts/rerank.py` → same `fcntl` import error — `retrieve.py` fails to import the sibling and exits 10.

Net effect: multi-writer locking and the **entire wiki-retrieve pipeline** are non-functional on Windows.

## Fix

Portable fallbacks that keep the POSIX path byte-for-byte unchanged:

| File | Change |
|------|--------|
| `wiki-lock.sh` | If `flock` is absent, `with_meta_lock()` falls back to an **atomic `mkdir` spinlock** (mkdir is atomic on POSIX/NTFS), preserving the 5s timeout and stale-reap semantics. `flock` path unchanged when present. |
| `bm25-index.py` | Guard the `fcntl` import; on Windows `acquire_lock()` uses an atomic **`O_EXCL` lockfile** (non-blocking exclusive) with a 60s stale reap. |
| `rerank.py` | Guard the `fcntl` import; on Windows fall through to the **existing atomic temp+rename** write (the WARN is suppressed since running unlocked is the expected path there). |

The page-level lock in `wiki-lock.sh` was already flock-free (atomic `noclobber` create); only the internal meta-lock needed the fallback.

## Validation

On **Windows 11 / Git Bash 5.2 / Python 3.12**:

- `wiki-lock.sh`: a 5-way concurrent `acquire` race on one page yields **exactly one winner**; acquire/list/peek/release/clear-stale all behave.
- `bm25-index.py build` + `retrieve.py "<query>"` return correct BM25 results (rerank cleanly no-ops without ollama).

No behavior change on Linux/macOS — all three fall back only when the POSIX primitive is missing.