### PR TITLE
feat(host): add ZCode host adapter for portable skill discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,8 @@ implementation record for older releases.
   becomes `bash scripts/setup-mode.sh`. Update any local scripts, aliases, or
   CI that reference the old `bin/` paths. `RELEASE_MANIFEST.json` and
   `SHA256SUMS` are refreshed at release time.
+- ZCode host adapter (`--host zcode`) for portable, user-level skill discovery
+  into `~/.zcode/skills/`, with a `ZCODE.md` instruction pointer.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ Then place a source in `inbox/` and invoke
 `/claude-obsidian:wiki-ingest`. Save an answer explicitly with
 `/claude-obsidian:save`; ask the vault with `/claude-obsidian:wiki-query`.
 
-For Codex, OpenCode, or Gemini, preview and then apply the portable skill links
-from the product checkout:
+For Codex, OpenCode, Gemini, or ZCode, preview and then apply the portable
+skill links from the product checkout:
 
 ```bash
 bash scripts/setup-multi-agent.sh --host codex

--- a/ZCODE.md
+++ b/ZCODE.md
@@ -1,0 +1,27 @@
+# claude-obsidian: ZCode instructions
+
+Read `AGENTS.md` as the canonical host-neutral contract. Skills live in
+`skills/<name>/SKILL.md` and the portable core lives in `claude_obsidian/`.
+
+ZCode reads `AGENTS.md` at the workspace and user scope natively, so no
+mirrored rules file is needed. Install skill discovery with:
+
+```bash
+bash bin/setup-multi-agent.sh --host zcode
+bash bin/setup-multi-agent.sh --host zcode --apply
+```
+
+The first command previews the links; the second applies that reviewed scope.
+Links land in `~/.zcode/skills/` (user-level), so every ZCode workspace can
+invoke the skills without per-project setup.
+
+This repository is product source, not the default user vault. Create a
+separate vault with the dry-run-first `init` command or adopt an existing vault.
+Resolve that vault before reading `wiki/hot.md` or running a skill.
+
+All shared mutations use one inspected `claude-obsidian.transaction.v1` bundle.
+Parallel workers draft only. Do not use direct shared writes, automatic commits,
+or the deprecated per-file lock helper. Remote egress and destructive actions
+need explicit user consent.
+
+Public canonical: https://github.com/AgriciDaniel/claude-obsidian

--- a/ZCODE.md
+++ b/ZCODE.md
@@ -3,12 +3,15 @@
 Read `AGENTS.md` as the canonical host-neutral contract. Skills live in
 `skills/<name>/SKILL.md` and the portable core lives in `claude_obsidian/`.
 
-ZCode reads `AGENTS.md` at the workspace and user scope natively, so no
-mirrored rules file is needed. Install skill discovery with:
+ZCode reads `AGENTS.md` at the workspace and user scope natively (per the
+ZCode Agent documentation, https://zcode.z.ai/en/docs/agents), so no mirrored
+rules file is needed. User-level skills are discovered at
+`~/.zcode/skills/<skill-name>/SKILL.md` (https://zcode.z.ai/en/docs/skill).
+Install skill discovery with:
 
 ```bash
-bash bin/setup-multi-agent.sh --host zcode
-bash bin/setup-multi-agent.sh --host zcode --apply
+bash scripts/setup-multi-agent.sh --host zcode
+bash scripts/setup-multi-agent.sh --host zcode --apply
 ```
 
 The first command previews the links; the second applies that reviewed scope.

--- a/config/release-allowlist.json
+++ b/config/release-allowlist.json
@@ -44,7 +44,8 @@
     "PRIVACY.md",
     "README.md",
     "SECURITY.md",
-    "WIKI.md"
+    "WIKI.md",
+    "ZCODE.md"
   ],
   "include_globs": [
     ".github/*.md",

--- a/docs/install-guide.md
+++ b/docs/install-guide.md
@@ -81,8 +81,8 @@ bash scripts/setup-multi-agent.sh --host cursor --host windsurf \
 ZCode is opt-in and user-level (no `--workspace` needed):
 
 ```bash
-bash bin/setup-multi-agent.sh --host zcode
-bash bin/setup-multi-agent.sh --host zcode --apply
+bash scripts/setup-multi-agent.sh --host zcode
+bash scripts/setup-multi-agent.sh --host zcode --apply
 ```
 
 You can also create equivalent per-skill links manually. For each `<name>` under

--- a/docs/install-guide.md
+++ b/docs/install-guide.md
@@ -78,6 +78,13 @@ bash scripts/setup-multi-agent.sh --host cursor --host windsurf \
   --workspace <workspace> --apply
 ```
 
