### PR TITLE
fix(hooks): remove invalid prompt-type hooks and restore post-compaction hot cache via the SessionStart compact matcher

### DIFF
--- a/hooks/README.md
+++ b/hooks/README.md
@@ -6,8 +6,7 @@ Plugin hooks for the claude-obsidian wiki vault. All hooks are defined in `hooks
 
 | Event | Type | Purpose |
 |---|---|---|
-| `SessionStart` | command + prompt | Loads `wiki/hot.md` into context. Command type runs `[ -f wiki/hot.md ] && cat wiki/hot.md` as the canonical safety check (works for non-vault sessions without erroring). Prompt type complements with semantic context restoration. Matcher: `startup\|resume`. |
-| `PostCompact` | prompt | Re-loads `wiki/hot.md` after context compaction. Hook-injected context does NOT survive compaction (only `CLAUDE.md` does), so this hook restores the hot cache mid-session. |
+| `SessionStart` | command | Loads `wiki/hot.md` into context via `[ -f wiki/hot.md ] && cat wiki/hot.md` (works for non-vault sessions without erroring). Matcher: `startup\|resume\|compact` — the `compact` matcher fires after context compaction, restoring the hot cache mid-session (hook-injected context does NOT survive compaction; only `CLAUDE.md` does). |
 | `PostToolUse` | command | Auto-commits any wiki/ or .raw/ changes after Write or Edit tool calls. Guarded by `[ -d .git ]` so it never errors in non-git directories, and by `git diff --cached --quiet` so it never creates empty commits. |
 | `Stop` | prompt | Updates `wiki/hot.md` at the end of every Claude response with a brief summary of what changed. |
 
@@ -15,7 +14,7 @@ Plugin hooks for the claude-obsidian wiki vault. All hooks are defined in `hooks
 
 `anthropics/claude-code#10875` documents that **plugin hook STDOUT may not be captured** by Claude Code, while identical inline hooks in `settings.json` work correctly.
 
-**Impact**: If this bug is active in your Claude Code version, the prompt-type SessionStart and PostCompact hooks may not inject context as expected.
+**Impact**: If this bug is active in your Claude Code version, the SessionStart command hooks (including the `compact`-matcher hot-cache restore) may not inject context as expected.
 
 **Workaround**: The command-type SessionStart hook (`cat wiki/hot.md`) is the canonical safety check. It relies on STDOUT capture for context injection, so test against this issue if hot cache restoration fails. As a fallback, copy the hook config from `hooks.json` into your user-level `~/.claude/settings.json` instead of relying on plugin hooks.
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -2,7 +2,7 @@
   "hooks": {
     "SessionStart": [
       {
-        "matcher": "startup|resume",
+        "matcher": "startup|resume|compact",
         "hooks": [
           {
             "type": "command",
@@ -11,21 +11,6 @@
           {
             "type": "command",
             "command": "[ -x scripts/wiki-lock.sh ] && bash scripts/wiki-lock.sh clear-stale --max-age 3600 >/dev/null 2>&1 || true"
-          },
-          {
-            "type": "prompt",
-            "prompt": "If a vault is configured for this session (check CLAUDE.md for VAULT_PATH or a wiki/ folder in the current directory), silently read wiki/hot.md to restore recent context. If wiki/hot.md does not exist, do nothing. This is a non-vault session. Do not announce this. Do not report what you read. Just have the context available."
-          }
-        ]
-      }
-    ],
-    "PostCompact": [
-      {
-        "matcher": "",
-        "hooks": [
-          {
-            "type": "prompt",
-            "prompt": "Hook-injected context does not survive context compaction. If wiki/hot.md exists in the current directory, silently re-read it now to restore the hot cache. Do not announce this."
           }
         ]
       }


### PR DESCRIPTION
## Problem

`hooks/hooks.json` ships two `"type": "prompt"` hook entries that Claude Code rejects:

1. **`SessionStart`** — prompt-type hooks are only valid on decision-capable events (`PreToolUse`, `PermissionRequest`, `Stop`). On `SessionStart`, Claude Code errors on every startup/resume:
   ```
   SessionStart:startup hook error — prompt-type hooks are not supported for
   SessionStart events (no conversation context is available). Use a command-type hook instead.
   ```
2. **`PostCompact`** — the prompt hook there never worked (silently dropped), and newer Claude Code versions (≥ 2.1.199, see #110) reject `PostCompact` as an invalid hook event outright, which breaks plugin load.

Already reported in #7, #29, #40, #45, #47, #48, #61, #87, #88, #91, #93, #96, #97, #106, #110, #116.

## Why this PR instead of the existing ones

The open fixes (#13, #21, #43, #49, #68, #71, #90, #99, #100) all either drop post-compaction restoration or keep a command hook on the `PostCompact` event — which still fails on Claude Code versions that reject `PostCompact` entirely (#110).

This PR uses the supported channel for the same behavior: the `SessionStart` event fires with matcher **`compact`** after context compaction, and its command-hook stdout **is** injected into context. So:

- **Removed** the `SessionStart` prompt entry — redundant; the existing command hook `[ -f wiki/hot.md ] && cat wiki/hot.md` already restores the hot cache.
- **Removed** the `PostCompact` block entirely (fixes #110's load failure).
- **Extended** the `SessionStart` matcher from `startup|resume` to `startup|resume|compact`, so the hot cache is restored after compaction — for the first time actually working, since the old prompt hook was silently dropped.
- Updated `hooks/README.md` events table to match.

Net diff: 3 insertions, 19 deletions.

Fixes #40. Fixes #110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)