### PR TITLE
fix: Windows Git Bash compatibility (flock, python3 stub, prompt-type hooks)

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -11,10 +11,6 @@
           {
             "type": "command",
             "command": "[ -x scripts/wiki-lock.sh ] && bash scripts/wiki-lock.sh clear-stale --max-age 3600 >/dev/null 2>&1 || true"
-          },
-          {
-            "type": "prompt",
-            "prompt": "If a vault is configured for this session (check CLAUDE.md for VAULT_PATH or a wiki/ folder in the current directory), silently read wiki/hot.md to restore recent context. If wiki/hot.md does not exist, do nothing. This is a non-vault session. Do not announce this. Do not report what you read. Just have the context available."
           }
         ]
       }
@@ -24,8 +20,8 @@
         "matcher": "",
         "hooks": [
           {
-            "type": "prompt",
-            "prompt": "Hook-injected context does not survive context compaction. If wiki/hot.md exists in the current directory, silently re-read it now to restore the hot cache. Do not announce this."
+            "type": "command",
+            "command": "[ -f wiki/hot.md ] && cat wiki/hot.md || true"
           }
         ]
       }

--- a/scripts/wiki-lock.sh
+++ b/scripts/wiki-lock.sh
@@ -127,6 +127,10 @@ validate_path() {
   # GNU coreutils + macOS BSD where realpath flag semantics differ).
   if command -v python3 >/dev/null 2>&1; then
     local resolved root
+    # `|| resolved=""` keeps set -e from aborting when python3 exists on PATH
+    # but cannot run — e.g. the Windows Store alias stub, which passes
+    # `command -v` yet exits 49 ("Python was not found"). Fail-open matches
+    # the existing 2>/dev/null intent: no python3 => skip symlink check.
     resolved=$(VAULT_ROOT_BASH="$VAULT_ROOT" P_BASH="$p" python3 -c '
 import os, sys
 root = os.path.realpath(os.environ["VAULT_ROOT_BASH"])
@@ -134,7 +138,7 @@ candidate = os.environ["P_BASH"]
 target = os.path.realpath(os.path.join(root, candidate))
 common = os.path.commonpath([root, target]) if target else ""
 sys.stdout.write("INSIDE" if common == root else "OUTSIDE")
-' 2>/dev/null)
+' 2>/dev/null) || resolved=""
     [ "$resolved" = "OUTSIDE" ] && die "path resolves outside vault via symlink: $p" 4
   fi
   return 0
@@ -152,10 +156,19 @@ is_alive() {
 with_meta_lock() {
   ensure_dirs
   # Use flock under bash's redirect; meta lock is short-lived per command.
-  (
-    flock -x -w 5 9 || die "could not acquire meta-lock within 5s" 1
+  if command -v flock >/dev/null 2>&1; then
+    (
+      flock -x -w 5 9 || die "could not acquire meta-lock within 5s" 1
+      "$@"
+    ) 9>"$META_LOCK"
+  else
+    # Git Bash on Windows ships no flock(1). Fall back to running without
+    # the meta-lock: _cmd_acquire's noclobber create is itself atomic, so
+    # the remaining race window only affects concurrent list/clear-stale.
+    # Without this fallback every wiki-lock invocation fails (rc=1), which
+    # silently disables the auto-commit PostToolUse hook on Windows.
     "$@"
-  ) 9>"$META_LOCK"
+  fi
 }
 
 read_lockfile() {


### PR DESCRIPTION
## Summary

Three independent Windows failure modes, found running claude-obsidian 1.9.2 as a daily vault on Windows 11 + Git Bash:

1. **`scripts/wiki-lock.sh`: Git Bash ships no `flock(1)`** — every invocation died with `flock: command not found` (rc=1), which silently disabled the auto-commit PostToolUse hook (our `.vault-meta/hook.log` had 15 'deferred auto-commit' entries and zero commits since clone). Fixed with a `command -v flock` fallback that runs without the meta-lock: `_cmd_acquire`'s noclobber create is itself atomic, so the remaining race only affects concurrent `list`/`clear-stale`.

2. **`scripts/wiki-lock.sh`: Windows Store python3 alias stub** passes `command -v python3` but exits 49 ('Python was not found') when run; under `set -e` the failing command substitution aborted `acquire`. Guarded with `|| resolved=""` — fail-open, same intent as the existing `2>/dev/null`.

3. **`hooks/hooks.json`: prompt-type hooks are rejected by Claude Code 2.1.x** — every session start shows `prompt-type hooks are not supported for SessionStart events`, and the PostCompact one fails with `Prompt stop hooks are not yet supported outside REPL`. The SessionStart prompt hook was redundant anyway (the first command hook already cats `wiki/hot.md` into context); removed it and converted PostCompact to the same `cat` command so hot-cache restoration after compaction actually works.

## Evidence (Windows 11, Git Bash from Git for Windows)

| Check | at HEAD (cb93ff6) | with this PR |
|---|---|---|
| `wiki-lock.sh list` | rc=1 `flock: command not found` | rc=0 |
| `wiki-lock.sh acquire` | rc=49 (python3 stub abort) | rc=0; second acquire rc=75; release rc=0 |
| `tests/test_wiki_lock.sh` | 2 pass / 15 fail | 14 pass / 2 fail* |
| `tests/test_concurrent_write.sh` | fails (flock) | 6/6 pass |
| Live vault | auto-commit dead since clone | auto-commits flowing |

\* The 2 remaining failures are a test-harness quirk of MSYS bash, not a product defect: inside `$( )` command substitution, MSYS bash drops the CR from `$'...\r...'` before it reaches the script (verified with `od`: probe receives `ef` for `$'e\rf'`), so the CR-rejection test never actually sends a CR — called directly, the script rejects CR paths with rc=4 as designed. The '11 locks' count failure is collateral (the CR path acquires as a normal path). These 2 also fail identically without this PR's changes when the flock issue is bypassed.

## Notes
- No behavior change on Linux/macOS: the flock branch is taken whenever flock exists, and the python3 guard only matters when python3 can't actually run.
- Happy to split into two PRs if you prefer the hooks.json change separate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)