### PR TITLE
fix(hooks): remove unsupported prompt-type hook from SessionStart

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -11,10 +11,6 @@
           {
             "type": "command",
             "command": "[ -x scripts/wiki-lock.sh ] && bash scripts/wiki-lock.sh clear-stale --max-age 3600 >/dev/null 2>&1 || true"
-          },
-          {
-            "type": "prompt",
-            "prompt": "If a vault is configured for this session (check CLAUDE.md for VAULT_PATH or a wiki/ folder in the current directory), silently read wiki/hot.md to restore recent context. If wiki/hot.md does not exist, do nothing. This is a non-vault session. Do not announce this. Do not report what you read. Just have the context available."
           }
         ]
       }


### PR DESCRIPTION
## Problem

Every session start prints:

```
SessionStart:startup hook error
Failed to run: prompt-type hooks are not supported for SessionStart events (no conversation context is available). Use a command-type hook instead.
```

Claude Code rejects `type: "prompt"` hooks on `SessionStart` — there is no conversation context at that point to inject a prompt into.

This is reported repeatedly and still open: #7, #29, #40, #45, #47, #48, #59, #61, #87, #88, #91, #93, #96, #97, #106, #116, #125, #137, #140.

## Fix

Remove the single `type: "prompt"` entry from `hooks.SessionStart` in `hooks/hooks.json`. Four deleted lines, nothing else.

## Why this is a no-op for functionality

The removed hook instructed the model to silently read `wiki/hot.md`. The very first hook in the same block already does exactly that, as a command hook:

```json
{ "type": "command", "command": "[ -f wiki/hot.md ] && cat wiki/hot.md || true" }
```

So hot-cache restore on session start is preserved. Only the error message goes away.

## What is intentionally left alone

The `PostCompact` prompt-type hook stays. `PostCompact` is still a valid hook event in Claude Code 2.1.220 (verified against the shipped binary) and it does have conversation context, so prompt-type is legitimate there. Issue #110 (`PostCompact` rejected on 2.1.199) looks like a separate regression and is out of scope for this PR.

## Verification

- `python3 -c "import json; json.load(open('hooks/hooks.json'))"` → valid
- `hooks.SessionStart` now contains only `command` hooks
- Applied the same change to a local plugin install; the startup error no longer appears, and `wiki/hot.md` is still picked up on session start
- Claude Code 2.1.220, Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)
