### PR TITLE
Portable locks: make DragonScale tooling work on Windows (Git Bash)

### DIFF
--- a/scripts/allocate-address.sh
+++ b/scripts/allocate-address.sh
@@ -32,10 +32,26 @@ mkdir -p "$(dirname "$COUNTER_FILE")" || {
 }
 
 # Acquire exclusive lock with 5-second timeout. Release automatically on scope exit.
-exec 9>"$LOCK_FILE"
-if ! flock -x -w 5 9; then
-  echo "ERR: could not acquire address allocator lock within 5s" >&2
-  exit 1
+# flock(1) is unavailable on Windows Git Bash / native msys; fall back to an
+# atomic mkdir lock (mkdir is atomic on every platform bash runs on).
+if command -v flock >/dev/null 2>&1; then
+  exec 9>"$LOCK_FILE"
+  if ! flock -x -w 5 9; then
+    echo "ERR: could not acquire address allocator lock within 5s" >&2
+    exit 1
+  fi
+else
+  LOCK_DIR_FALLBACK="${LOCK_FILE}.d"
+  acquired=0
+  for _ in $(seq 1 50); do
+    if mkdir "$LOCK_DIR_FALLBACK" 2>/dev/null; then acquired=1; break; fi
+    sleep 0.1
+  done
+  if [ "$acquired" -ne 1 ]; then
+    echo "ERR: could not acquire address allocator lock within 5s" >&2
+    exit 1
+  fi
+  trap 'rmdir "$LOCK_DIR_FALLBACK" 2>/dev/null || true' EXIT
 fi
 
 scan_max_c_address() {

--- a/scripts/tiling-check.py
+++ b/scripts/tiling-check.py
@@ -27,7 +27,12 @@ Usage:
 """
 
 import argparse
-import fcntl
+
+try:
+    import fcntl  # POSIX advisory locks
+except ImportError:  # Windows: no fcntl; use msvcrt byte-range locking
+    fcntl = None
+    import msvcrt
 import hashlib
 import json
 import math
@@ -164,7 +169,13 @@ def _lock_cache():
     META_DIR.mkdir(exist_ok=True)
     fd = os.open(str(CACHE_LOCK), os.O_CREAT | os.O_RDWR, 0o644)
     try:
-        fcntl.flock(fd, fcntl.LOCK_EX)
+        if fcntl is not None:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+        else:
+            # msvcrt locks a byte range; locking byte 0 (even past EOF) gives
+            # the same mutual exclusion as flock LOCK_EX for this cache file.
+            os.lseek(fd, 0, os.SEEK_SET)
+            msvcrt.locking(fd, msvcrt.LK_LOCK, 1)
     except OSError:
         os.close(fd)
         raise
@@ -173,7 +184,11 @@ def _lock_cache():
 
 def _unlock_cache(fd: int) -> None:
     try:
-        fcntl.flock(fd, fcntl.LOCK_UN)
+        if fcntl is not None:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        else:
+            os.lseek(fd, 0, os.SEEK_SET)
+            msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
     finally:
         os.close(fd)
 

--- a/scripts/wiki-lock.sh
+++ b/scripts/wiki-lock.sh
@@ -151,11 +151,25 @@ is_alive() {
 # acquire/release/clear-stale don't race against each other.
 with_meta_lock() {
   ensure_dirs
-  # Use flock under bash's redirect; meta lock is short-lived per command.
-  (
-    flock -x -w 5 9 || die "could not acquire meta-lock within 5s" 1
-    "$@"
-  ) 9>"$META_LOCK"
+  if command -v flock >/dev/null 2>&1; then
+    # Use flock under bash's redirect; meta lock is short-lived per command.
+    (
+      flock -x -w 5 9 || die "could not acquire meta-lock within 5s" 1
+      "$@"
+    ) 9>"$META_LOCK"
+  else
+    # Portable fallback (no flock on Windows Git Bash): atomic mkdir lock.
+    local mdir="${META_LOCK}.d" acquired=0 rc=0 _i
+    for _i in $(seq 1 50); do
+      if mkdir "$mdir" 2>/dev/null; then acquired=1; break; fi
+      sleep 0.1
+    done
+    [ "$acquired" -eq 1 ] || die "could not acquire meta-lock within 5s" 1
+    # Subshell so an inner die()/exit can't skip the rmdir cleanup below.
+    set +e; ( "$@" ); rc=$?; set -e
+    rmdir "$mdir" 2>/dev/null || true
+    return "$rc"
+  fi
 }
 
 read_lockfile() {

--- a/tests/test_wiki_lock.sh
+++ b/tests/test_wiki_lock.sh
@@ -143,7 +143,11 @@ RC_NL=$( (wl acquire $'wiki/concepts/Foo\nbar.md' >/dev/null 2>&1); echo $? )
 assert_eq "acquire newline path rejected" "4" "$RC_NL"
 
 # ── path validation: carriage return rejected (v1.7.2; closes audit M4) ──────
-RC_CR=$( (wl acquire $'wiki/concepts/Foo\rbar.md' >/dev/null 2>&1); echo $? )
+# Pass the CR via a variable: on Windows Git Bash (msys), a $'\r' literal used
+# directly as an argument inside command substitution is stripped before it
+# reaches the child process, so the rejection could never be exercised.
+CR_PATH="wiki/concepts/Foo"$'\r'"bar.md"
+RC_CR=$( (wl acquire "$CR_PATH" >/dev/null 2>&1); echo $? )
 assert_eq "acquire carriage-return path rejected" "4" "$RC_CR"
 
 # ── stress: 10 unique paths all acquire cleanly ──────────────────────────────


### PR DESCRIPTION
Fixes #117.

On Windows, Git Bash has no `flock(1)` and Python has no `fcntl`, so address allocation, wiki locking and tiling checks are all broken (details in the issue).

## Changes

- **`scripts/allocate-address.sh`** — if `flock` is unavailable, fall back to an atomic `mkdir` lock (`$LOCK_FILE.d`) with the same 5s timeout semantics; cleanup via `trap EXIT`. The flock path is untouched.
- **`scripts/wiki-lock.sh`** — same mkdir fallback inside `with_meta_lock`. The inner command runs in a subshell so an inner `die()`/`exit` can't skip the lock cleanup (mirrors how the flock branch releases on subshell exit).
- **`scripts/tiling-check.py`** — `import fcntl` wrapped in try/except; on Windows `_lock_cache`/`_unlock_cache` use `msvcrt.locking` on byte 0 of the lock file, giving the same mutual exclusion as `flock LOCK_EX`. Documented exit codes (10/11) now work on Windows.
- **`tests/test_wiki_lock.sh`** — MSYS quirk: a `$'\r'` literal passed directly as an argument to a child process inside command substitution loses the CR before it reaches the child, so the CR-rejection test never actually tested anything on Windows (and left a stray lock that broke the stress-count assertion). Building the path in a variable first preserves the CR on both platforms.

## Testing

- Windows 11 + Git for Windows (no flock): `test_wiki_lock.sh` 16/16, `test_allocate_address.sh` 12/12, `test_concurrent_write.sh` all pass, `test_tiling_check.py` all pass. Manually verified `allocate-address.sh --peek/--rebuild/allocate`, `wiki-lock.sh acquire/release/list/clear-stale/peek` and `tiling-check.py --peek` (exit 10 without ollama, as documented).
- POSIX: flock/fcntl branches unchanged; suite unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)