### PR TITLE
Fix macOS compatibility: wiki-lock.sh flock fallback + test whitespace

### DIFF
--- a/scripts/wiki-lock.sh
+++ b/scripts/wiki-lock.sh
@@ -151,11 +151,34 @@ is_alive() {
 # acquire/release/clear-stale don't race against each other.
 with_meta_lock() {
   ensure_dirs
-  # Use flock under bash's redirect; meta lock is short-lived per command.
-  (
-    flock -x -w 5 9 || die "could not acquire meta-lock within 5s" 1
-    "$@"
-  ) 9>"$META_LOCK"
+  if command -v flock >/dev/null 2>&1; then
+    # Linux/util-linux: advisory fd lock, auto-released when the subshell exits.
+    (
+      flock -x -w 5 9 || die "could not acquire meta-lock within 5s" 1
+      "$@"
+    ) 9>"$META_LOCK"
+  else
+    # macOS/BSD have no flock. Portable equivalent: an atomic mkdir lock. mkdir is
+    # atomic on every POSIX filesystem, so exactly one holder wins the race. Bounded
+    # retry (~5s, matching flock -w 5), age-based reap so a crashed holder cannot wedge
+    # the lock forever, and cleanup on both normal return and an unexpected exit.
+    local mdir="${META_LOCK}.mklock" waited=0 age rc
+    until mkdir "$mdir" 2>/dev/null; do
+      if [ -d "$mdir" ]; then
+        age=$(( $(now_epoch) - $(stat -f %m "$mdir" 2>/dev/null || stat -c %Y "$mdir" 2>/dev/null || echo 0) ))
+        if [ "$age" -ge 5 ]; then rmdir "$mdir" 2>/dev/null || true; continue; fi
+      fi
+      waited=$((waited + 1))
+      if [ "$waited" -ge 50 ]; then die "could not acquire meta-lock within 5s" 1; fi
+      sleep 0.1
+    done
+    trap 'rmdir "$mdir" 2>/dev/null || true' EXIT
+    rc=0
+    "$@" || rc=$?          # capture rc without tripping set -e; 75=held is a valid rc
+    rmdir "$mdir" 2>/dev/null || true
+    trap - EXIT
+    return "$rc"
+  fi
 }
 
 read_lockfile() {

--- a/tests/test_concurrent_write.sh
+++ b/tests/test_concurrent_write.sh
@@ -38,11 +38,16 @@ PASS=0
 FAIL=0
 
 assert_eq() {
-  if [ "$2" = "$3" ]; then
+  # Trim leading/trailing whitespace before comparing: BSD/macOS `wc` pads its counts
+  # with spaces, which would fail an otherwise-correct numeric assertion.
+  local expected="$2" actual="$3"
+  expected="${expected#"${expected%%[![:space:]]*}"}"; expected="${expected%"${expected##*[![:space:]]}"}"
+  actual="${actual#"${actual%%[![:space:]]*}"}"; actual="${actual%"${actual##*[![:space:]]}"}"
+  if [ "$expected" = "$actual" ]; then
     echo "OK   $1"
     PASS=$((PASS + 1))
   else
-    echo "FAIL $1: expected '$2', got '$3'"
+    echo "FAIL $1: expected '$expected', got '$actual'"
     FAIL=$((FAIL + 1))
   fi
 }

--- a/tests/test_wiki_lock.sh
+++ b/tests/test_wiki_lock.sh
@@ -22,6 +22,10 @@ FAIL=0
 
 assert_eq() {
   local label="$1" expected="$2" actual="$3"
+  # Trim leading/trailing whitespace before comparing: BSD/macOS `wc` pads its counts
+  # with spaces, which would fail an otherwise-correct numeric assertion.
+  expected="${expected#"${expected%%[![:space:]]*}"}"; expected="${expected%"${expected##*[![:space:]]}"}"
+  actual="${actual#"${actual%%[![:space:]]*}"}"; actual="${actual%"${actual##*[![:space:]]}"}"
   if [ "$expected" = "$actual" ]; then
     echo "OK   $label"
     PASS=$((PASS + 1))


### PR DESCRIPTION
## Problem

On macOS/BSD there is no `flock`, so `with_meta_lock` in `scripts/wiki-lock.sh` fails on the very first `acquire` with `flock: command not found`, breaking every wiki-lock operation (acquire/release/list/peek). The bundled tests also fail on macOS even when the values are correct, because BSD `wc` pads its counts with leading spaces and `assert_eq` compared them as strings (`expected '10', got '      10'`).

Repro on macOS:
```
WIKI_LOCK_VAULT=<vault> bash scripts/wiki-lock.sh acquire wiki/hot.md
# -> scripts/wiki-lock.sh: line 156: flock: command not found
```

## Changes

- **`scripts/wiki-lock.sh`** — `with_meta_lock` now detects `flock`. On Linux/util-linux the original `flock` path is unchanged. When `flock` is absent it falls back to an atomic `mkdir` lock (atomic on every POSIX filesystem), with a ~5s bounded retry matching `flock -w 5`, an age-based reap so a crashed holder can't wedge the lock, and cleanup on both normal return and an unexpected exit. A valid non-zero return (`75` = lock held) is preserved under `set -e`.
- **`tests/test_wiki_lock.sh`, `tests/test_concurrent_write.sh`** — `assert_eq` trims leading/trailing whitespace before comparing, so BSD `wc`'s padding no longer fails a correct numeric assertion.

## Verification (macOS)

- `tests/test_wiki_lock.sh`: **16/16** pass (was 15/1)
- `tests/test_concurrent_write.sh`: **6/6** pass (was 3/3)
- Concurrency invariants hold under the `mkdir` fallback: 10 concurrent writers, no leaked lockfiles, no torn/garbled lines.
- Linux behavior is unchanged (the `flock` branch is byte-identical to before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)