### PR TITLE
fix(schema): declare the page-type vocabulary once and let the router file every documented type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ implementation record for older releases.
   or `wiki-lint.json`; CLI and vault-config patterns are combined. The
   report's new `summary.excluded_paths` count reports how many walked files
   were dropped.
+- `claude_obsidian/page_schema.py` declares the page-type vocabulary once,
+  separating every valid `type` value from the subset the methodology router can
+  file. `wiki-mode.py` derives its accepted types from it instead of
+  keeping a fifth hand-maintained copy.
+- `question` is routable in all four modes, with a `questions_folder` generic
+  setting that defaults to `wiki/questions/`.
 
 ### Changed
 
@@ -44,6 +50,13 @@ implementation record for older releases.
 
 ### Fixed
 
+- `wiki-mode.py route` rejected `question`, `comparison`, `overview`, `meta`, and
+  `fold` — five of the nine page types WIKI.md documents — and did so through a
+  bare exit with no message, so a typo and a valid-but-unroutable type were
+  indistinguishable. Rejections now explain which case applies.
+- The frontmatter reference no longer restates a shorter type list that omitted
+  `session` and `fold`, and the save skill no longer names `synthesis`/`decision`
+  types that no other source declares.
 - The scaffolded vault's `.obsidian/app.json` now pins Obsidian's "New link
   format" setting to `absolute`. It was previously left unset, defaulting to
   Obsidian's own "shortest path when possible" — links created through

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,13 @@ implementation record for older releases.
   file. `wiki-mode.py` derives its accepted types from it instead of
   keeping a fifth hand-maintained copy.
 - `question` is routable in all four modes, with a `questions_folder` generic
-  setting that defaults to `wiki/questions/`.
+  setting that defaults to `wiki/questions/`. Note the asymmetry: only `generic`
+  routes it through a configurable folder key; `para` places questions under
+  `resources_folder + "questions/"`, matching how that mode treats its siblings.
+- `wiki-mode.py route` now exits `6` for a valid-but-unroutable page type and
+  keeps `4` for an unknown one. The two are different problems with different
+  fixes, so a script branching on `$?` can tell them apart — not only a human
+  reading stderr.
 
 ### Changed
 

--- a/WIKI.md
+++ b/WIKI.md
@@ -81,6 +81,15 @@ Common page types:
 | `meta` | Index, log, cache, convention, or maintenance page |
 | `fold` | Extractive rollup of identified log entries |
 
+`claude_obsidian/page_schema.py` is the one declaration of this vocabulary. The
+table above documents it for a reader; code reads the module rather than
+restating the values, and a test asserts the two stay in step.
+
+`source`, `entity`, `concept`, `question`, and `session` are *routable*: the
+methodology router can place a new page of that type. `comparison`, `overview`,
+`meta`, and `fold` are valid frontmatter and not routable, because the product
+creates them through a dedicated operation instead of filing a new note.
+
 Common statuses are `seed`, `active`, `developing`, `evergreen`, `answered`,
 `provisional`, `contested`, `deprecated`, and `archived`. Use only statuses the
 vault's dashboards and conventions understand.

--- a/claude_obsidian/cli.py
+++ b/claude_obsidian/cli.py
@@ -566,6 +566,7 @@ DEFAULT_MODE_CONFIG: dict[str, Any] = {
             "entities_folder": "wiki/entities/",
             "concepts_folder": "wiki/concepts/",
             "sessions_folder": "wiki/sessions/",
+            "questions_folder": "wiki/questions/",
         },
     },
 }

--- a/claude_obsidian/mode_config.py
+++ b/claude_obsidian/mode_config.py
@@ -13,12 +13,12 @@ MODE_FOLDER_KEYS = {
         "entities_folder",
         "concepts_folder",
         "sessions_folder",
+        "questions_folder",
     ),
     "lyt": ("moc_folder", "notes_folder"),
     "para": ("projects_folder", "areas_folder", "resources_folder", "archives_folder"),
     "zettelkasten": ("root_folder",),
 }
-
 
 def _has_control(value: str) -> bool:
     return any(unicodedata.category(character).startswith("C") for character in value)

--- a/claude_obsidian/page_schema.py
+++ b/claude_obsidian/page_schema.py
@@ -28,6 +28,8 @@ so `VALID_TYPES` read like the vocabulary while being neither list.
 
 from __future__ import annotations
 
+from typing import NamedTuple
+
 
 # Authoritative page vocabulary. WIKI.md's table is the source this mirrors; the
 # doc now points here instead of restating the values.
@@ -43,14 +45,24 @@ PAGE_TYPES: tuple[str, ...] = (
     "fold",
 )
 
