### PR TITLE
wiki: refresh hot cache through v1.9.2

### DIFF
--- a/wiki/hot.md
+++ b/wiki/hot.md
@@ -1,7 +1,7 @@
 ---
 type: meta
 title: "Hot Cache"
-updated: 2026-05-17T04:30:00
+updated: 2026-05-28T03:42:00
 tags:
   - meta
   - hot-cache
@@ -19,6 +19,12 @@ related:
 Navigation: [[index]] | [[log]] | [[overview]]
 
 ## Last Updated
+
+**Repo has been dormant since 2026-05-28** (no commits between then and the current session date). Everything below through v1.9.2 is real shipped history; nothing has happened since. `git log` is the source of truth if this drifts further.
+
+2026-05-28 (early morning): **v1.9.2 shipped, then promoted to public canonical.** Two commits: `73616fa` (prompt-cache hardening in `scripts/contextual-prefix.py` — page-body `cache_control` now only attaches above the Haiku 4.5 minimum cacheable size, `HAIKU_CACHE_MIN_CHARS = 16384`; below the floor the marker was a silent no-op. Added cache telemetry logging `cache: wrote=<N> read=<N> tok`, a sequential-invariant doc note on the chunk loop, and `tests/test_contextual_prefix.py` — `make test` now **9 suites**. Also fixed explicit missing/out-of-vault page paths to fail cleanly with proper exit codes instead of silent exit 0 or a raw traceback), then `00213b7` (**public-promotion release**: flipped README/docs framing so `AgriciDaniel/claude-obsidian` is the default install everywhere, repositioned "AI Marketing Hub Pro" as early-access rather than default, corrected the plugin install slug to `claude-obsidian@agricidaniel-claude-obsidian`, added SSS+ repo-hygiene files (`CITATION.cff`, `PRIVACY.md`, `CODEOWNERS`, `.github/FUNDING.yml`), and ran an SEO/GEO pass — H1 now leads with "Self-Organizing AI Second Brain", 4 GEO Q&As added to the FAQ. Gates: secret scan clean over 55-commit history, `make test` 9/9, `claude plugin validate` clean, verifier agent SHIP 0 BLOCKER/0 HIGH). Followed same day by `cb93ff6` (1280x640 branded social-preview card, upload-via-GitHub-Settings pending on the user). **This is the current HEAD.**
+
+2026-05-18 (late, same-day patch chain after the v1.7.1 entry below): **v1.8.0 → v1.8.2 → v1.9.0 → v1.9.1 landed same day**, closing the full v1.7.0 audit ledger and adding two major features. `1b54a79`/`5cdfecf` = **v1.9.1** (patch closing 6/6 remaining findings from the v1.9.0 pre-public-promotion audit: SessionStart stale-lock reaper `wiki-lock.sh clear-stale --max-age 3600`, PostToolUse opt-out gate via `.vault-meta/auto-commit.disabled`, symlink-canonicalization fix in `wiki-lock.sh validate_path()`, `.vault-meta/locks/.gitkeep` gitignore fix, rerank.py warnings routed to `hook.log`, ollama-localhost assert in `setup-retrieve.sh`, plus a new `SECURITY.md` "Threat model: single-tenant vault" section). Before that, **v1.9.0** shipped the **10-principle thinking framework** as skill #15 (`/think` — OBSERVE-OBSERVE-LISTEN-THINK-CONNECT-CONNECT-FEEL-ACCEPT-CREATE-GROW) plus a unique "How to think" appendix bolted onto all 14 existing skills, and first-public-release repo hygiene (CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md, issue/PR templates, CI workflow). Before that, **v1.8.2** closed all 4 HIGH findings from the v1.8.0 pre-push audit (manual_override implemented in `detect-transport.sh`, `Bash` tool added to `wiki-ingest` agent frontmatter, web-egress hygiene section added to autoresearch, `/save` Step 0 destination-root decision logic). Before that, **v1.8.0** shipped the **`wiki-mode` skill** (skill #14) — closing compass priority gap 5: four methodology modes (LYT / PARA / Zettelkasten / Generic) via `scripts/wiki-mode.py`, `bin/setup-mode.sh`, 6 per-mode templates, and mode-awareness sections added to wiki-ingest/save/autoresearch. **After v1.8.0, claude-obsidian claims #1 on 5 of 7 compass axes** (up from 4/7 in v1.7); the 2 remaining (derivative outputs, GUI/install ergonomics) are scoped to v2.0/v2.5+. Also same-day: `df3a167`/`3c15ef2`/`548d294` (README SSS+ tier rewrite, private-mirror → public badge fixes), and several `wiki: auto-commit` housekeeping commits. **Version arc this single day: 1.7.1 → 1.7.2 → 1.8.0 → 1.8.2 → 1.9.0 → 1.9.1.**
 
 2026-05-17 (very late, post-polish): **v1.7.1 patch + polish slice shipped locally** (branch `v1.7.0-compound-vault`, still NOT pushed). All 1 BLOCKER + 6 HIGH findings closed; then verifier agent re-pass surfaced 2 MEDIUM + 3 LOW polish items, all closed in `c2d7575`. Final verifier verdict: 0/0/0/0 SHIP. Score: 100/100 on the v1.7.1 patch dimensions (plan fidelity, behavioral correctness, test health, internal consistency, constraint honor, defect introduction, kernel application). 8 commits landed in this resumption session: `ca68bb6` (Fix 1+6 BLOCKER B1 + H6 — contextual-prefix `--allow-egress` flag default-off + `bin/setup-retrieve.sh` consent prompt + `skills/wiki-retrieve/SKILL.md` Data Privacy callout, mirror of `tiling-check.py:351` `--allow-remote-ollama` precedent), `4837d4f` (Fix 2 H1 — setup-retrieve exit 5 + 3-option recovery hint on Stage 1 failure), `7e1f187` (Fix 3 H2 — `make clean-test-state` extended to v1.7 artifacts), `7120970` (Fix 4 H3 — PostToolUse hook captures LOCK_RC directly, not via pipeline; defers commit on script error OR locks held), `722ac97` (Fix 5 H5 — `detect-transport.sh` `json_escape()` helper via `python3 json.dumps`), `3ea443f` (Fix 7 H4 — new `agents/verifier.md` read-only pre-commit specialist + CLAUDE.md reference), and the cross-cutting closeout `822c80a` (version bump 1.7.0 → 1.7.1, CHANGELOG entry, audit doc updated with §10.2 SHAs + v1.7.1 closeout block, audit benchmark scripts promoted to tracked files). `make test` ran 7/7 green after every fix. End-to-end verifications: `python3 scripts/contextual-prefix.py --peek` returns `tier=synthetic` even with `ANTHROPIC_API_KEY` set (default-deny works); `--allow-egress` correctly flips it; `echo "" | bash bin/setup-retrieve.sh` aborts at the consent prompt; `bash scripts/wiki-lock.sh acquire ...` then hook trigger correctly defers auto-commit. **Next step**: ask user whether to push + tag `v1.7.1`. Do NOT push without explicit go.
 
