### PR TITLE
fix(defuddle): every documented invocation is missing `parse` and `--md`

### DIFF
--- a/skills/defuddle/SKILL.md
+++ b/skills/defuddle/SKILL.md
@@ -28,25 +28,25 @@ Verify: `defuddle --version`
 
 ### Clean a URL directly
 ```bash
-defuddle https://example.com/article
+defuddle parse https://example.com/article --md
 ```
-Outputs clean markdown to stdout.
+Outputs clean markdown to stdout. Without `--md` the output is HTML.
 
 ### Save to .raw/
 ```bash
-defuddle https://example.com/article > .raw/articles/article-slug-$(date +%Y-%m-%d).md
+defuddle parse https://example.com/article --md > .raw/articles/article-slug-$(date +%Y-%m-%d).md
 ```
 
 ### Add frontmatter header after saving
 After running defuddle, prepend the source URL and fetch date:
 ```bash
 SLUG="article-slug-$(date +%Y-%m-%d)"
-{ echo "---"; echo "source_url: https://example.com/article"; echo "fetched: $(date +%Y-%m-%d)"; echo "---"; echo ""; defuddle https://example.com/article; } > .raw/articles/$SLUG.md
+{ echo "---"; echo "source_url: https://example.com/article"; echo "fetched: $(date +%Y-%m-%d)"; echo "---"; echo ""; defuddle parse https://example.com/article --md; } > .raw/articles/$SLUG.md
 ```
 
 ### Clean a local HTML file
 ```bash
-defuddle page.html
+defuddle parse page.html --md
 ```
 
 ---

--- a/skills/wiki-ingest/SKILL.md
+++ b/skills/wiki-ingest/SKILL.md
@@ -121,7 +121,7 @@ Trigger: user passes a URL starting with `https://`.
 Steps:
 
 1. **Fetch** the page using WebFetch.
-2. **Clean** (optional): if `defuddle` is available (`which defuddle 2>/dev/null`), run `defuddle [url]` to strip ads, nav, and clutter. Typically saves 40-60% tokens. Fall back to raw WebFetch output if not installed.
+2. **Clean** (optional): if `defuddle` is available (`which defuddle 2>/dev/null`), run `defuddle parse [url] --md` to strip ads, nav, and clutter. Typically saves 40-60% tokens. Fall back to raw WebFetch output if not installed.
 3. **Derive slug** from the URL path (last segment, lowercased, spaces→hyphens, strip query strings).
 4. **Save** to `.raw/articles/[slug]-[YYYY-MM-DD].md` with a frontmatter header:
    ```markdown


### PR DESCRIPTION
`parse` is the only command the CLI exposes, so every documented invocation fails:

```
$ defuddle https://example.com/article
error: unknown command 'https://example.com/article'
rc=0
```

It exits 0 while failing, so a `defuddle ... || fallback` guard never fires — the same reason this stayed hidden.

Second issue: `parse` emits HTML unless `--md` is passed.

```
$ defuddle parse https://example.com
<body><p>This domain is for use in documentation examples...</p></body>
```

So the recipes redirecting into `.raw/articles/*.md` were writing HTML into files named `.md`, and "Outputs clean markdown to stdout" was not accurate.

Fixed all five invocations (four in the skill, one in `wiki-ingest`) and noted the default format. The frontmatter recipe now round-trips:

```
---
source_url: https://example.com
fetched: 2026-07-20
---

This domain is for use in documentation examples without needing permission.

[Learn more](https://iana.org/domains/example)
```

Verified against defuddle-cli 0.1.0 (`npm install -g defuddle-cli`, as the skill already documents). Docs only.