-# Types the router can place. See the module docstring for why the remainder are
-# excluded rather than missing.
-ROUTABLE_TYPES: tuple[str, ...] = (
-    "source",
-    "entity",
-    "concept",
-    "question",
-    "session",
+# The types the router deliberately does NOT place. See the module docstring for
+# why each is excluded rather than missing.
+NON_ROUTABLE_TYPES: tuple[str, ...] = (
+    "comparison",
+    "overview",
+    "meta",
+    "fold",
+)
+
+# Derived, never restated — this module exists because two copies of a list drift,
+# and writing ROUTABLE_TYPES out by hand would have reintroduced exactly that one
+# level up: nothing stopped a value from being routable without being a valid page
+# type, in which case `route_rejection` would clear a `type:` the frontmatter
+# vocabulary rejects. Subtraction makes ROUTABLE_TYPES ⊆ PAGE_TYPES structurally
+# true; a test covers the remaining direction (a typo in NON_ROUTABLE_TYPES would
+# silently leave a type routable).
+ROUTABLE_TYPES: tuple[str, ...] = tuple(
+    page_type for page_type in PAGE_TYPES if page_type not in NON_ROUTABLE_TYPES
 )
 
 # `research` was accepted by the router and documented nowhere. Its routing was
@@ -62,30 +74,55 @@ ROUTABLE_TYPES: tuple[str, ...] = (
 LEGACY_TYPE_ALIASES: dict[str, str] = {"research": "concept"}
 
 
-def route_rejection_reason(content_type: str) -> str | None:
+# Exit codes. `4` keeps its meaning for an unknown type, because that is what the
+# router already returned and callers may test for it. The unroutable case gets a
+# code of its own: the whole argument for this change is that a typo and a valid
+# page type with no filing destination are *different problems with different
+# fixes*, and a message alone only tells a human. A script still branched on one
+# number, so the distinction stopped at the terminal — the fix applied halfway.
+# `6` because 2, 3, 4 and 5 are already taken in `scripts/wiki-mode.py`.
+UNKNOWN_TYPE_EXIT = 4
+UNROUTABLE_TYPE_EXIT = 6
+
+
+class RouteRejection(NamedTuple):
+    """Why a type cannot be routed, in the two forms a caller needs."""
+
+    exit_code: int
+    message: str
+
+
+def route_rejection(content_type: str) -> RouteRejection | None:
     """Explain why ``content_type`` cannot be routed, or ``None`` when it can.
 
     The router used to exit on an unroutable type with no message, so a caller
     could not tell a typo from a valid type that has no filing destination. Those
-    are different problems with different fixes.
+    are different problems with different fixes — which is why the exit code
+    differs too, not only the text.
     """
 
     if content_type in ROUTABLE_TYPES or content_type in LEGACY_TYPE_ALIASES:
         return None
     if content_type in PAGE_TYPES:
-        return (
+        return RouteRejection(
+            UNROUTABLE_TYPE_EXIT,
             f"type {content_type!r} is a valid page type but is not routable: "
-            "it is created by a dedicated operation, not filed as a new note"
+            "it is created by a dedicated operation, not filed as a new note",
         )
-    return (
+    return RouteRejection(
+        UNKNOWN_TYPE_EXIT,
         f"unknown type {content_type!r}; valid page types are "
-        f"{', '.join(PAGE_TYPES)}"
+        f"{', '.join(PAGE_TYPES)}",
     )
 
 
 __all__ = [
     "LEGACY_TYPE_ALIASES",
+    "NON_ROUTABLE_TYPES",
     "PAGE_TYPES",
     "ROUTABLE_TYPES",
-    "route_rejection_reason",
+    "RouteRejection",
+    "UNKNOWN_TYPE_EXIT",
+    "UNROUTABLE_TYPE_EXIT",
+    "route_rejection",
 ]

--- a/claude_obsidian/page_schema.py
+++ b/claude_obsidian/page_schema.py
@@ -1,0 +1,91 @@
+"""One declaration of the wiki page-type vocabulary, for docs and code to share.
+
+Before this module the `type` vocabulary was declared in four places that did not
+agree: `WIKI.md`, `skills/wiki/references/frontmatter.md`, `skills/save/SKILL.md`,
+and `scripts/wiki-mode.py`. Their union held twelve values and their intersection
+held two, so an agent following the canonical docs could not satisfy all four and
+picked one, silently. Nothing detected the result: `lint_engine` checks that
+`type` is present, never that its value means anything.
+
+Two lists, deliberately separate, because conflating them is what made the router
+look broken:
+
+``PAGE_TYPES``
+    Every value allowed in a page's `type:` frontmatter.
+
+``ROUTABLE_TYPES``
+    The subset the methodology router can place, because a new page of that type
+    has a natural home. `overview`, `meta` and `fold` are excluded on purpose:
+    they are singular or structural pages the product creates through a dedicated
+    operation, not by asking where a new note should live. `wiki/overview.md` is
+    one fixed path (`transaction.py`), and a fold may only write under
+    `wiki/folds/` during an `operation_type: fold` bundle. Routing them would
+    invent a destination the rest of the product does not use.
+
+That distinction already existed in behavior; it was simply never written down,
+so `VALID_TYPES` read like the vocabulary while being neither list.
+"""
+
+from __future__ import annotations
+
+
+# Authoritative page vocabulary. WIKI.md's table is the source this mirrors; the
+# doc now points here instead of restating the values.
+PAGE_TYPES: tuple[str, ...] = (
+    "source",
+    "entity",
+    "concept",
+    "question",
+    "comparison",
+    "session",
+    "overview",
+    "meta",
+    "fold",
+)
+
+# Types the router can place. See the module docstring for why the remainder are
+# excluded rather than missing.
+ROUTABLE_TYPES: tuple[str, ...] = (
+    "source",
+    "entity",
+    "concept",
+    "question",
+    "session",
+)
+
+# `research` was accepted by the router and documented nowhere. Its routing was
+# already `concept`'s folder under `generic`, so it is kept as an alias rather
+# than removed: dropping an accepted CLI argument would break callers for no
+# behavioral gain. Aliases resolve before routing and are not part of the
+# frontmatter vocabulary; the router keeps `research`'s original destinations
+# rather than rewriting them through this map, so accepted calls do not move.
+LEGACY_TYPE_ALIASES: dict[str, str] = {"research": "concept"}
+
+
+def route_rejection_reason(content_type: str) -> str | None:
+    """Explain why ``content_type`` cannot be routed, or ``None`` when it can.
+
+    The router used to exit on an unroutable type with no message, so a caller
+    could not tell a typo from a valid type that has no filing destination. Those
+    are different problems with different fixes.
+    """
+
+    if content_type in ROUTABLE_TYPES or content_type in LEGACY_TYPE_ALIASES:
+        return None
+    if content_type in PAGE_TYPES:
+        return (
+            f"type {content_type!r} is a valid page type but is not routable: "
+            "it is created by a dedicated operation, not filed as a new note"
+        )
+    return (
+        f"unknown type {content_type!r}; valid page types are "
+        f"{', '.join(PAGE_TYPES)}"
+    )
+
+
+__all__ = [
+    "LEGACY_TYPE_ALIASES",
+    "PAGE_TYPES",
+    "ROUTABLE_TYPES",
+    "route_rejection_reason",
+]

--- a/scripts/wiki-mode.py
+++ b/scripts/wiki-mode.py
@@ -48,7 +48,7 @@ from claude_obsidian.mode_config import validate_mode_folders, validate_wiki_rou
 from claude_obsidian.page_schema import (
     LEGACY_TYPE_ALIASES,
     ROUTABLE_TYPES,
-    route_rejection_reason,
+    route_rejection,
 )
 from claude_obsidian.ledgers import strict_json_loads
 from claude_obsidian.paths import VaultSelectionError, resolve_vault_root
@@ -263,12 +263,14 @@ def mint_zettel_id():
 
 def route_path(mode, content_type, name, cfg):
     """Return the suggested vault-relative path for new content under `mode`."""
-    reason = route_rejection_reason(content_type)
-    if reason is not None:
-        # Was a bare SystemExit(4): a caller could not tell a typo from a valid
-        # page type that simply has no filing destination.
-        print(f"ERR: {reason}", file=sys.stderr)
-        raise SystemExit(4)
+    rejection = route_rejection(content_type)
+    if rejection is not None:
+        # Was a bare SystemExit(4) for both cases: a caller could not tell a typo
+        # from a valid page type that simply has no filing destination. The
+        # message says which, and so does the exit code — a script branching on
+        # `$?` gains the distinction too, not just a human reading stderr.
+        print(f"ERR: {rejection.message}", file=sys.stderr)
+        raise SystemExit(rejection.exit_code)
     slug = slugify(name)
 
     raw = safe_name(name)  # case + spaces preserved, but path-traversal stripped

--- a/scripts/wiki-mode.py
+++ b/scripts/wiki-mode.py
@@ -45,6 +45,11 @@ if str(PLUGIN_ROOT) not in sys.path:
     sys.path.insert(0, str(PLUGIN_ROOT))
 
 from claude_obsidian.mode_config import validate_mode_folders, validate_wiki_route
+from claude_obsidian.page_schema import (
+    LEGACY_TYPE_ALIASES,
+    ROUTABLE_TYPES,
+    route_rejection_reason,
+)
 from claude_obsidian.ledgers import strict_json_loads
 from claude_obsidian.paths import VaultSelectionError, resolve_vault_root
 from claude_obsidian.transaction import (
@@ -58,7 +63,9 @@ META_DIR = VAULT_ROOT / ".vault-meta"
 MODE_PATH = META_DIR / "mode.json"
 
 VALID_MODES = ("generic", "lyt", "para", "zettelkasten")
-VALID_TYPES = ("source", "entity", "concept", "session", "research")
+# Derived, never restated: claude_obsidian.page_schema is the one declaration.
+# The legacy `research` alias stays accepted on the command line.
+VALID_TYPES = ROUTABLE_TYPES + tuple(LEGACY_TYPE_ALIASES)
 ZETTEL_ID_FORMAT = "YYYYMMDDHHMMSSffffff-UUID4HEX"
 MAX_COMPONENT_BYTES = 255
 _WINDOWS_RESERVED_STEMS = {
@@ -96,6 +103,7 @@ DEFAULT_CONFIG = {
             "entities_folder": "wiki/entities/",
             "concepts_folder": "wiki/concepts/",
             "sessions_folder": "wiki/sessions/",
+            "questions_folder": "wiki/questions/",
         },
     },
 }
@@ -255,7 +263,11 @@ def mint_zettel_id():
 
 def route_path(mode, content_type, name, cfg):
     """Return the suggested vault-relative path for new content under `mode`."""
-    if content_type not in VALID_TYPES:
+    reason = route_rejection_reason(content_type)
+    if reason is not None:
+        # Was a bare SystemExit(4): a caller could not tell a typo from a valid
+        # page type that simply has no filing destination.
+        print(f"ERR: {reason}", file=sys.stderr)
         raise SystemExit(4)
     slug = slugify(name)
 
@@ -268,6 +280,9 @@ def route_path(mode, content_type, name, cfg):
             "entity":   g["entities_folder"] + _markdown_filename(raw),
             "concept":  g["concepts_folder"] + _markdown_filename(raw),
             "session":  g["sessions_folder"] + _markdown_filename(slug),
+            "question": g["questions_folder"] + _markdown_filename(slug),
+            # Legacy alias of `concept`; its existing destination is preserved
+            # rather than rewritten, so accepted calls keep their exact paths.
             "research": g["concepts_folder"] + _markdown_filename(raw),
         }
         result = mapping[content_type]
@@ -288,6 +303,7 @@ def route_path(mode, content_type, name, cfg):
             "concept":  p["resources_folder"] + "concepts/" + _markdown_filename(raw),
             # Session notes land in projects/inbox/; user reroutes to specific projects
             "session":  p["projects_folder"] + "inbox/" + _markdown_filename(slug),
+            "question": p["resources_folder"] + "questions/" + _markdown_filename(slug),
             "research": p["resources_folder"] + research_stem + "/" + research_stem + ".md",
         }
         result = mapping[content_type]
@@ -311,7 +327,14 @@ def main(argv=None):
     sub.add_parser("config", help="Print full config JSON")
 
     sp_route = sub.add_parser("route", help="Print suggested vault path for new content")
-    sp_route.add_argument("type", choices=VALID_TYPES)
+    # No argparse `choices` here on purpose: it rejects before route_path runs, so
+    # every bad type produced the same usage dump and a valid-but-unroutable type
+    # was indistinguishable from a typo. route_path owns the explanation.
+    sp_route.add_argument(
+        "type",
+        metavar="TYPE",
+        help="Page type to file. Routable: " + ", ".join(VALID_TYPES),
+    )
     sp_route.add_argument("name", help="Content name (will be slugified for filenames)")
     sp_route.add_argument("--mode", choices=VALID_MODES, default=None,
                           help="Preview routing under MODE without writing mode.json (default: use current vault mode)")

--- a/skills/save/SKILL.md
+++ b/skills/save/SKILL.md
@@ -43,9 +43,11 @@ selected vault's `wiki/` directory.
 3. Search for an existing note before creating one. Prefer a small update over a
    duplicate. Obtain explicit approval before replacing an existing canonical
    note.
-4. Select the smallest useful note type: synthesis, concept, decision, source,
-   or session summary. Use declarative prose, Obsidian wikilinks, and honest
-   frontmatter.
+4. Select the smallest useful note type from the declared vocabulary
+   (`claude_obsidian/page_schema.py`, documented in WIKI.md) — usually
+   `question` for an answered analysis, `concept` for an idea worth naming,
+   `source` for material summary, or `session` for approved conversation
+   content. Use declarative prose, Obsidian wikilinks, and honest frontmatter.
 
 If the material has no durable value or is already represented, report that and
 offer a no-op. Honor the user's choice if they still want it saved.

--- a/skills/wiki/references/frontmatter.md
+++ b/skills/wiki/references/frontmatter.md
@@ -24,11 +24,14 @@ claim_ids:
 ---
 ```
 
-Core generated page types are `source`, `entity`, `concept`, `comparison`,
-`question`, `overview`, and `meta`. A custom scaffold may add types when its
-schema is documented. `status` commonly progresses through `seed`,
-`developing`, `mature`, and `evergreen`; preserve other established values in
-an adopted vault.
+Page types are declared once in `claude_obsidian/page_schema.py` and documented in
+[WIKI.md](../../../WIKI.md). This file previously restated a shorter list that
+omitted `session` and `fold`, which is how a vault ends up carrying values one
+document calls invalid. Statuses are still described in prose in both places and
+are out of this change's scope. A custom scaffold may add types when
+its schema is documented. `status` commonly progresses through `seed`,
+`developing`, `mature`, and `evergreen`; preserve other established values in an
+adopted vault.
 
 ## Source properties
 

--- a/tests/test_wiki_mode.py
+++ b/tests/test_wiki_mode.py
@@ -607,6 +607,135 @@ def test_cli_templates_lists_six():
         assert_eq("cli templates returns 6 paths", 6, len(lines))
 
 
+# ─── Single-source page vocabulary (claude_obsidian.page_schema) ─────────────
+def test_routable_types_are_derived_not_restated():
+    """Regression: VALID_TYPES was a fifth hand-maintained copy of the vocabulary.
+
+    Four sources declared `type` differently — WIKI.md, the frontmatter reference,
+    the save skill, and this router — with a union of twelve values and an
+    intersection of two. The router must now read the one declaration.
+    """
+    from claude_obsidian.page_schema import LEGACY_TYPE_ALIASES, ROUTABLE_TYPES
+
+    assert_eq(
+        "VALID_TYPES derives from page_schema",
+        set(ROUTABLE_TYPES) | set(LEGACY_TYPE_ALIASES),
+        set(wm.VALID_TYPES),
+    )
+
+
+def test_question_is_routable_in_every_mode():
+    """Regression: `question` is documented in WIKI.md and the root layout ships
+    wiki/questions/, yet the router rejected it — so the save skill's own default
+    note kind had no filing destination."""
+    cfg = wm.default_config()
+    for mode in ("generic", "lyt", "para", "zettelkasten"):
+        path = wm.route_path(mode, "question", "an open question", cfg)
+        assert_true(
+            f"question routes under {mode}",
+            path.startswith("wiki/") and path.endswith(".md"),
+            hint=path,
+        )
+
+
+def test_unroutable_valid_type_is_distinguished_from_unknown_type():
+    """Regression: both cases exited 4 with no message, so a typo and a valid
+    page type that has no filing destination were indistinguishable."""
+    from claude_obsidian.page_schema import route_rejection_reason
+
+    for page_type in ("overview", "meta", "fold", "comparison"):
+        reason = route_rejection_reason(page_type)
+        assert_true(
+            f"{page_type} is valid but not routable",
+            reason is not None and "valid page type" in reason,
+            hint=str(reason),
+        )
+    unknown = route_rejection_reason("garbage")
+    assert_true(
+        "unknown type says unknown",
+        unknown is not None and "unknown type" in unknown,
+        hint=str(unknown),
+    )
+
+
+def test_legacy_research_alias_keeps_its_exact_destinations():
+    """`research` was accepted by the CLI and documented nowhere. It stays
+    accepted, and its paths must not move: rewriting it as an alias of `concept`
+    would silently relocate para-mode research folders."""
+    cfg = wm.default_config()
+    assert_eq(
+        "generic research destination unchanged",
+        "wiki/concepts/x.md",
+        wm.route_path("generic", "research", "x", cfg),
+    )
+    assert_eq(
+        "para research destination unchanged",
+        "wiki/resources/x/x.md",
+        wm.route_path("para", "research", "x", cfg),
+    )
+
+
+def test_legacy_mode_json_on_disk_routes_through_both_callers():
+    """Regression: `questions_folder` is a folder key added after release, so no
+    existing `mode.json` contains it. Both callers own a separate default document
+    and merge the on-disk file onto it, so this must be exercised on the REAL path
+    — through a file on disk — not by deleting a key from an in-memory default,
+    which is a state neither caller can reach.
+    """
+    with tempfile.TemporaryDirectory() as directory:
+        vault = Path(directory)
+        (vault / "wiki").mkdir()
+        meta = vault / ".vault-meta"
+        meta.mkdir()
+        legacy = {
+            "schema_version": 1,
+            "mode": "generic",
+            "configured_at": "2026-06-09T14:38:44Z",
+            "config": {
+                "generic": {
+                    "sources_folder": "wiki/sources/",
+                    "entities_folder": "wiki/entities/",
+                    "concepts_folder": "wiki/concepts/",
+                    "sessions_folder": "wiki/sessions/",
+                }
+            },
+        }
+        (meta / "mode.json").write_text(json.dumps(legacy), encoding="utf-8")
+
+        routed = subprocess.run(
+            [sys.executable, str(HELPER), "route", "question", "x", "--vault", str(vault)],
+            capture_output=True, text=True, timeout=10,
+        )
+        assert_eq("legacy mode.json routes question", 0, routed.returncode)
+        assert_eq(
+            "legacy mode.json gets the default questions_folder",
+            "wiki/questions/x.md",
+            routed.stdout.strip(),
+        )
+
+        core = subprocess.run(
+            [sys.executable, str(ROOT / "scripts" / "claude-obsidian.py"),
+             "mode", "get", "--vault", str(vault)],
+            capture_output=True, text=True, timeout=15,
+        )
+        assert_eq("legacy mode.json loads through the core CLI", 0, core.returncode)
+
+
+def test_page_vocabulary_matches_the_documented_table():
+    """Anti-drift: the point of one declaration is that the docs stop restating
+    it. WIKI.md's table is prose, so this asserts every documented type appears
+    in the module, which is what a reader of either one relies on."""
+    from claude_obsidian.page_schema import PAGE_TYPES
+
+    documented = (ROOT / "WIKI.md").read_text(encoding="utf-8")
+    for page_type in PAGE_TYPES:
+        assert_true(
+            f"WIKI.md documents type {page_type}",
+            f"`{page_type}`" in documented,
+            hint=page_type,
+        )
+
+
 def main():
     print("=== test_wiki_mode.py ===")
     test_load_config_defaults_to_generic_when_absent()
@@ -634,6 +763,12 @@ def main():
     test_cli_route_returns_path()
     test_cli_set_is_unavailable()
     test_cli_templates_lists_six()
+    test_routable_types_are_derived_not_restated()
+    test_question_is_routable_in_every_mode()
+    test_unroutable_valid_type_is_distinguished_from_unknown_type()
+    test_legacy_research_alias_keeps_its_exact_destinations()
+    test_legacy_mode_json_on_disk_routes_through_both_callers()
+    test_page_vocabulary_matches_the_documented_table()
     print("\nAll wiki-mode tests passed.")
 
 

--- a/tests/test_wiki_mode.py
+++ b/tests/test_wiki_mode.py
@@ -640,21 +640,83 @@ def test_question_is_routable_in_every_mode():
 
 def test_unroutable_valid_type_is_distinguished_from_unknown_type():
     """Regression: both cases exited 4 with no message, so a typo and a valid
-    page type that has no filing destination were indistinguishable."""
-    from claude_obsidian.page_schema import route_rejection_reason
+    page type that has no filing destination were indistinguishable.
+
+    The distinction must reach a SCRIPT, not only a human: the argument for this
+    change is that the two are different problems with different fixes, and a
+    caller branching on `$?` learns nothing from a message on stderr. Asserting
+    only the text would have left the fix applied halfway.
+    """
+    from claude_obsidian.page_schema import (
+        UNKNOWN_TYPE_EXIT,
+        UNROUTABLE_TYPE_EXIT,
+        route_rejection,
+    )
+
+    assert_true(
+        "the two rejection exit codes are distinct",
+        UNKNOWN_TYPE_EXIT != UNROUTABLE_TYPE_EXIT,
+        hint=f"{UNKNOWN_TYPE_EXIT} vs {UNROUTABLE_TYPE_EXIT}",
+    )
 
     for page_type in ("overview", "meta", "fold", "comparison"):
-        reason = route_rejection_reason(page_type)
+        rejection = route_rejection(page_type)
         assert_true(
             f"{page_type} is valid but not routable",
-            reason is not None and "valid page type" in reason,
-            hint=str(reason),
+            rejection is not None and "valid page type" in rejection.message,
+            hint=str(rejection),
         )
-    unknown = route_rejection_reason("garbage")
+        assert_eq(
+            f"{page_type} exits with the unroutable code",
+            UNROUTABLE_TYPE_EXIT,
+            rejection.exit_code,
+        )
+
+    unknown = route_rejection("garbage")
     assert_true(
         "unknown type says unknown",
-        unknown is not None and "unknown type" in unknown,
+        unknown is not None and "unknown type" in unknown.message,
         hint=str(unknown),
+    )
+    assert_eq("unknown type keeps exit 4", UNKNOWN_TYPE_EXIT, unknown.exit_code)
+
+
+def test_route_rejection_exit_codes_reach_the_command_line():
+    """The codes are only worth having if the CLI actually returns them."""
+    with tempfile.TemporaryDirectory() as directory:
+        vault = Path(directory)
+        (vault / "wiki").mkdir()
+        for page_type, expected in (("overview", 6), ("garbage", 4)):
+            done = subprocess.run(
+                [sys.executable, str(HELPER), "route", page_type, "x", "--vault", str(vault)],
+                capture_output=True, text=True, timeout=10,
+            )
+            assert_eq(f"`route {page_type}` exit code", expected, done.returncode)
+
+
+def test_routable_types_cannot_escape_the_page_vocabulary():
+    """Regression the first version of this module shipped: PAGE_TYPES and
+    ROUTABLE_TYPES were two hand-written tuples with nothing tying them together,
+    so a routable type that was not a valid page type would have been cleared by
+    `route_rejection` while the frontmatter vocabulary rejected it — the exact
+    two-copies-drift this module exists to end, reintroduced one level up.
+
+    ROUTABLE_TYPES is now subtraction, so ⊆ holds structurally. This covers the
+    direction subtraction cannot: a typo in NON_ROUTABLE_TYPES silently leaves a
+    type routable, and nothing else would notice.
+    """
+    from claude_obsidian.page_schema import (
+        NON_ROUTABLE_TYPES,
+        PAGE_TYPES,
+        ROUTABLE_TYPES,
+    )
+
+    unknown = sorted(set(NON_ROUTABLE_TYPES) - set(PAGE_TYPES))
+    assert_eq("every NON_ROUTABLE_TYPES value is a real page type", [], unknown)
+    assert_eq(
+        "routable and non-routable partition the vocabulary",
+        sorted(PAGE_TYPES),
+        sorted(set(ROUTABLE_TYPES) | set(NON_ROUTABLE_TYPES)),
     )
 
 
@@ -721,19 +783,53 @@ def test_legacy_mode_json_on_disk_routes_through_both_callers():
         assert_eq("legacy mode.json loads through the core CLI", 0, core.returncode)
 
 
+def _documented_page_types() -> list[str]:
+    """Page types read from WIKI.md's `| Type | Purpose |` TABLE.
+
+    Anchored on the table header and stopping at the first non-row, because a
+    whole-file substring search is not a check: the first version of this test
+    asked whether ``f"`{page_type}`"`` appeared anywhere in WIKI.md, and the same
+    commit added a paragraph naming five of the types in prose. Deleting the
+    entire table would have left it green — it was satisfied by its own PR's
+    wording rather than by the documentation it claimed to verify.
+    """
+    lines = (ROOT / "WIKI.md").read_text(encoding="utf-8").splitlines()
+    try:
+        start = lines.index("| Type | Purpose |")
+    except ValueError:  # pragma: no cover - asserted by the caller
+        return []
+    found = []
+    for line in lines[start + 2 :]:  # skip the header and its `|---|---|`
+        if not line.startswith("|"):
+            break
+        cell = line.split("|")[1].strip()
+        if cell.startswith("`") and cell.endswith("`"):
+            found.append(cell.strip("`"))
+    return found
+
+
 def test_page_vocabulary_matches_the_documented_table():
-    """Anti-drift: the point of one declaration is that the docs stop restating
-    it. WIKI.md's table is prose, so this asserts every documented type appears
-    in the module, which is what a reader of either one relies on."""
+    """Anti-drift, in BOTH directions.
+
+    One declaration only pays off if the doc and the module cannot disagree. The
+    previous assertion covered one direction (every module type is mentioned
+    somewhere) and would not have noticed WIKI.md documenting a tenth type the
+    code rejects — which is the very defect this PR was opened to fix, in the
+    other direction.
+    """
     from claude_obsidian.page_schema import PAGE_TYPES
 
-    documented = (ROOT / "WIKI.md").read_text(encoding="utf-8")
-    for page_type in PAGE_TYPES:
-        assert_true(
-            f"WIKI.md documents type {page_type}",
-            f"`{page_type}`" in documented,
-            hint=page_type,
-        )
+    documented = _documented_page_types()
+    assert_true(
+        "the WIKI.md type table was found and parsed",
+        len(documented) > 0,
+        hint="header `| Type | Purpose |` missing or table empty",
+    )
+    assert_eq(
+        "WIKI.md's table and PAGE_TYPES hold the same values",
+        sorted(PAGE_TYPES),
+        sorted(documented),
+    )
 
 
 def main():
@@ -764,8 +860,10 @@ def main():
     test_cli_set_is_unavailable()
     test_cli_templates_lists_six()
     test_routable_types_are_derived_not_restated()
+    test_routable_types_cannot_escape_the_page_vocabulary()
     test_question_is_routable_in_every_mode()
     test_unroutable_valid_type_is_distinguished_from_unknown_type()
+    test_route_rejection_exit_codes_reach_the_command_line()
     test_legacy_research_alias_keeps_its_exact_destinations()
     test_legacy_mode_json_on_disk_routes_through_both_callers()
     test_page_vocabulary_matches_the_documented_table()


### PR DESCRIPTION
Fixes #148.

## Problem

The `type` vocabulary is declared in four places that disagree. Union of 12 values, intersection of 2:

| Source | Values |
|---|---|
| `WIKI.md:70-83` | source, entity, concept, question, comparison, session, overview, meta, fold |
| `skills/wiki/references/frontmatter.md:27` | source, entity, concept, comparison, question, overview, meta |
| `skills/save/SKILL.md:42` | synthesis, concept, decision, source, session |
| `scripts/wiki-mode.py:61` `VALID_TYPES` | source, entity, concept, session, research |

The fourth is executable, so this is not only a docs inconsistency. `wiki-mode.py route` rejected **5 of the 9 types `WIKI.md` documents**, through a bare `SystemExit(4)` and an argparse usage dump:

```
route session     exit=0     route comparison  exit=2
route concept     exit=0     route overview    exit=2
route question    exit=2     route meta        exit=2
                             route fold        exit=2
```

`question` mattered most: `WIKI.md`'s root layout already ships `wiki/questions/`, and it is the most common kind of note `save` produces. A caller also could not tell a typo from a valid page type that has no filing destination — both exited the same way with no message.

## Behavior

`claude_obsidian/page_schema.py` holds the one declaration and separates two lists that behavior already distinguished but nothing wrote down:

- **`PAGE_TYPES`** — every value allowed in `type:` frontmatter.
- **`ROUTABLE_TYPES`** — the subset the router can place.

`overview`, `meta`, `fold` and `comparison` are valid frontmatter and deliberately **not** routable. That is not an omission: `transaction.py` already treats `wiki/overview.md` as one fixed path and confines a fold to `wiki/folds/` inside an `operation_type: fold` bundle. Routing them would invent destinations the rest of the product does not use. Previously `VALID_TYPES` read like the vocabulary while being neither list.

Changes:

- `wiki-mode.py` derives its accepted types from the module instead of keeping a fifth hand-maintained copy.
- `question` is routable in all four modes; `generic` gains `questions_folder`, defaulting to `wiki/questions/`.
- Rejections explain which case applies: `unknown type 'garbage'; valid page types are …` vs `type 'overview' is a valid page type but is not routable: it is created by a dedicated operation, not filed as a new note`.
- The three docs point at the module rather than restating lists. `frontmatter.md` had dropped `session` and `fold`; `save/SKILL.md` named `synthesis`/`decision`, which no other source declares.

One deliberate consequence: argparse `choices` is gone from the `route` positional, because it rejected *before* `route_path` could explain anything. `route_path` validates instead. Containment is unchanged — `route_rejection_reason` gates before `slugify`/`safe_name`/`mapping[…]`/`validate_wiki_route`, and the mapping keyspace stays provably closed (`ROUTABLE_TYPES ∪ LEGACY_TYPE_ALIASES` equals the `generic` and `para` mapping dicts' key sets). Probed with `../../../etc/passwd` as the name (→ `wiki/questions/etc-passwd.md`), and with `--evil` and `question/../../evil` as the type (both rejected before touching a path).

## Compatibility

- **`research`** stays accepted and keeps its exact prior destinations (`wiki/concepts/<name>.md` under generic, `wiki/resources/<stem>/<stem>.md` under para). It is recorded as a legacy alias but the router does **not** resolve it through the alias map, because doing so would silently relocate para-mode research folders. Asserted on the concrete paths, checked against `git show HEAD:scripts/wiki-mode.py`.
- **Existing `mode.json` files** lack `questions_folder`. Both callers deep-copy their own defaults and merge the on-disk file onto them, so the key is present by the time validation runs. The test exercises the real path — a legacy file on disk, through both `wiki-mode.py route` and `claude-obsidian.py mode get` — rather than deleting a key from an in-memory default, which is a state neither caller can reach.
- No user file is migrated, rewritten, or moved. **Rollback is reverting the commit.**

## Verification

```
make test                      # exit 0 — python + shell + contracts + package
python3 tests/test_wiki_mode.py # 31 assertions incl. 6 new
```

Regression coverage fails against the old behavior (CONTRIBUTING §1), proven by reverting the production files in an isolated copy and rerunning the new tests unmodified: `route_path('generic', 'question', …)` → `SystemExit(4)`, same for `comparison`.

Also ran `agents/verifier.md` in a fresh read-only context over the worktree. It returned `SHIP` with no BLOCKER or HIGH, and four lower findings that are all fixed in this branch rather than deferred:

- an `OPTIONAL_MODE_FOLDER_KEYS` mechanism whose stated justification it could not reproduce — removed, the key is required, and the test now exercises the caller path instead of a synthetic one;
- a `resolve_type_alias` helper with no caller — removed;
- a `PAGE_STATUSES` list with no consumer and no test, sitting under a doc sentence claiming statuses were "declared once" — removed, and the claim narrowed to types, which is what this change actually delivers;
- an inaccurate provenance comment about `mature`.

## Out of scope, noted

- **`lint_engine.py:48`** validates that `type` and `status` are *present*, never that a value means anything — which is why this divergence went undetected. A check against `PAGE_TYPES` is the natural follow-up and is left out to keep this reviewable.
- **`claude_obsidian/cli.py:546 DEFAULT_MODE_CONFIG` and `scripts/wiki-mode.py:74 DEFAULT_CONFIG` are two independent copies of the same default document** — the same "one rule, N copies" pattern this PR fixes for types, in another dimension. It predates this change (all four other generic folder keys were already duplicated), and I added `questions_folder` to both rather than unifying them, to keep the diff on one thesis. Happy to send that separately if you want it.
- **Statuses** diverge too (`WIKI.md` lists 9, `frontmatter.md` lists 4 and includes `mature`, which `WIKI.md` omits). Not touched here: picking the union or the intersection is a product decision, not a mechanical one.

## Limitations

`PAGE_TYPES` mirrors `WIKI.md`'s table, and the anti-drift test asserts every declared type appears in that document. It cannot assert the reverse — that the doc adds no undeclared type — without parsing prose, so a new row added to the table alone would not fail. If you would rather the table be generated from the module, say so and I will do that instead.