@@ -50,14 +56,17 @@ Navigation: [[index]] | [[log]] | [[overview]]
 
 ## Plugin State
 
-- **Version**: 1.7.1 (audit-driven patch on top of Compound Vault; plugin.json + marketplace.json synced; local-only branch `v1.7.0-compound-vault`, no push, no tag)
-- **Install ID**: `claude-obsidian@ai-marketing-hub-claude-obsidian`
-- **Skills**: 13 (wiki, wiki-ingest, wiki-query, wiki-lint, wiki-fold, save, autoresearch, canvas, defuddle, obsidian-bases, obsidian-markdown, **wiki-cli (v1.7)**, **wiki-retrieve (v1.7, opt-in)**)
+- **Version**: 1.9.2, **promoted to public canonical** (`AgriciDaniel/claude-obsidian` is now the default install; "AI Marketing Hub Pro" is early-access, not default). This is HEAD as of 2026-05-28; repo dormant since.
+- **Install ID**: `claude-obsidian@agricidaniel-claude-obsidian` (changed from `ai-marketing-hub-claude-obsidian` in the public-promotion commit `00213b7` — matches `marketplace.json`'s `name` field, which is what `claude plugin list` slugs derive from)
+- **Skills**: 15 — wiki, wiki-ingest, wiki-query, wiki-lint, wiki-fold, save, autoresearch, canvas, defuddle, obsidian-bases, obsidian-markdown, wiki-cli (v1.7), wiki-retrieve (v1.7, opt-in), **wiki-mode (v1.8)**, **think (v1.9)**
 - **Scripts (v1.6)**: `scripts/allocate-address.sh`, `scripts/tiling-check.py`, `scripts/boundary-score.py` (DragonScale; opt-in; feature-detected by skills)
-- **Scripts (v1.7 — new)**: `scripts/detect-transport.sh`, `scripts/contextual-prefix.py`, `scripts/bm25-index.py`, `scripts/rerank.py`, `scripts/retrieve.py`, `scripts/wiki-lock.sh`
-- **Setup**: `bin/setup-vault.sh` (base vault), `bin/setup-dragonscale.sh` (opt-in DragonScale), `bin/setup-multi-agent.sh` (multi-agent bootstrap), `bin/setup-retrieve.sh` (opt-in v1.7 hybrid retrieval)
-- **Tests**: `make test` runs 7 suites — `test_allocate_address.sh`, `test_tiling_check.py`, `test_boundary_score.py`, **`test_bm25_index.py`**, **`test_retrieve.py`**, **`test_wiki_lock.sh`**, **`test_concurrent_write.sh`**. Zero ollama and zero network dependency for all core tests.
-- **Hooks**: 4 (SessionStart, PostCompact, PostToolUse [stages wiki/, .raw/, .vault-meta/; **v1.7: defers `git add` if wiki-lock locks held**], Stop)
+- **Scripts (v1.7)**: `scripts/detect-transport.sh`, `scripts/contextual-prefix.py`, `scripts/bm25-index.py`, `scripts/rerank.py`, `scripts/retrieve.py`, `scripts/wiki-lock.sh`
+- **Scripts (v1.8 — new)**: `scripts/wiki-mode.py` (pure-stdlib router: `get`/`config`/`route`/`set`/`id`/`templates` subcommands)
+- **Setup**: `bin/setup-vault.sh`, `bin/setup-dragonscale.sh`, `bin/setup-multi-agent.sh`, `bin/setup-retrieve.sh` (opt-in), `bin/setup-mode.sh` (v1.8, opt-in — `--mode <name>` non-interactive flag, idempotent)
+- **Tests**: `make test` runs **9 suites** — address, tiling, boundary, bm25, retrieve, lock, concurrent, **mode (v1.8)**, **contextual (v1.9.2)**. Zero ollama and zero network dependency for all core tests.
+- **Hooks**: 4 (SessionStart [**v1.9.1: now also reaps stale wiki-locks via `wiki-lock.sh clear-stale --max-age 3600` on every resume**], PostCompact, PostToolUse [stages wiki/, .raw/, .vault-meta/; defers `git add` if wiki-lock locks held; **v1.9.1: exits early if `.vault-meta/auto-commit.disabled` exists**], Stop)
+- **Repo hygiene (v1.9.0+)**: CONTRIBUTING.md, CODE_OF_CONDUCT.md, SECURITY.md (now includes a "Threat model: single-tenant vault" section, v1.9.1), issue/PR templates, CI workflow (`.github/workflows/test.yml`), CITATION.cff, PRIVACY.md, CODEOWNERS, `.github/FUNDING.yml` (all v1.9.2 SSS+ additions)
+- **Compass axis status (per CHANGELOG v1.9.0)**: #1 on 5 of 7 axes — compounding wiki primitive, multi-writer safety, retrieval architecture (free tier), license/openness, methodology support. Still NO on derivative outputs (scoped v2.0) and GUI/install ergonomics (scoped v2.5+).
 
 ## DragonScale Mechanisms
 
@@ -83,10 +92,13 @@ Navigation: [[index]] | [[log]] | [[overview]]
 ## Active Threads
 
 - DragonScale Mechanism 4 shipped in Phase 4 as an opt-in Topic Selection mode in `skills/autoresearch/`. All four DragonScale mechanisms are now shipped and feature-gated.
-- v1.6.0 not yet pushed to GitHub (local commits only, no git tag created). User controls push and tag timing.
-- CLAUDE.md has one pre-existing uncommitted change ("Release Blog Post" section) that predates this session.
+- All versions through v1.9.2 are pushed and tagged (`v1.1` through `v1.9.2`). `origin/main` matches local `main` exactly as of this update (only local diff is this hot.md refresh).
+- `cb93ff6` (the social-preview asset commit) landed one commit after the `v1.9.2` tag and is itself untagged — cosmetic gap only, not release-blocking.
+- Repo has had zero commits between 2026-05-28 and the current session date (2026-07-14) — a ~7-week dormancy. No open plan file or in-progress workstream found; next session should treat this as a fresh entry point, not a resumption.
+- CLAUDE.md is clean (the "Release Blog Post" section noted as a pre-existing uncommitted change in the prior hot.md entry is no longer present as a diff).
 
 ## Repo Locations
 
-- Working: `~/Desktop/claude-obsidian/`
-- Public: https://github.com/AI-Marketing-Hub/claude-obsidian
+- Working: `C:\Users\CPU12814-local\claude-obsidian` (this machine; Windows)
+- Public + canonical (default install target as of v1.9.2): https://github.com/AgriciDaniel/claude-obsidian
+- Pro/early-access mirror: AI Marketing Hub (`ai-marketing-hub-claude-obsidian` install slug) — now the non-default option per the public-promotion commit


### PR DESCRIPTION
## Summary
- `wiki/hot.md` (the vault's "recent context" hot cache) still described state as of the v1.7.1 patch (2026-05-17), while the repo had since shipped v1.8.0, v1.8.2, v1.9.0, v1.9.1, and v1.9.2, plus the public-canonical promotion and social-preview asset commit (all landed by 2026-05-28).
- Backfilled the "Last Updated" log with that missing history, corrected the "Plugin State" section (version 1.7.1 -> 1.9.2, skill count 13 -> 15, test suite count 7 -> 9, install slug), and fixed "Active Threads" / "Repo Locations", which incorrectly claimed v1.6.0 was still unpushed — `main` is actually in sync with `origin/main` through v1.9.2.
- Also noted the repo has had zero commits between 2026-05-28 and now, so a future session treats this as a fresh entry point rather than an interrupted resumption.

## Test plan
- [x] Verified via `git log`/`git fetch` that all facts backfilled into hot.md (version, skill/test counts, push/tag status) match current repo state.
- N/A for automated tests — this is a documentation-only change to a wiki cache file, no code touched.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>