+ZCode is opt-in and user-level (no `--workspace` needed):
+
+```bash
+bash bin/setup-multi-agent.sh --host zcode
+bash bin/setup-multi-agent.sh --host zcode --apply
+```
+
 You can also create equivalent per-skill links manually. For each `<name>` under
 the product's `skills/` directory, link that directory at:
 
@@ -85,6 +92,7 @@ the product's `skills/` directory, link that directory at:
 Codex:     ~/.agents/skills/<name>          -> <product-repository>/skills/<name>
 OpenCode:  ~/.config/opencode/skills/<name> -> <product-repository>/skills/<name>
 Gemini:    ~/.gemini/skills/<name>          -> <product-repository>/skills/<name>
+ZCode:     ~/.zcode/skills/<name>           -> <product-repository>/skills/<name>
 Cursor:    <workspace>/.cursor/skills/<name>   -> <product-repository>/skills/<name>
 Windsurf:  <workspace>/.windsurf/skills/<name> -> <product-repository>/skills/<name>
 ```

--- a/scripts/setup-multi-agent.sh
+++ b/scripts/setup-multi-agent.sh
@@ -14,10 +14,11 @@ HOST_COUNT=0
 usage() {
   cat <<'EOF'
 Usage: scripts/setup-multi-agent.sh [--check|--dry-run|--apply]
-       [--host codex|opencode|gemini|cursor|windsurf|all] [--workspace PATH]
+       [--host codex|opencode|gemini|zcode|cursor|windsurf|all] [--workspace PATH]
 
 Default: dry-run for Codex, OpenCode, and Gemini user-level per-skill links.
-Cursor and Windsurf require an explicit --workspace destination.
+ZCode, Cursor and Windsurf are opt-in and require an explicit --host selection;
+Cursor and Windsurf also require an explicit --workspace destination.
 Existing files and links pointing elsewhere are never replaced.
 EOF
 }
@@ -54,7 +55,7 @@ expanded=()
 for host in "${HOSTS[@]}"; do
   case "$host" in
     all) expanded+=(codex opencode gemini cursor windsurf) ;;
-    codex|opencode|gemini|cursor|windsurf) expanded+=("$host") ;;
+    codex|opencode|gemini|zcode|cursor|windsurf) expanded+=("$host") ;;
     *) echo "ERROR: unsupported host: $host" >&2; exit 2 ;;
   esac
 done
@@ -161,6 +162,7 @@ for host in "${expanded[@]}"; do
     codex) destination_root="$HOME/.agents/skills" ;;
     opencode) destination_root="$HOME/.config/opencode/skills" ;;
     gemini) destination_root="$HOME/.gemini/skills" ;;
+    zcode) destination_root="$HOME/.zcode/skills" ;;
     cursor|windsurf)
       if [ -z "$WORKSPACE" ]; then
         echo "ERROR: --host $host requires --workspace PATH" >&2

--- a/tests/test_setup_multi_agent.py
+++ b/tests/test_setup_multi_agent.py
@@ -76,6 +76,42 @@ class SetupMultiAgentTests(unittest.TestCase):
             self.assertEqual("preserve", marker.read_text(encoding="utf-8"))
             self.assertTrue((home / ".agents/skills/save/SKILL.md").is_file())
 
+    def test_zcode_host_installs_global_links(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            home = Path(directory)
+            first = self.invoke(home, "--apply", "--host", "zcode")
+            self.assertEqual(0, first.returncode, first.stderr)
+            skill_root = home / ".zcode/skills"
+            expected = sorted(
+                path.parent.name for path in (ROOT / "skills").glob("*/SKILL.md")
+            )
+            self.assertEqual(15, len(expected))
+            discovered = sorted(
+                path.parent.name for path in skill_root.glob("*/SKILL.md")
+            )
+            self.assertEqual(expected, discovered)
+            for skill_name in expected:
+                link = skill_root / skill_name
+                self.assertTrue(link.is_symlink(), skill_name)
+                self.assertEqual(ROOT / "skills" / skill_name, link.resolve())
+            # ZCode is opt-in: the default hosts are not installed alongside it.
+            self.assertFalse((home / ".agents/skills").exists())
+            second = self.invoke(home, "--apply", "--host", "zcode")
+            self.assertEqual(0, second.returncode, second.stderr)
+            self.assertEqual(15, second.stdout.count("READY"))
+
+    def test_zcode_host_conflict_is_preserved(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            home = Path(directory)
+            conflict = home / ".zcode/skills/wiki"
+            conflict.mkdir(parents=True)
+            marker = conflict / "mine"
+            marker.write_text("preserve", encoding="utf-8")
+            result = self.invoke(home, "--apply", "--host", "zcode")
+            self.assertEqual(2, result.returncode)
+            self.assertEqual("preserve", marker.read_text(encoding="utf-8"))
+            self.assertTrue((home / ".zcode/skills/save/SKILL.md").is_file())
+
     def test_workspace_hosts_are_explicit(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             base = Path(directory)


### PR DESCRIPTION
## Problem

ZCode (the agent CLI from Z.ai) is not a supported host. Users who run ZCode cannot install the 15 portable skills via `setup-multi-agent.sh`, even though ZCode is Agent-Skills compatible and reads `AGENTS.md` natively. No existing issue or PR covers this (searched open/closed issues and PRs for `zcode`/`z.ai`).

## Behavior

Adds ZCode as a first-class **opt-in** host, mirroring the existing Gemini global-host pattern:

- `bin/setup-multi-agent.sh --host zcode` symlinks the 15 skills into `~/.zcode/skills/` (user-level, no `--workspace` needed, like Gemini/Codex/OpenCode).
- New `ZCODE.md` instruction pointer, structured identically to `GEMINI.md`.
- README + install-guide + CHANGELOG updated to list ZCode.

ZCode is **opt-in**: `--host zcode` only. It is intentionally excluded from the `all)` expansion, so the default dry-run (3 hosts) and `--host all` behavior are unchanged.

## Why `~/.zcode/skills`

ZCode scans `~/.zcode/skills/` (ZCode-native) and `~/.agents/skills/` (shared with Codex). Using the ZCode-native path avoids colliding with `--host codex` and keeps semantics clear. It is a global, user-level host — no workspace confinement needed.

## Compatibility / rollback

Purely additive. No changes to `claude_obsidian/`, `AGENTS.md`, `hooks/hooks.json`, `plugin.json`, or any of the 15 `skills/*`. Existing hosts and the default 3-host dry-run are untouched. Rollback = revert this single commit.

## Verification

Could not run `make test` locally — the hermetic test suite shells out via `subprocess` with `cwd=ROOT`, which breaks under Git Bash on Windows (Windows path passed to `/bin/bash` mangles backslashes), and `ln -s` without `MSYS=winsymlinks:nativestrict` copies instead of symlinking. These are pre-existing Windows-environment limitations that affect the whole suite, not this change. Verified the behavior manually instead:

```
# dry-run: 15 PLANNED, all targeting ~/.zcode/skills/
HOME=$TMP bash bin/setup-multi-agent.sh --host zcode | grep -c "PLANNED zcode"  # -> 15

# apply: 15 real symlinks created, each resolving to skills/<name>
HOME=$TMP bash bin/setup-multi-agent.sh --host zcode --apply
ls -ld $TMP/.zcode/skills/wiki   # -> lrwxrwxrwx ... -> .../skills/wiki

# idempotent: second apply -> 15 READY, exit 0
HOME=$TMP bash bin/setup-multi-agent.sh --host zcode --apply | grep -c "READY zcode"  # -> 15

# conflict: pre-existing dir preserved, exit 2, other skills still created
HOME=$TMP bash bin/setup-multi-agent.sh --host zcode --apply; echo $?  # -> 2

# opt-in: --host all does NOT create .zcode/skills
HOME=$TMP bash bin/setup-multi-agent.sh --host all --apply  # -> no .zcode/

# existing behavior unchanged: default apply -> 45 READY (15 x 3 hosts)
HOME=$TMP bash bin/setup-multi-agent.sh --apply | grep -c "READY"  # -> 45
```

The two new test methods (`test_zcode_host_installs_global_links`, `test_zcode_host_conflict_is_preserved`) mirror the existing Codex idempotent/conflict tests and should pass on the Linux/macOS CI.

## Limitations / notes

- `python3` is required by `make test`; my Windows box only exposes `python`. Expect CI (Linux) to run cleanly.
- Did not add a `.zcode/` rules directory: ZCode reads `AGENTS.md` natively at workspace + user scope, so a `ZCODE.md` pointer (matching the Gemini precedent) is the lighter, consistent choice.
- Happy to adjust naming, test granularity, or docs per review.

## Checklist

- [x] Focused branch from a public fork
- [x] Hermetic regression tests added (idempotent + conflict), no network/model/global paths
- [x] Skill frontmatter untouched (exactly `name` + `description`)
- [x] No root vault state (`wiki/`, `.raw/`, `.vault-meta/`) added
- [x] CHANGELOG `## [Unreleased]` entry added under `### Added`
- [x] No credentials, generated runtime state, or unreviewed binaries