### PR TITLE
fix: native Windows crash (os.O_DIRECTORY) — working dry-runs, fail-closed writes, Windows CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Never translate line endings at checkout: frontmatter parsing requires exact
+# "---\n" and content hashes (templates, release manifests, approval plans)
+# must be byte-identical on every platform, including Windows checkouts.
+* -text

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,6 +49,62 @@ jobs:
           git diff --exit-code
           test -z "$(git status --porcelain=v1 --untracked-files=all)"
 
+  windows-smoke:
+    # The full suite exercises dirfd confinement, symlinks, fcntl, and bash —
+    # deliberately unsupported on native Windows.  This job runs the portable
+    # surface (schema/package/contract validation plus the Windows
+    # compatibility suite) as an explicit allowlist so a skip can never be
+    # mistaken for a pass.
+    name: windows-latest / Python 3.12 (portable surface)
+    runs-on: windows-latest
+    timeout-minutes: 10
+    env:
+      PYTHONDONTWRITEBYTECODE: '1'
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Disable line-ending translation before checkout
+        # The runner image ships autocrlf=true globally; frontmatter parsing
+        # and content hashing require byte-exact LF checkouts.  Must run
+        # before actions/checkout writes any file.
+        run: git config --global core.autocrlf false
+
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Set up Python
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+        with:
+          python-version: '3.12'
+
+      - name: Show runtime versions
+        run: python --version
+
+      - name: Run portable-surface tests
+        run: |
+          set -eu
+          for test_file in \
+            tests/test_package_validation.py \
+            tests/test_knowledge_contracts.py \
+            tests/test_contracts.py \
+            tests/test_benchmark_tools.py \
+            tests/test_windows_compat.py; do
+            echo "=== $test_file ==="
+            python "$test_file"
+          done
+
+      - name: Run portable validators
+        run: |
+          python scripts/claude-obsidian.py package validate
+          python scripts/claude-obsidian.py contracts --check-only
+
+      - name: Prove tests did not mutate or create product files
+        run: |
+          git diff --exit-code
+          test -z "$(git status --porcelain=v1 --untracked-files=all)"
+
   release-safety:
     name: Reproducible release artifact
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,44 @@ implementation record for older releases.
 
 ## [Unreleased]
 
+### Fixed
+
+- Native Windows no longer crashes with `AttributeError: os.O_DIRECTORY` on
+  every vault command. Read-only inspection and dry-runs (`transaction
+  inspect`, `migrate`/`init`/`adopt`/`capture` previews) now work natively
+  with real equivalent safety checks: path-based casefold-alias auditing,
+  lstat-based vault identity, and symlink/junction rejection.
+- File reads in the transaction core now force binary mode (`O_BINARY`), so
+  CRLF content is hashed byte-exactly on Windows instead of producing false
+  `CONTENT_HASH_MISMATCH`/`EXPECTED_HASH_MISMATCH` failures.
+- CLI output is always UTF-8, fixing `UnicodeEncodeError` crashes when
+  redirecting output containing non-ASCII titles on Windows (cp1252 consoles).
+- Retrieval no longer returns zero results for vaults with CRLF line endings:
+  the chunker, index, and retriever now hash page bodies byte-identically
+  (previously `read_text` newline normalization made every chunk look stale).
+- Selecting a vault whose on-disk name differs only by case or Unicode
+  normalization from the spelling used on the command line no longer raises a
+  spurious `CASEFOLD_PATH_ALIAS` on case-insensitive filesystems (APFS, NTFS).
+
 ### Changed
 
+- Vault mutation on hosts without directory-descriptor confinement (native
+  Windows) is refused before any side effect with a new
+  `UNSUPPORTED_PLATFORM` validation error (exit 2, previously a generic
+  `LOCK_FAILED` exit 1 or a traceback), and `init --apply` no longer creates
+  an abandoned empty vault directory on refused platforms.
+- Transaction write paths are now validated against portable-filesystem rules
+  on every platform: Windows-reserved device names (`CON`, `NUL`, ...),
+  `:<>|?*"` characters, and trailing dots/spaces are rejected with
+  `UNPORTABLE_WRITE_PATH` so an approved plan means the same thing everywhere.
+- Degraded-mode path walks now reject Windows directory junctions and mount
+  points in addition to symlinks.
+- File permission bits feeding plan hashes are normalized to `0o644` on
+  Windows, keeping inspect output deterministic.
+- Added a `.gitattributes` that disables line-ending translation so checkouts
+  hash identically on every platform.
+- CI gained a `windows-smoke` job exercising the portable Python surface and
+  the new Windows compatibility suite on `windows-latest`.
 - Replaced the animated README hero with the selected static PNG cover while
   preserving the warm orbital style.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,10 +33,12 @@ implementation record for older releases.
   `UNSUPPORTED_PLATFORM` validation error (exit 2, previously a generic
   `LOCK_FAILED` exit 1 or a traceback), and `init --apply` no longer creates
   an abandoned empty vault directory on refused platforms.
-- Transaction write paths are now validated against portable-filesystem rules
-  on every platform: Windows-reserved device names (`CON`, `NUL`, ...),
-  `:<>|?*"` characters, and trailing dots/spaces are rejected with
-  `UNPORTABLE_WRITE_PATH` so an approved plan means the same thing everywhere.
+- New transaction write destinations are validated against
+  portable-filesystem rules on every platform: Windows-reserved device names
+  (`CON`, `NUL`, ...), `:<>|?*"` characters, and trailing dots/spaces are
+  rejected with `UNPORTABLE_WRITE_PATH` so an approved plan means the same
+  thing everywhere. Reads, retrieval indexing, and journal recovery of
+  pre-existing files with such names are intentionally unaffected.
 - Degraded-mode path walks now reject Windows directory junctions and mount
   points in addition to symlinks.
 - File permission bits feeding plan hashes are normalized to `0o644` on

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,10 +24,11 @@ implementation record for older releases.
   (previously `read_text` newline normalization made every chunk look stale).
 - Under a held mutation lock, a vault whose on-disk name differs only by case
   from the spelling used on the command line is no longer misreported as its
-  own portable alias on case-insensitive filesystems (APFS, NTFS); the
-  descriptor-pinned vault object is recognized as itself. Inspect-time
-  auditing keeps the stricter shipped behavior, since an absent init root on
-  a case-insensitive volume cannot distinguish itself from an alien sibling.
+  own portable alias on case-insensitive filesystems (APFS; the lock layer
+  never runs on native Windows); the descriptor-pinned vault object is
+  recognized as itself. Inspect-time auditing keeps the stricter shipped
+  behavior, since an absent init root on a case-insensitive volume cannot
+  distinguish itself from an alien sibling.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,9 +22,12 @@ implementation record for older releases.
 - Retrieval no longer returns zero results for vaults with CRLF line endings:
   the chunker, index, and retriever now hash page bodies byte-identically
   (previously `read_text` newline normalization made every chunk look stale).
-- Selecting a vault whose on-disk name differs only by case or Unicode
-  normalization from the spelling used on the command line no longer raises a
-  spurious `CASEFOLD_PATH_ALIAS` on case-insensitive filesystems (APFS, NTFS).
+- Under a held mutation lock, a vault whose on-disk name differs only by case
+  from the spelling used on the command line is no longer misreported as its
+  own portable alias on case-insensitive filesystems (APFS, NTFS); the
+  descriptor-pinned vault object is recognized as itself. Inspect-time
+  auditing keeps the stricter shipped behavior, since an absent init root on
+  a case-insensitive volume cannot distinguish itself from an alien sibling.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -345,10 +345,12 @@ remain yours.
 - Bash for setup, optional extensions, and shell test suites
 - Git only for development, releases, or an explicit knowledge checkpoint
 
-CI exercises Linux and macOS. On Windows, use WSL; native Windows and Git Bash
-are not current compatibility guarantees. Optional tools such as Obsidian CLI,
-Ollama, and defuddle are capability-detected and affect only their dependent
-workflow.
+CI exercises Linux and macOS, plus a native-Windows smoke job for the portable
+surface. On native Windows (including Git Bash), read-only inspection and
+dry-run commands work; vault writes require WSL and fail closed with an
+`UNSUPPORTED_PLATFORM` error otherwise. The bash setup scripts and shell test
+suites remain POSIX-only. Optional tools such as Obsidian CLI, Ollama, and
+defuddle are capability-detected and affect only their dependent workflow.
 
 ## Development and release
 

--- a/README.md
+++ b/README.md
@@ -348,9 +348,12 @@ remain yours.
 CI exercises Linux and macOS, plus a native-Windows smoke job for the portable
 surface. On native Windows (including Git Bash), read-only inspection and
 dry-run commands work; vault writes require WSL and fail closed with an
-`UNSUPPORTED_PLATFORM` error otherwise. The bash setup scripts and shell test
-suites remain POSIX-only. Optional tools such as Obsidian CLI, Ollama, and
-defuddle are capability-detected and affect only their dependent workflow.
+`UNSUPPORTED_PLATFORM` error otherwise. Approval hashes bind to the reviewing
+environment's filesystem identity, so run the dry-run review inside WSL when
+the apply will happen there — a natively produced `approved_plan_sha256`
+cannot be replayed from WSL. The bash setup scripts and shell test suites
+remain POSIX-only. Optional tools such as Obsidian CLI, Ollama, and defuddle
+are capability-detected and affect only their dependent workflow.
 
 ## Development and release
 

--- a/claude_obsidian/capture.py
+++ b/claude_obsidian/capture.py
@@ -36,6 +36,7 @@ from .transaction import (
     BUNDLE_SCHEMA,
     TransactionValidationError,
     _LockIdentityChanged,
+    _UNSUPPORTED_PLATFORM_MESSAGE,
     _lock_entry_matches,
     _open_lock_directory_at,
     _open_lock_parent_from_root_fd,
@@ -205,6 +206,10 @@ def _safe_runtime_dir(vault_root: Path) -> Path:
             create=True,
         )
     except OSError as exc:
+        if exc.errno == errno.ENOTSUP:
+            raise CaptureValidationError(
+                "UNSUPPORTED_PLATFORM", _UNSUPPORTED_PLATFORM_MESSAGE
+            ) from exc
         if exc.errno in {errno.ELOOP, errno.ENOTDIR}:
             raise CaptureValidationError(
                 "RUNTIME_SYMLINK",
@@ -1494,6 +1499,10 @@ class CaptureQueueLock:
         try:
             root_fd = _open_lock_root_fd(self.vault_root)
         except OSError as exc:
+            if exc.errno == errno.ENOTSUP:
+                raise CaptureValidationError(
+                    "UNSUPPORTED_PLATFORM", _UNSUPPORTED_PLATFORM_MESSAGE
+                ) from exc
             raise CaptureError(
                 "QUEUE_LOCK_FAILED", f"cannot pin capture vault root: {exc}"
             ) from exc

--- a/claude_obsidian/capture.py
+++ b/claude_obsidian/capture.py
@@ -36,6 +36,7 @@ from .transaction import (
     BUNDLE_SCHEMA,
     TransactionValidationError,
     _LockIdentityChanged,
+    _PlatformConfinementUnavailable,
     _UNSUPPORTED_PLATFORM_MESSAGE,
     _lock_entry_matches,
     _open_lock_directory_at,
@@ -206,7 +207,7 @@ def _safe_runtime_dir(vault_root: Path) -> Path:
             create=True,
         )
     except OSError as exc:
-        if exc.errno == errno.ENOTSUP:
+        if isinstance(exc, _PlatformConfinementUnavailable):
             raise CaptureValidationError(
                 "UNSUPPORTED_PLATFORM", _UNSUPPORTED_PLATFORM_MESSAGE
             ) from exc
@@ -1499,7 +1500,7 @@ class CaptureQueueLock:
         try:
             root_fd = _open_lock_root_fd(self.vault_root)
         except OSError as exc:
-            if exc.errno == errno.ENOTSUP:
+            if isinstance(exc, _PlatformConfinementUnavailable):
                 raise CaptureValidationError(
                     "UNSUPPORTED_PLATFORM", _UNSUPPORTED_PLATFORM_MESSAGE
                 ) from exc

--- a/claude_obsidian/checkpoint.py
+++ b/claude_obsidian/checkpoint.py
@@ -18,7 +18,7 @@ from typing import Any, Mapping, Sequence
 
 from .json_utils import parse_finite_json_float
 from .lint_engine import lint_vault
-from .paths import canonical
+from .paths import canonical, directory_open_flags, read_open_flags
 from .transaction import (
     RESULT_SCHEMA,
     MutationLock,
@@ -425,11 +425,7 @@ class _CheckpointStore:
                 or before.st_size > MAX_CHECKPOINT_STATE_BYTES
             ):
                 raise CheckpointError(code, f"{label} is not a bounded regular file")
-            descriptor = os.open(
-                name,
-                os.O_RDONLY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0),
-                dir_fd=self.operation_fd,
-            )
+            descriptor = os.open(name, read_open_flags(), dir_fd=self.operation_fd)
             opened = os.fstat(descriptor)
             if (opened.st_dev, opened.st_ino) != (before.st_dev, before.st_ino):
                 raise CheckpointError(code, f"{label} changed before it could be read")
@@ -530,9 +526,7 @@ class _CheckpointStore:
             raise CheckpointError(
                 "CORRUPT_CHECKPOINT", f"cannot list transaction state: {exc}"
             ) from exc
-        flags = (
-            os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW | getattr(os, "O_CLOEXEC", 0)
-        )
+        flags = directory_open_flags()
         for name in names:
             if name == self.operation_id:
                 continue

--- a/claude_obsidian/cli.py
+++ b/claude_obsidian/cli.py
@@ -45,6 +45,7 @@ from .transaction import (
     MutationLock,
     TransactionError,
     TransactionValidationError,
+    _require_write_platform,
     apply_bundle,
     inspect_bundle,
     read_vault_regular,
@@ -810,6 +811,10 @@ def command_init(args: argparse.Namespace) -> int:
             }
         )
         return 0
+    # Refuse unsupported write platforms before creating the destination
+    # directory: a failed Init root is never path-deleted (see below), so the
+    # check must precede the mkdir rather than surface later in apply_bundle.
+    _require_write_platform()
     reviewed_plan = _require_approved_plan(args, destination, operation)
     approval = str(reviewed_plan["approval_sha256"])
     created = False
@@ -1218,7 +1223,27 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _force_utf8_stdio() -> None:
+    """Emit UTF-8 regardless of the console code page.
+
+    On Windows, redirected stdout/stderr default to the locale encoding
+    (cp1252), so any non-ASCII page title crashes ``_emit``'s
+    ``ensure_ascii=False`` output.  ``newline=""`` keeps JSON output
+    byte-identical across platforms.
+    """
+
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(encoding="utf-8", newline="")
+        except (OSError, ValueError):
+            pass
+
+
 def main(argv: Sequence[str] | None = None) -> int:
+    _force_utf8_stdio()
     parser = build_parser()
     args = parser.parse_args(argv)
     try:

--- a/claude_obsidian/hook_adapter.py
+++ b/claude_obsidian/hook_adapter.py
@@ -16,6 +16,7 @@ from .paths import (
     VaultSelectionError,
     assert_within,
     canonical,
+    is_name_surrogate,
     is_relative_to,
     resolve_vault_root,
 )
@@ -88,7 +89,7 @@ def _bounded_regular_bytes(root: Path, path: Path, limit: int) -> bytes | None:
                 metadata = cursor.lstat()
             except OSError:
                 return None
-            if stat.S_ISLNK(metadata.st_mode):
+            if is_name_surrogate(metadata):
                 return None
         try:
             descriptor = os.open(path, file_flags)

--- a/claude_obsidian/hook_adapter.py
+++ b/claude_obsidian/hook_adapter.py
@@ -47,8 +47,13 @@ def _bounded_regular_bytes(root: Path, path: Path, limit: int) -> bytes | None:
         | getattr(os, "O_CLOEXEC", 0)
         | getattr(os, "O_NOFOLLOW", 0)
     )
+    # O_BINARY keeps the Windows CRT from CRLF-translating reads at the
+    # descriptor layer, which would corrupt content passed to hashing callers.
     file_flags = (
-        os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_BINARY", 0)
     )
     if os.name != "nt" and os.open in os.supports_dir_fd and hasattr(os, "O_DIRECTORY"):
         try:

--- a/claude_obsidian/paths.py
+++ b/claude_obsidian/paths.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import errno
 import json
 import os
 import stat
@@ -48,6 +49,110 @@ def _portable_path_key(path: Path) -> str:
     """Return the case/normalization-insensitive identity used by policy."""
 
     return unicodedata.normalize("NFC", os.fspath(path).replace("\\", "/").casefold())
+
+
+def supports_confined_dirfd() -> bool:
+    """True when the POSIX openat-style confinement primitives all exist.
+
+    Native Windows lacks ``O_DIRECTORY`` and dir_fd support entirely; callers
+    take a path-based degraded branch there instead of descriptor confinement.
+    ``legacy_lock._supports_confined_runtime`` and the inline probe in
+    ``hook_adapter`` intentionally require different primitive sets and stay
+    separate.
+    """
+
+    return (
+        os.name != "nt"
+        and hasattr(os, "O_DIRECTORY")
+        and os.open in os.supports_dir_fd
+        and os.mkdir in os.supports_dir_fd
+        and os.rename in os.supports_dir_fd
+        and os.stat in os.supports_dir_fd
+        and os.unlink in os.supports_dir_fd
+    )
+
+
+def directory_open_flags() -> int:
+    """Directory-pinning open flags; flags absent on this platform become 0."""
+
+    return (
+        os.O_RDONLY
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+    )
+
+
+def read_open_flags() -> int:
+    """Regular-file read flags.
+
+    ``O_BINARY`` matters: the Windows CRT defaults descriptors to text mode,
+    which strips ``\\r\\n`` during reads and silently corrupts content hashes.
+    """
+
+    return (
+        os.O_RDONLY
+        | getattr(os, "O_CLOEXEC", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
+        | getattr(os, "O_BINARY", 0)
+    )
+
+
+# Name-surrogate reparse tags only: symlinks and junctions/mount points redirect
+# the name lookup, while cloud placeholders (OneDrive/Dropbox) and dedup files
+# carry FILE_ATTRIBUTE_REPARSE_POINT without aliasing the path, so a blanket
+# attribute check would fail-closed every vault stored in a synced folder.
+_NAME_SURROGATE_REPARSE_TAGS = frozenset(
+    {
+        getattr(stat, "IO_REPARSE_TAG_SYMLINK", 0xA000000C),
+        getattr(stat, "IO_REPARSE_TAG_MOUNT_POINT", 0xA0000003),
+    }
+)
+
+
+def is_name_surrogate(value: os.stat_result) -> bool:
+    """True when the stat result names a path-redirecting object.
+
+    Covers POSIX symlinks plus Windows junctions/mount points, which since
+    Python 3.8 lstat as ordinary directories (``S_ISLNK`` is False) but still
+    redirect name lookups exactly like a symlink would.
+    """
+
+    return (
+        stat.S_ISLNK(value.st_mode)
+        or getattr(value, "st_reparse_tag", 0) in _NAME_SURROGATE_REPARSE_TAGS
+    )
+
+
+def assert_unaliased_directory(path: str | os.PathLike[str] | Path) -> os.stat_result:
+    """lstat ``path`` and fail unless it is a plain, non-redirecting directory.
+
+    This is a point-in-time check, not descriptor pinning: it offers the same
+    guarantee level as the documented degraded (non-dirfd) mode.  Raises
+    ``OSError(ELOOP)`` for a symlink or a Windows junction/mount point and
+    ``OSError(ENOTDIR)`` for anything that is not a directory, mirroring what
+    ``O_DIRECTORY | O_NOFOLLOW`` opens produce on POSIX so callers can share
+    one error-mapping path.
+    """
+
+    value = os.lstat(path)
+    if is_name_surrogate(value):
+        raise OSError(errno.ELOOP, f"path is a symlink or directory junction: {path}")
+    if not stat.S_ISDIR(value.st_mode):
+        raise OSError(errno.ENOTDIR, f"not a directory: {path}")
+    return value
+
+
+def is_same_object(left: os.stat_result, right: os.stat_result) -> bool:
+    """samestat with a degraded-identity guard.
+
+    A zero inode (FAT/exFAT, some SMB redirectors) means the filesystem does
+    not expose stable identity, so equality can never be asserted.
+    """
+
+    if left.st_ino == 0 or right.st_ino == 0:
+        return False
+    return (left.st_dev, left.st_ino) == (right.st_dev, right.st_ino)
 
 
 def _strict_json_loads(value: str) -> object:
@@ -109,10 +214,7 @@ def _read_workspace_config(path: Path) -> Path:
                 f"workspace config must be a regular file of at most "
                 f"{MAX_WORKSPACE_CONFIG_BYTES} bytes"
             )
-        descriptor = os.open(
-            path,
-            os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0),
-        )
+        descriptor = os.open(path, read_open_flags())
         opened = os.fstat(descriptor)
         if (
             not stat.S_ISREG(opened.st_mode)

--- a/claude_obsidian/transaction.py
+++ b/claude_obsidian/transaction.py
@@ -3277,6 +3277,9 @@ def _prepare_writes(
     # Lexical portability pre-pass before any filesystem probe so unportable
     # plans are rejected with the same code on every platform (a Windows lstat
     # of e.g. "a:b.md" would otherwise fail first with a different error).
+    # expected_hashes keys are deliberately exempt: probe-only keys are read
+    # preconditions, and a legacy vault must stay able to pin the state of a
+    # pre-existing file whose historical name violates the portable rules.
     for raw in raw_writes:
         if isinstance(raw, dict) and isinstance(raw.get("path"), str):
             _assert_portable_write_path(raw["path"])

--- a/claude_obsidian/transaction.py
+++ b/claude_obsidian/transaction.py
@@ -1124,10 +1124,12 @@ def _is_leaf_itself(parent: int | Path, name: str, self_lstat: os.stat_result) -
 
 
 def _assert_no_portable_vault_root_alias(vault_root: Path) -> None:
-    try:
-        self_lstat: os.stat_result | None = os.lstat(vault_root)
-    except OSError:
-        self_lstat = None
+    # No self_lstat here: on case-insensitive filesystems os.lstat(vault_root)
+    # resolves ANY casing, so for an absent root (init) it would misidentify
+    # an alien same-key sibling as "the vault itself" and skip the rejection.
+    # The self-entry skip is safe only where the vault object is already
+    # descriptor-pinned (the MutationLock call sites).  Native Windows does
+    # not need it here because canonical() case-normalizes existing paths.
     if _supports_confined_dirfd():
         try:
             parent_fd = os.open(vault_root.parent, directory_open_flags())
@@ -1136,9 +1138,7 @@ def _assert_no_portable_vault_root_alias(vault_root: Path) -> None:
                 "UNSAFE_VAULT_IDENTITY", f"cannot pin vault parent: {exc}"
             ) from exc
         try:
-            _assert_no_portable_vault_leaf_alias_at(
-                parent_fd, vault_root.name, self_lstat=self_lstat
-            )
+            _assert_no_portable_vault_leaf_alias_at(parent_fd, vault_root.name)
         finally:
             os.close(parent_fd)
         return
@@ -1149,9 +1149,7 @@ def _assert_no_portable_vault_root_alias(vault_root: Path) -> None:
         raise TransactionValidationError(
             "UNSAFE_VAULT_IDENTITY", f"cannot pin vault parent: {exc}"
         ) from exc
-    _assert_no_portable_vault_leaf_alias_at(
-        parent, vault_root.name, self_lstat=self_lstat
-    )
+    _assert_no_portable_vault_leaf_alias_at(parent, vault_root.name)
 
 
 def _path_mode_identity(vault: Path) -> dict[str, Any]:

--- a/claude_obsidian/transaction.py
+++ b/claude_obsidian/transaction.py
@@ -25,7 +25,17 @@ from pathlib import Path, PurePosixPath
 from typing import Any, Callable, Iterable, Mapping, Sequence
 
 from .json_utils import parse_finite_json_float
-from .paths import VaultSelectionError, assert_within, canonical
+from .paths import (
+    VaultSelectionError,
+    assert_unaliased_directory,
+    assert_within,
+    canonical,
+    directory_open_flags,
+    is_name_surrogate,
+    is_same_object,
+    read_open_flags,
+    supports_confined_dirfd,
+)
 
 
 BUNDLE_SCHEMA = "claude-obsidian.transaction.v1"
@@ -190,6 +200,24 @@ def _portable_name_key(value: str) -> str:
     return unicodedata.normalize("NFC", value.casefold())
 
 
+# Portable-vault write-path rules (enforced on every platform so an inspect
+# verdict means the same thing everywhere).  ``:`` names an NTFS alternate data
+# stream — invisible to directory enumeration, so the alias audit could never
+# see it; the rest are Win32-invalid filename characters.  Mirrors the capture
+# layer's filename policy (capture._RESERVED_WINDOWS_NAMES).
+_UNPORTABLE_PATH_CHARACTERS = frozenset(':<>|?*"')
+_RESERVED_DEVICE_NAMES = frozenset(
+    {
+        "CON",
+        "PRN",
+        "AUX",
+        "NUL",
+        *(f"COM{i}" for i in range(1, 10)),
+        *(f"LPT{i}" for i in range(1, 10)),
+    }
+)
+
+
 def sha256_bytes(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
@@ -234,6 +262,11 @@ def _normalize_vault_path(value: Any) -> str:
         raise TransactionValidationError(
             "INVALID_WRITE_PATH", "path contains a control character or backslash"
         )
+    if any(character in _UNPORTABLE_PATH_CHARACTERS for character in value):
+        raise TransactionValidationError(
+            "UNPORTABLE_WRITE_PATH",
+            f"path contains a character that is unsafe on portable filesystems: {value}",
+        )
     parsed = PurePosixPath(value)
     if parsed.is_absolute() or value in {"", "."} or ".." in parsed.parts:
         raise TransactionValidationError(
@@ -254,6 +287,20 @@ def _normalize_vault_path(value: Any) -> str:
             "WRITE_PATH_TOO_LONG",
             f"path exceeds the {MAX_TRANSACTION_PATH_BYTES}-byte portability limit: {value}",
         )
+    for component in parsed.parts:
+        if component.endswith((".", " ")):
+            # Win32 strips trailing dots/spaces at the syscall boundary, so such
+            # a name silently aliases its stripped form — an alias class the
+            # casefold audit cannot observe.  Reject it everywhere.
+            raise TransactionValidationError(
+                "UNPORTABLE_WRITE_PATH",
+                f"path component may not end with a dot or space: {value}",
+            )
+        if component.split(".", 1)[0].upper() in _RESERVED_DEVICE_NAMES:
+            raise TransactionValidationError(
+                "UNPORTABLE_WRITE_PATH",
+                f"path component is a reserved device name: {value}",
+            )
     return normalized
 
 
@@ -281,10 +328,10 @@ def _safe_vault_path(vault_root: Path, value: Any) -> tuple[str, Path]:
             raise TransactionValidationError(
                 "UNSAFE_VAULT_PATH", f"cannot inspect {normalized}: {exc}"
             ) from exc
-        if stat.S_ISLNK(metadata.st_mode):
+        if is_name_surrogate(metadata):
             raise TransactionValidationError(
                 "SYMLINK_WRITE_PATH",
-                f"transaction paths may not traverse symlinks: {normalized}",
+                f"transaction paths may not traverse symlinks or junctions: {normalized}",
             )
         if index < len(parsed.parts) - 1 and not stat.S_ISDIR(metadata.st_mode):
             raise TransactionValidationError(
@@ -327,7 +374,7 @@ def _safe_directory(
                 "UNSAFE_RUNTIME_PATH",
                 f"cannot inspect runtime directory {relative}: {exc}",
             ) from exc
-        if stat.S_ISLNK(metadata.st_mode) or not stat.S_ISDIR(metadata.st_mode):
+        if is_name_surrogate(metadata) or not stat.S_ISDIR(metadata.st_mode):
             raise TransactionValidationError(
                 "UNSAFE_RUNTIME_PATH",
                 f"runtime directory is not a safe directory: {relative}",
@@ -351,15 +398,7 @@ def safe_transactions_root(vault_root: Path | str, *, create: bool = False) -> P
 
 
 def _supports_confined_dirfd() -> bool:
-    return (
-        os.name != "nt"
-        and hasattr(os, "O_DIRECTORY")
-        and os.open in os.supports_dir_fd
-        and os.mkdir in os.supports_dir_fd
-        and os.rename in os.supports_dir_fd
-        and os.stat in os.supports_dir_fd
-        and os.unlink in os.supports_dir_fd
-    )
+    return supports_confined_dirfd()
 
 
 def _open_parent_directory(
@@ -372,18 +411,20 @@ def _open_parent_directory(
 ) -> tuple[int, str]:
     """Open a target parent from the vault FD without following symlinks."""
 
+    if root_fd is None and not _supports_confined_dirfd():
+        # Callers gate on _supports_confined_dirfd(); this backstop turns a
+        # future unguarded call into a clean failure instead of AttributeError.
+        raise TransactionValidationError(
+            "UNSAFE_VAULT_PATH",
+            "directory-descriptor traversal is unavailable on this platform",
+        )
     normalized = (
         _normalize_vault_path(relative)
         if root_fd is not None
         else _safe_vault_path(vault_root, relative)[0]
     )
     parts = PurePosixPath(normalized).parts
-    flags = (
-        os.O_RDONLY
-        | os.O_DIRECTORY
-        | getattr(os, "O_CLOEXEC", 0)
-        | getattr(os, "O_NOFOLLOW", 0)
-    )
+    flags = directory_open_flags()
     if meta_fd is not None and parts[0] == ".vault-meta":
         descriptor = os.dup(meta_fd)
         walk_parts = parts[1:-1]
@@ -426,23 +467,40 @@ def _assert_no_existing_portable_alias(
         if root_fd is not None
         else _safe_vault_path(vault_root, relative)[0]
     )
-    flags = (
-        os.O_RDONLY
-        | os.O_DIRECTORY
-        | getattr(os, "O_CLOEXEC", 0)
-        | getattr(os, "O_NOFOLLOW", 0)
-    )
-    try:
-        descriptor = (
-            os.dup(root_fd) if root_fd is not None else os.open(vault_root, flags)
-        )
-    except FileNotFoundError:
-        return
+    flags = directory_open_flags()
+    handle: int | Path
+    if root_fd is not None:
+        handle = os.dup(root_fd)
+    elif _supports_confined_dirfd():
+        try:
+            handle = os.open(vault_root, flags)
+        except FileNotFoundError:
+            return
+    else:
+        # Degraded platforms (native Windows) walk by path.  _safe_vault_path
+        # above already rejected symlink/junction components lexically; each
+        # directory is re-checked immediately before enumeration below.
+        handle = canonical(vault_root)
     try:
         for index, part in enumerate(PurePosixPath(normalized).parts):
+            if isinstance(handle, Path):
+                try:
+                    assert_unaliased_directory(handle)
+                except (FileNotFoundError, NotADirectoryError):
+                    return
+                except OSError as exc:
+                    if exc.errno == errno.ELOOP:
+                        raise TransactionValidationError(
+                            "SYMLINK_WRITE_PATH",
+                            f"transaction paths may not traverse symlinks or junctions: {normalized}",
+                        ) from exc
+                    raise TransactionValidationError(
+                        "UNSAFE_VAULT_PATH",
+                        f"cannot enumerate siblings for {normalized}: {exc}",
+                    ) from exc
             try:
                 names: list[str] = []
-                with os.scandir(descriptor) as entries:
+                with os.scandir(handle) as entries:
                     for entry in entries:
                         names.append(entry.name)
                         if len(names) > MAX_PORTABLE_SIBLING_ENTRIES:
@@ -450,6 +508,13 @@ def _assert_no_existing_portable_alias(
                                 "VAULT_DIRECTORY_LIMIT",
                                 f"directory containing {normalized} exceeds the portable-name audit limit",
                             )
+            except FileNotFoundError:
+                if isinstance(handle, Path):
+                    return
+                raise TransactionValidationError(
+                    "UNSAFE_VAULT_PATH",
+                    f"cannot enumerate siblings for {normalized}: directory vanished",
+                ) from None
             except OSError as exc:
                 raise TransactionValidationError(
                     "UNSAFE_VAULT_PATH",
@@ -465,17 +530,21 @@ def _assert_no_existing_portable_alias(
                 )
             if part not in names or index == len(PurePosixPath(normalized).parts) - 1:
                 return
+            if isinstance(handle, Path):
+                handle = handle / part
+                continue
             try:
                 if index == 0 and part == ".vault-meta" and meta_fd is not None:
                     child = os.dup(meta_fd)
                 else:
-                    child = os.open(part, flags, dir_fd=descriptor)
+                    child = os.open(part, flags, dir_fd=handle)
             except (FileNotFoundError, NotADirectoryError):
                 return
-            os.close(descriptor)
-            descriptor = child
+            os.close(handle)
+            handle = child
     finally:
-        os.close(descriptor)
+        if isinstance(handle, int):
+            os.close(handle)
 
 
 def _safe_hash(
@@ -504,7 +573,7 @@ def _safe_hash(
                 "UNSAFE_VAULT_PATH",
                 f"transaction target is not a regular file: {normalized}",
             )
-        flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+        flags = read_open_flags()
         try:
             descriptor = os.open(path, flags)
         except OSError as exc:
@@ -523,9 +592,7 @@ def _safe_hash(
         except FileNotFoundError:
             return None
         try:
-            flags = (
-                os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
-            )
+            flags = read_open_flags()
             try:
                 descriptor = os.open(leaf, flags, dir_fd=parent_descriptor)
             except FileNotFoundError:
@@ -578,13 +645,7 @@ def _safe_file_state(
                     root_fd=root_fd,
                     meta_fd=meta_fd,
                 )
-                descriptor = os.open(
-                    leaf,
-                    os.O_RDONLY
-                    | getattr(os, "O_CLOEXEC", 0)
-                    | getattr(os, "O_NOFOLLOW", 0),
-                    dir_fd=parent_descriptor,
-                )
+                descriptor = os.open(leaf, read_open_flags(), dir_fd=parent_descriptor)
             except FileNotFoundError:
                 return None, None
             except OSError as exc:
@@ -601,12 +662,7 @@ def _safe_file_state(
                     "UNSAFE_VAULT_PATH",
                     f"transaction target is not regular: {normalized}",
                 )
-            descriptor = os.open(
-                path,
-                os.O_RDONLY
-                | getattr(os, "O_CLOEXEC", 0)
-                | getattr(os, "O_NOFOLLOW", 0),
-            )
+            descriptor = os.open(path, read_open_flags())
         before = os.fstat(descriptor)
         if not stat.S_ISREG(before.st_mode):
             raise TransactionValidationError(
@@ -632,12 +688,25 @@ def _safe_file_state(
                 "FILE_CHANGED_DURING_READ",
                 f"{normalized} changed while it was inspected",
             )
-        return digest.hexdigest(), after.st_mode & 0o777
+        return digest.hexdigest(), _portable_file_mode(after.st_mode)
     finally:
         if descriptor >= 0:
             os.close(descriptor)
         if parent_descriptor >= 0:
             os.close(parent_descriptor)
+
+
+def _portable_file_mode(st_mode: int) -> int:
+    """Permission bits for plan hashing, normalized on Windows.
+
+    The Windows CRT synthesizes 0o666/0o444 regardless of how the file was
+    created, which would make ``approval_sha256`` and the inspect ``modes``
+    output differ from every POSIX host for identical content.
+    """
+
+    if os.name == "nt":
+        return 0o644
+    return st_mode & 0o777
 
 
 def read_vault_regular(
@@ -673,13 +742,7 @@ def read_vault_regular(
                     root_fd=root_fd,
                     meta_fd=meta_fd,
                 )
-                descriptor = os.open(
-                    leaf,
-                    os.O_RDONLY
-                    | getattr(os, "O_CLOEXEC", 0)
-                    | getattr(os, "O_NOFOLLOW", 0),
-                    dir_fd=parent_descriptor,
-                )
+                descriptor = os.open(leaf, read_open_flags(), dir_fd=parent_descriptor)
             except FileNotFoundError:
                 if missing_ok:
                     return None
@@ -704,12 +767,7 @@ def read_vault_regular(
                     "UNSAFE_VAULT_PATH", f"vault file is not regular: {normalized}"
                 )
             try:
-                descriptor = os.open(
-                    path,
-                    os.O_RDONLY
-                    | getattr(os, "O_CLOEXEC", 0)
-                    | getattr(os, "O_NOFOLLOW", 0),
-                )
+                descriptor = os.open(path, read_open_flags())
             except OSError as exc:
                 raise TransactionValidationError(
                     "UNSAFE_VAULT_PATH", f"cannot open {normalized}: {exc}"
@@ -881,7 +939,7 @@ def _confined_vault_unlink(
         ) from exc
     descriptor = -1
     try:
-        flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+        flags = read_open_flags()
         try:
             descriptor = os.open(leaf, flags, dir_fd=parent_descriptor)
         except OSError as exc:
@@ -975,7 +1033,12 @@ def _identity_from_stat(value: os.stat_result) -> dict[str, Any]:
     }
 
 
-def _assert_no_portable_vault_leaf_alias_at(parent_fd: int, leaf: str) -> None:
+def _assert_no_portable_vault_leaf_alias_at(
+    parent: int | Path,
+    leaf: str,
+    *,
+    self_lstat: os.stat_result | None = None,
+) -> None:
     try:
         leaf_size = len(leaf.encode("utf-8"))
     except UnicodeEncodeError as exc:
@@ -996,7 +1059,7 @@ def _assert_no_portable_vault_leaf_alias_at(parent_fd: int, leaf: str) -> None:
         )
     count = 0
     try:
-        with os.scandir(parent_fd) as entries:
+        with os.scandir(parent) as entries:
             for entry in entries:
                 count += 1
                 if count > MAX_PORTABLE_SIBLING_ENTRIES:
@@ -1007,6 +1070,14 @@ def _assert_no_portable_vault_leaf_alias_at(parent_fd: int, leaf: str) -> None:
                 if entry.name != leaf and _portable_name_key(
                     entry.name
                 ) == _portable_name_key(leaf):
+                    if self_lstat is not None and _is_leaf_itself(
+                        parent, entry.name, self_lstat
+                    ):
+                        # On case-insensitive filesystems (APFS, NTFS) the
+                        # on-disk spelling of the vault itself can differ from
+                        # the spelling the caller typed; that is the same
+                        # object, not an alias.
+                        continue
                     raise TransactionValidationError(
                         "CASEFOLD_PATH_ALIAS",
                         f"vault parent already contains a portable alias for {leaf}: {entry.name}",
@@ -1017,23 +1088,102 @@ def _assert_no_portable_vault_leaf_alias_at(parent_fd: int, leaf: str) -> None:
         ) from exc
 
 
-def _assert_no_portable_vault_root_alias(vault_root: Path) -> None:
-    flags = (
-        os.O_RDONLY
-        | os.O_DIRECTORY
-        | getattr(os, "O_CLOEXEC", 0)
-        | getattr(os, "O_NOFOLLOW", 0)
-    )
+def _is_leaf_itself(parent: int | Path, name: str, self_lstat: os.stat_result) -> bool:
     try:
-        parent_fd = os.open(vault_root.parent, flags)
+        if isinstance(parent, int):
+            entry_stat = os.lstat(name, dir_fd=parent)
+        else:
+            entry_stat = os.lstat(parent / name)
+    except OSError:
+        return False
+    return is_same_object(entry_stat, self_lstat)
+
+
+def _assert_no_portable_vault_root_alias(vault_root: Path) -> None:
+    try:
+        self_lstat: os.stat_result | None = os.lstat(vault_root)
+    except OSError:
+        self_lstat = None
+    if _supports_confined_dirfd():
+        try:
+            parent_fd = os.open(vault_root.parent, directory_open_flags())
+        except OSError as exc:
+            raise TransactionValidationError(
+                "UNSAFE_VAULT_IDENTITY", f"cannot pin vault parent: {exc}"
+            ) from exc
+        try:
+            _assert_no_portable_vault_leaf_alias_at(
+                parent_fd, vault_root.name, self_lstat=self_lstat
+            )
+        finally:
+            os.close(parent_fd)
+        return
+    parent = canonical(vault_root).parent
+    try:
+        assert_unaliased_directory(parent)
     except OSError as exc:
         raise TransactionValidationError(
             "UNSAFE_VAULT_IDENTITY", f"cannot pin vault parent: {exc}"
         ) from exc
+    _assert_no_portable_vault_leaf_alias_at(
+        parent, vault_root.name, self_lstat=self_lstat
+    )
+
+
+def _path_mode_identity(vault: Path) -> dict[str, Any]:
+    """Identity for degraded (non-dirfd) platforms, from lstat alone.
+
+    Never opens a directory: the Windows CRT refuses ``os.open`` on
+    directories regardless of flags.
+    """
+
     try:
-        _assert_no_portable_vault_leaf_alias_at(parent_fd, vault_root.name)
-    finally:
-        os.close(parent_fd)
+        value = assert_unaliased_directory(vault)
+    except FileNotFoundError:
+        parent = vault.parent
+        try:
+            parent_stat = assert_unaliased_directory(parent)
+        except OSError as exc:
+            raise TransactionValidationError(
+                "UNSAFE_VAULT_IDENTITY", f"cannot identify vault directory: {exc}"
+            ) from exc
+        _require_stable_identity(parent_stat, parent)
+        _assert_no_portable_vault_leaf_alias_at(parent, vault.name)
+        try:
+            os.lstat(vault)
+        except FileNotFoundError:
+            return {
+                "state": "absent",
+                "parent_device": parent_stat.st_dev,
+                "parent_inode": parent_stat.st_ino,
+                "leaf": vault.name,
+            }
+        except OSError as exc:
+            raise TransactionValidationError(
+                "UNSAFE_VAULT_IDENTITY", f"cannot identify vault directory: {exc}"
+            ) from exc
+        raise TransactionValidationError(
+            "VAULT_IDENTITY_CHANGED", "vault appeared while its identity was read"
+        )
+    except OSError as exc:
+        if exc.errno == errno.ENOTDIR:
+            raise TransactionValidationError(
+                "VAULT_NOT_DIRECTORY", f"vault is not a directory: {vault}"
+            ) from exc
+        raise TransactionValidationError(
+            "UNSAFE_VAULT_IDENTITY", f"cannot identify vault directory: {exc}"
+        ) from exc
+    _require_stable_identity(value, vault)
+    return _identity_from_stat(value)
+
+
+def _require_stable_identity(value: os.stat_result, path: Path) -> None:
+    if value.st_ino == 0:
+        raise TransactionValidationError(
+            "UNSAFE_VAULT_IDENTITY",
+            f"filesystem does not expose stable file identity for {path} "
+            "(FAT/exFAT/some network shares); use an NTFS volume or WSL",
+        )
 
 
 def _vault_object_identity(
@@ -1044,6 +1194,8 @@ def _vault_object_identity(
     vault = canonical(vault_root)
     if root_fd is not None:
         return _identity_from_stat(os.fstat(root_fd))
+    if not _supports_confined_dirfd():
+        return _path_mode_identity(vault)
     try:
         descriptor = os.open(
             vault,
@@ -1209,6 +1361,30 @@ def _require_lock_dirfd_support() -> None:
             errno.ENOTSUP,
             "directory-descriptor lock confinement requires WSL/Linux or supported macOS",
         )
+
+
+_UNSUPPORTED_PLATFORM_MESSAGE = (
+    "vault writes require directory-descriptor confinement (WSL/Linux or "
+    "supported macOS); on native Windows run this command inside WSL — "
+    "read-only inspection and dry-runs work natively"
+)
+
+
+def _require_write_platform() -> None:
+    """Refuse vault mutation on hosts without dirfd confinement, cleanly.
+
+    Called before any side effect (directory creation, backup staging) so a
+    refused ``--apply`` leaves nothing behind.
+    """
+
+    try:
+        _require_lock_dirfd_support()
+    except OSError as exc:
+        if exc.errno == errno.ENOTSUP:
+            raise TransactionValidationError(
+                "UNSUPPORTED_PLATFORM", _UNSUPPORTED_PLATFORM_MESSAGE
+            ) from exc
+        raise
 
 
 def _open_lock_parent_fd(
@@ -1577,7 +1753,9 @@ class MutationLock:
         try:
             assert self._root_parent_fd is not None
             _assert_no_portable_vault_leaf_alias_at(
-                self._root_parent_fd, self._root_name
+                self._root_parent_fd,
+                self._root_name,
+                self_lstat=os.fstat(self._root_fd),
             )
         except TransactionValidationError as exc:
             raise TransactionError(
@@ -1609,6 +1787,10 @@ class MutationLock:
         try:
             root_fd = _open_lock_root_fd(self.vault_root)
         except OSError as exc:
+            if exc.errno == errno.ENOTSUP:
+                raise TransactionValidationError(
+                    "UNSUPPORTED_PLATFORM", _UNSUPPORTED_PLATFORM_MESSAGE
+                ) from exc
             if exc.errno in {errno.ELOOP, errno.ENOTDIR}:
                 raise TransactionValidationError(
                     "SYMLINK_WRITE_PATH",
@@ -1639,7 +1821,9 @@ class MutationLock:
             )
         try:
             _assert_no_portable_vault_leaf_alias_at(
-                self._root_parent_fd, self._root_name
+                self._root_parent_fd,
+                self._root_name,
+                self_lstat=os.fstat(root_fd),
             )
         except TransactionValidationError:
             self._close_descriptors()
@@ -2377,10 +2561,7 @@ def _load_bundle(
             raise ValueError(
                 f"bundle exceeds the {MAX_TRANSACTION_BUNDLE_BYTES}-byte limit"
             )
-        descriptor = os.open(
-            path,
-            os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0),
-        )
+        descriptor = os.open(path, read_open_flags())
         opened = os.fstat(descriptor)
         if (
             not stat.S_ISREG(opened.st_mode)
@@ -3594,6 +3775,15 @@ def _validated_recovery_writes(
         if (
             unicodedata.normalize("NFC", supplied_path) != supplied_path
             or len(supplied_path.encode("utf-8")) > MAX_TRANSACTION_PATH_BYTES
+            or any(
+                character in _UNPORTABLE_PATH_CHARACTERS
+                for character in supplied_path
+            )
+            or any(
+                component.endswith((".", " "))
+                or component.split(".", 1)[0].upper() in _RESERVED_DEVICE_NAMES
+                for component in parsed_path.parts
+            )
         ):
             raise TransactionRecoveryError(
                 "CORRUPT_JOURNAL",
@@ -4074,15 +4264,9 @@ def inspect_bundle(
             "INVALID_OPERATION_TYPE", f"unsupported operation_type: {operation_type!r}"
         )
     root_fd: int | None = None
-    if vault.exists():
-        flags = (
-            os.O_RDONLY
-            | os.O_DIRECTORY
-            | getattr(os, "O_CLOEXEC", 0)
-            | getattr(os, "O_NOFOLLOW", 0)
-        )
+    if vault.exists() and _supports_confined_dirfd():
         try:
-            root_fd = os.open(vault, flags)
+            root_fd = os.open(vault, directory_open_flags())
         except OSError as exc:
             raise TransactionValidationError(
                 "UNSAFE_VAULT_IDENTITY", f"cannot pin vault directory: {exc}"
@@ -4101,7 +4285,8 @@ def inspect_bundle(
                 Path(directory),
                 root_fd=root_fd,
             )
-        if root_fd is not None and _vault_object_identity(vault) != vault_identity:
+        recheck_identity = root_fd is not None or not _supports_confined_dirfd()
+        if recheck_identity and _vault_object_identity(vault) != vault_identity:
             raise TransactionValidationError(
                 "VAULT_IDENTITY_CHANGED", "vault changed while the plan was inspected"
             )
@@ -4138,6 +4323,7 @@ def apply_bundle(
     reviewed_vault_identity: Mapping[str, Any] | None = None,
     expected_current_vault_identity: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
+    _require_write_platform()
     vault = canonical(vault_root)
     if not vault.is_dir():
         raise TransactionValidationError(

--- a/claude_obsidian/transaction.py
+++ b/claude_obsidian/transaction.py
@@ -262,11 +262,6 @@ def _normalize_vault_path(value: Any) -> str:
         raise TransactionValidationError(
             "INVALID_WRITE_PATH", "path contains a control character or backslash"
         )
-    if any(character in _UNPORTABLE_PATH_CHARACTERS for character in value):
-        raise TransactionValidationError(
-            "UNPORTABLE_WRITE_PATH",
-            f"path contains a character that is unsafe on portable filesystems: {value}",
-        )
     parsed = PurePosixPath(value)
     if parsed.is_absolute() or value in {"", "."} or ".." in parsed.parts:
         raise TransactionValidationError(
@@ -287,7 +282,28 @@ def _normalize_vault_path(value: Any) -> str:
             "WRITE_PATH_TOO_LONG",
             f"path exceeds the {MAX_TRANSACTION_PATH_BYTES}-byte portability limit: {value}",
         )
-    for component in parsed.parts:
+    return normalized
+
+
+def _assert_portable_write_path(value: str) -> None:
+    """Reject NEW write destinations that portable filesystems cannot host.
+
+    Applies only where a plan proposes writes — never to reads of existing
+    vault content, so pre-existing files with historically accepted names stay
+    readable, indexable, and recoverable.
+    """
+
+    if any(character in _UNPORTABLE_PATH_CHARACTERS for character in value):
+        # ``:`` names an NTFS alternate data stream, invisible to directory
+        # enumeration; the rest are Win32-invalid filename characters.
+        raise TransactionValidationError(
+            "UNPORTABLE_WRITE_PATH",
+            f"path contains a character that is unsafe on portable filesystems: {value}",
+        )
+    for component in value.split("/"):
+        if component in {"", ".", ".."}:
+            # Structural defects; _normalize_vault_path owns their error codes.
+            continue
         if component.endswith((".", " ")):
             # Win32 strips trailing dots/spaces at the syscall boundary, so such
             # a name silently aliases its stripped form — an alias class the
@@ -301,7 +317,6 @@ def _normalize_vault_path(value: Any) -> str:
                 "UNPORTABLE_WRITE_PATH",
                 f"path component is a reserved device name: {value}",
             )
-    return normalized
 
 
 def _safe_vault_path(vault_root: Path, value: Any) -> tuple[str, Path]:
@@ -1089,6 +1104,15 @@ def _assert_no_portable_vault_leaf_alias_at(
 
 
 def _is_leaf_itself(parent: int | Path, name: str, self_lstat: os.stat_result) -> bool:
+    """True when a differently spelled sibling entry IS the vault object.
+
+    Deliberate tolerance: two directory entries naming the same object (a
+    case-insensitive volume's single entry, or a same-parent bind mount) are
+    one vault, so treating them as a CASEFOLD_PATH_ALIAS would reject the
+    vault itself.  Distinct objects — including a junction pointing at the
+    vault, whose reparse point lstats with its own identity — still flag.
+    """
+
     try:
         if isinstance(parent, int):
             entry_stat = os.lstat(name, dir_fd=parent)
@@ -1357,7 +1381,7 @@ def _require_lock_dirfd_support() -> None:
         or any(function not in os.supports_dir_fd for function in required)
         or os.stat not in os.supports_follow_symlinks
     ):
-        raise OSError(
+        raise _PlatformConfinementUnavailable(
             errno.ENOTSUP,
             "directory-descriptor lock confinement requires WSL/Linux or supported macOS",
         )
@@ -1370,6 +1394,16 @@ _UNSUPPORTED_PLATFORM_MESSAGE = (
 )
 
 
+class _PlatformConfinementUnavailable(OSError):
+    """ENOTSUP raised by the platform capability gate itself.
+
+    Distinct type so callers can map exactly this condition to
+    UNSUPPORTED_PLATFORM without also swallowing a genuine EOPNOTSUPP that a
+    filesystem returns on an otherwise supported host (Linux aliases the two
+    errno values).
+    """
+
+
 def _require_write_platform() -> None:
     """Refuse vault mutation on hosts without dirfd confinement, cleanly.
 
@@ -1379,12 +1413,10 @@ def _require_write_platform() -> None:
 
     try:
         _require_lock_dirfd_support()
-    except OSError as exc:
-        if exc.errno == errno.ENOTSUP:
-            raise TransactionValidationError(
-                "UNSUPPORTED_PLATFORM", _UNSUPPORTED_PLATFORM_MESSAGE
-            ) from exc
-        raise
+    except _PlatformConfinementUnavailable as exc:
+        raise TransactionValidationError(
+            "UNSUPPORTED_PLATFORM", _UNSUPPORTED_PLATFORM_MESSAGE
+        ) from exc
 
 
 def _open_lock_parent_fd(
@@ -1787,7 +1819,7 @@ class MutationLock:
         try:
             root_fd = _open_lock_root_fd(self.vault_root)
         except OSError as exc:
-            if exc.errno == errno.ENOTSUP:
+            if isinstance(exc, _PlatformConfinementUnavailable):
                 raise TransactionValidationError(
                     "UNSUPPORTED_PLATFORM", _UNSUPPORTED_PLATFORM_MESSAGE
                 ) from exc
@@ -2662,7 +2694,7 @@ def _raw_write_bytes(raw: Mapping[str, Any], bundle_dir: Path) -> bytes:
             "TRANSACTION_FILE_TOO_LARGE",
             f"content file exceeds {MAX_TRANSACTION_FILE_BYTES} bytes: {source}",
         )
-    flags = os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    flags = read_open_flags()
     descriptor = -1
     try:
         descriptor = os.open(source, flags)
@@ -3244,6 +3276,12 @@ def _prepare_writes(
             "TRANSACTION_WRITE_LIMIT",
             f"bundle exceeds the {MAX_TRANSACTION_WRITES}-write recovery limit",
         )
+    # Lexical portability pre-pass before any filesystem probe so unportable
+    # plans are rejected with the same code on every platform (a Windows lstat
+    # of e.g. "a:b.md" would otherwise fail first with a different error).
+    for raw in raw_writes:
+        if isinstance(raw, dict) and isinstance(raw.get("path"), str):
+            _assert_portable_write_path(raw["path"])
     expected = bundle.get("expected_hashes")
     if not isinstance(expected, dict):
         raise TransactionValidationError(
@@ -3775,16 +3813,10 @@ def _validated_recovery_writes(
         if (
             unicodedata.normalize("NFC", supplied_path) != supplied_path
             or len(supplied_path.encode("utf-8")) > MAX_TRANSACTION_PATH_BYTES
-            or any(
-                character in _UNPORTABLE_PATH_CHARACTERS
-                for character in supplied_path
-            )
-            or any(
-                component.endswith((".", " "))
-                or component.split(".", 1)[0].upper() in _RESERVED_DEVICE_NAMES
-                for component in parsed_path.parts
-            )
         ):
+            # Deliberately NOT mirroring _assert_portable_write_path here:
+            # recovery must be able to roll back a journal written by a release
+            # that still accepted such paths.
             raise TransactionRecoveryError(
                 "CORRUPT_JOURNAL",
                 f"journal write {index} has a non-portable path",

--- a/config/release-allowlist.json
+++ b/config/release-allowlist.json
@@ -29,6 +29,7 @@
     "wiki/meta/**"
   ],
   "include_files": [
+    ".gitattributes",
     ".gitignore",
     "AGENTS.md",
     "ATTRIBUTION.md",

--- a/docs/compound-vault-guide.md
+++ b/docs/compound-vault-guide.md
@@ -73,7 +73,10 @@ capture queue, checkpoint state, and retrieval publications remain pinned for
 their complete mutation window. Concurrent alias replacement therefore fails
 closed or rolls back without touching a replacement tree. These guarantees
 require WSL/Linux or supported macOS; native Windows and Git Bash are not
-supported mutation hosts.
+supported mutation hosts and are refused with `UNSUPPORTED_PLATFORM` before
+any side effect. Read-only inspection and dry-runs run natively on Windows
+using point-in-time lstat validation (symlink and junction rejection) instead
+of descriptor pinning.
 
 Raw source bytes can be supplied through hash-checked binary `content_file`
 writes, but their destination mode is create-only. Address allocation, page

--- a/scripts/bm25-index.py
+++ b/scripts/bm25-index.py
@@ -210,8 +210,8 @@ def parse_top_k(value):
 def _directory_flags():
     return (
         os.O_RDONLY
-        | os.O_DIRECTORY
-        | os.O_NOFOLLOW
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
         | getattr(os, "O_CLOEXEC", 0)
         | getattr(os, "O_NONBLOCK", 0)
     )
@@ -389,7 +389,13 @@ def source_page_is_current(data, vault_root, hash_cache, *, vault_root_fd=None):
         return False, "missing page_path"
 
     rel = Path(page_path)
-    if rel.is_absolute():
+    # On Windows a drive-less rooted path ("/x") and a drive prefix ("C:x")
+    # are not "absolute" under pathlib but still escape a joined root.
+    if (
+        rel.is_absolute()
+        or page_path.startswith(("/", "\\"))
+        or re.match(r"^[A-Za-z]:", page_path)
+    ):
         return False, "absolute page_path"
 
     root = vault_root.resolve()
@@ -413,7 +419,10 @@ def source_page_is_current(data, vault_root, hash_cache, *, vault_root_fd=None):
                     return False, "page_path is outside wiki"
                 if not source.is_file():
                     return False, "source page missing"
-                text = source.read_text(encoding="utf-8", errors="replace")
+                # Byte-identical with the fd branch below: read_text would
+                # CRLF-normalize, making the same page hash two different ways
+                # and permanently marking every chunk stale on CRLF vaults.
+                text = source.read_bytes().decode("utf-8", errors="replace")
             else:
                 raw = read_vault_regular(
                     root,

--- a/scripts/contextual-prefix.py
+++ b/scripts/contextual-prefix.py
@@ -848,6 +848,10 @@ def collect_pages(target):
             pages.append(path)
         return sorted(pages)
     p = Path(target)
+    # Deliberately no rooted-/drive-prefix rejection here (unlike the chunk
+    # validators in rerank.py/bm25-index.py): this is CLI target selection, and
+    # process_selection() enforces containment via resolve()+is_relative_to
+    # against WIKI_DIR plus _safe_vault_path before any chunk is touched.
     if not p.is_absolute():
         p = VAULT_ROOT / p
     return [p]

--- a/scripts/contextual-prefix.py
+++ b/scripts/contextual-prefix.py
@@ -185,8 +185,8 @@ def sha256(text):
 def _directory_flags():
     return (
         os.O_RDONLY
-        | os.O_DIRECTORY
-        | os.O_NOFOLLOW
+        | getattr(os, "O_DIRECTORY", 0)
+        | getattr(os, "O_NOFOLLOW", 0)
         | getattr(os, "O_CLOEXEC", 0)
         | getattr(os, "O_NONBLOCK", 0)
     )
@@ -393,7 +393,10 @@ def read_page(path, *, root_fd=None):
     if root_fd is None:
         if not path.is_file():
             raise SystemExit(EXIT_PAGE_MISSING)
-        return path.read_text(encoding="utf-8", errors="replace")
+        # Byte-identical with the fd branch below: read_text would CRLF-
+        # normalize, so the same page would hash differently per branch and
+        # every derived chunk would be treated as stale on CRLF vaults.
+        return path.read_bytes().decode("utf-8", errors="replace")
     try:
         relative = path.relative_to(VAULT_ROOT).as_posix()
         raw = read_vault_regular(

--- a/scripts/rerank.py
+++ b/scripts/rerank.py
@@ -378,7 +378,13 @@ def load_chunk(chunk_rel_path):
     if not isinstance(chunk_rel_path, str) or not chunk_rel_path:
         return None
     rel = Path(chunk_rel_path)
-    if rel.is_absolute():
+    # On Windows "/x" and "C:x" are not "absolute" under pathlib but still
+    # escape a joined root.
+    if (
+        rel.is_absolute()
+        or chunk_rel_path.startswith(("/", "\\"))
+        or re.match(r"^[A-Za-z]:", chunk_rel_path)
+    ):
         return None
     p = (VAULT_ROOT / rel).resolve()
     if not p.is_relative_to((META_DIR / "chunks").resolve()):

--- a/scripts/retrieve.py
+++ b/scripts/retrieve.py
@@ -212,8 +212,11 @@ def chunk_is_current(hit, chunk, page_path, page_hash_cache):
     cache_key = str(page_path)
     if cache_key not in page_hash_cache:
         try:
+            # read_bytes keeps CRLF content byte-identical with the hash the
+            # chunker computed; read_text would normalize newlines and drop
+            # every candidate as stale on CRLF vaults.
             page_hash_cache[cache_key] = sha256(
-                page_path.read_text(encoding="utf-8", errors="replace")
+                page_path.read_bytes().decode("utf-8", errors="replace")
             )
         except OSError:
             page_hash_cache[cache_key] = None

--- a/scripts/tiling-check.py
+++ b/scripts/tiling-check.py
@@ -237,7 +237,7 @@ def load_cache(current_model: str) -> dict:
     if not CACHE_PATH.exists():
         return {"version": 1, "model": current_model, "embeddings": {}}
     try:
-        with CACHE_PATH.open() as f:
+        with CACHE_PATH.open(encoding="utf-8") as f:
             data = json.load(f)
     except (OSError, json.JSONDecodeError) as exc:
         log(f"ERR: cache read failed: {exc}")
@@ -287,7 +287,7 @@ def load_thresholds() -> dict:
             "bands": {"error": 0.90, "review": 0.80},
             "calibrated": False, "calibration_pairs_labeled": 0,
         }
-    with THRESHOLDS_PATH.open() as f:
+    with THRESHOLDS_PATH.open(encoding="utf-8") as f:
         return json.load(f)
 
 
@@ -500,7 +500,7 @@ def cmd_peek(ollama_url: str, model: str) -> int:
     diag["cache_model"] = None
     if diag["cache_present"]:
         try:
-            with CACHE_PATH.open() as f:
+            with CACHE_PATH.open(encoding="utf-8") as f:
                 c = json.load(f)
             diag["cache_readable"] = (c.get("version") == 1
                                       and isinstance(c.get("embeddings"), dict))
@@ -513,7 +513,7 @@ def cmd_peek(ollama_url: str, model: str) -> int:
     diag["thresholds_readable"] = False
     if diag["thresholds_present"]:
         try:
-            with THRESHOLDS_PATH.open() as f:
+            with THRESHOLDS_PATH.open(encoding="utf-8") as f:
                 t = json.load(f)
             diag["thresholds_readable"] = True
             diag["thresholds_calibrated"] = bool(t.get("calibrated", False))

--- a/tests/test_bm25_index.py
+++ b/tests/test_bm25_index.py
@@ -644,6 +644,22 @@ def test_hashless_or_malformed_chunks_are_never_indexed():
         page.unlink()
 
 
+def test_crlf_source_page_stays_current():
+    # Regression: source_page_is_current hashed pages via read_text (which
+    # normalizes CRLF) while the locked build path hashed raw bytes, so every
+    # chunk of a CRLF page was permanently reported stale.  Both sides must
+    # hash identical bytes.
+    with tempfile.TemporaryDirectory() as tmpdir:
+        root = Path(tmpdir)
+        page = root / "wiki" / "fake" / "c-000001.md"
+        page.parent.mkdir(parents=True, exist_ok=True)
+        page.write_bytes(b"crlf line one\r\ncrlf line two\r\n")
+        text = page.read_bytes().decode("utf-8", errors="replace")
+        record = synthetic_chunk(0, "c-000001", text, text)
+        current, reason = bm25.source_page_is_current(record, root, {})
+        assert_true(f"CRLF page stays current ({reason})", current)
+
+
 def test_cli_build_refuses_shared_vault_writer_lock():
     with tempfile.TemporaryDirectory() as tmpdir:
         root = Path(tmpdir)
@@ -982,6 +998,7 @@ def main():
     test_query_score_monotonicity()
     test_rebuild_reconciles_changed_and_deleted_source_pages()
     test_hashless_or_malformed_chunks_are_never_indexed()
+    test_crlf_source_page_stays_current()
     test_cli_build_refuses_shared_vault_writer_lock()
     test_pinned_build_survives_lexical_root_replacement()
     test_pinned_build_never_follows_meta_or_bm25_aliases()

--- a/tests/test_bm25_index.py
+++ b/tests/test_bm25_index.py
@@ -795,7 +795,12 @@ def test_pinned_build_never_follows_meta_or_bm25_aliases():
             outside_leaf = outside_bm25 / "index.json"
             outside_leaf.write_bytes(b"outside-index\n")
             (safe_meta / "bm25").symlink_to(outside_bm25, target_is_directory=True)
-            safe_fd = os.open(safe_meta, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
+            safe_fd = os.open(
+                safe_meta,
+                os.O_RDONLY
+                | getattr(os, "O_DIRECTORY", 0)
+                | getattr(os, "O_NOFOLLOW", 0),
+            )
             try:
                 try:
                     bm25.write_index({"schema_version": 1}, meta_fd=safe_fd)

--- a/tests/test_contextual_prefix.py
+++ b/tests/test_contextual_prefix.py
@@ -698,6 +698,17 @@ def test_chunk_parent_swap_never_redirects_atomic_publication() -> None:
             ) = original_paths
 
 
+def test_read_page_preserves_crlf_bytes() -> None:
+    # Regression: read_page previously used read_text, which normalizes CRLF,
+    # so the chunker's page_body_hash diverged from the byte-exact hash used
+    # under the writer lock and by the retriever.
+    with tempfile.TemporaryDirectory() as tmpdir:
+        page = Path(tmpdir) / "c.md"
+        page.write_bytes(b"line one\r\nline two\r\n")
+        text = cp.read_page(page)
+        assert "\r\n" in text, "read_page must not normalize line endings"
+
+
 def main():
     print("=== test_contextual_prefix.py ===")
     test_below_floor_returns_none()
@@ -717,6 +728,7 @@ def main():
     test_prefix_generation_refuses_shared_vault_writer_lock()
     test_pinned_contextual_write_survives_root_replacement()
     test_chunk_parent_swap_never_redirects_atomic_publication()
+    test_read_page_preserves_crlf_bytes()
     print("\nAll contextual-prefix tests passed.")
 
 

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import fnmatch
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -112,6 +113,12 @@ class CanonicalContractTests(unittest.TestCase):
     def test_canonical_core_capabilities_report_only_behavioral_verification(
         self,
     ) -> None:
+        if os.name == "nt":
+            self.skipTest(
+                "wiki/wiki-lint verifiers exercise vault mutation, which native "
+                "Windows refuses by design (UNSUPPORTED_PLATFORM), so verified "
+                "capabilities report degraded here"
+            )
         report = evaluate_capabilities(ROOT, verify=True)
         core = {
             item["id"]: item

--- a/tests/test_legacy_lock.py
+++ b/tests/test_legacy_lock.py
@@ -151,11 +151,13 @@ class LegacyLockRuntimeRaceTests(unittest.TestCase):
             self.assertEqual(component_error.exception.exit_code, 4)
 
     def test_lock_directory_enumeration_is_cardinality_bounded(self) -> None:
+        if os.name == "nt":
+            self.skipTest("fd-based directory enumeration is POSIX-only")
         with tempfile.TemporaryDirectory() as directory:
             locks = Path(directory)
             (locks / "one").write_text("x", encoding="utf-8")
             (locks / "two").write_text("x", encoding="utf-8")
-            descriptor = os.open(locks, os.O_RDONLY | os.O_DIRECTORY)
+            descriptor = os.open(locks, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
             try:
                 with (
                     mock.patch.object(legacy_lock, "MAX_LOCK_DIRECTORY_ENTRIES", 1),

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -17,7 +17,11 @@ from claude_obsidian.paths import (
     VaultSelectionError,
     assert_not_plugin_tree,
     assert_within,
+    directory_open_flags,
+    is_same_object,
+    read_open_flags,
     resolve_vault_root,
+    supports_confined_dirfd,
 )
 
 
@@ -235,6 +239,29 @@ def test_product_tree_exclusion_uses_portable_case_and_unicode_identity() -> Non
             raise AssertionError("post-casefold canonical aliases must be rejected")
 
 
+def test_platform_flag_helpers_degrade_without_posix_flags() -> None:
+    import stat as stat_helper
+
+    directory_flags = directory_open_flags()
+    read_flags = read_open_flags()
+    assert directory_flags & os.O_RDONLY == os.O_RDONLY
+    assert read_flags & os.O_RDONLY == os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        assert directory_flags & os.O_DIRECTORY
+        saved = os.O_DIRECTORY
+        del os.O_DIRECTORY
+        try:
+            assert directory_open_flags() & saved == 0
+            assert not supports_confined_dirfd()
+        finally:
+            os.O_DIRECTORY = saved
+    fake_zero = os.stat_result((stat_helper.S_IFDIR, 0, 3, 1, 0, 0, 0, 0, 0, 0))
+    fake_real = os.stat_result((stat_helper.S_IFDIR, 42, 3, 1, 0, 0, 0, 0, 0, 0))
+    assert is_same_object(fake_real, fake_real)
+    assert not is_same_object(fake_zero, fake_zero), "zero inode is never equal"
+    assert not is_same_object(fake_real, fake_zero)
+
+
 def main() -> None:
     test_precedence_and_config()
     test_plugin_root_rejected_implicitly_and_explicitly()
@@ -245,6 +272,7 @@ def main() -> None:
     test_workspace_config_root_must_be_an_object()
     test_workspace_config_rejects_ambiguous_or_nonregular_authority()
     test_product_tree_exclusion_uses_portable_case_and_unicode_identity()
+    test_platform_flag_helpers_degrade_without_posix_flags()
     print("All path tests passed.")
 
 

--- a/tests/test_retrieve.py
+++ b/tests/test_retrieve.py
@@ -1078,6 +1078,34 @@ def test_chunk_currency_rejects_hashless_or_malformed_legacy_records():
             )
 
 
+def test_chunk_currency_accepts_crlf_pages():
+    # Regression: chunk_is_current hashed pages via read_text (CRLF-normalizing),
+    # so vaults with CRLF line endings dropped every candidate as stale and
+    # retrieval returned zero results.  The hash must match the chunker's
+    # byte-exact reading of the same page.
+    with tempfile.TemporaryDirectory() as tmpdir:
+        page = Path(tmpdir) / "wiki/fake/c-000001.md"
+        page.parent.mkdir(parents=True)
+        page.write_bytes(b"crlf line one\r\ncrlf line two\r\n")
+        page_text = page.read_bytes().decode("utf-8", errors="replace")
+        chunk = {
+            "page_address": "c-000001",
+            "chunk_index": 0,
+            "raw_text": page_text,
+            "body_hash": sha256_text(page_text),
+            "page_body_hash": sha256_text(page_text),
+        }
+        hit = {
+            "chunk_id": "c-000001:0",
+            "body_hash": chunk["body_hash"],
+            "page_body_hash": chunk["page_body_hash"],
+        }
+        assert_true(
+            "CRLF page chunk is current",
+            retrieve.chunk_is_current(hit, chunk, page, {}),
+        )
+
+
 # ─── M8 closure: --explain and --no-rerank flag coverage ─────────────────────
 def test_explain_flag_adds_diagnostics_block():
     """v1.7.2 / closes audit M8: --explain must include an 'explain' diagnostics block."""
@@ -1277,6 +1305,7 @@ def main():
     test_dedupe_happens_before_final_top_k()
     test_retrieve_skips_page_deleted_after_index_build()
     test_chunk_currency_rejects_hashless_or_malformed_legacy_records()
+    test_chunk_currency_accepts_crlf_pages()
     test_explain_flag_adds_diagnostics_block()
     test_no_rerank_flag_strategy_bm25_only()
     print("\nAll retrieve tests passed.")

--- a/tests/test_windows_compat.py
+++ b/tests/test_windows_compat.py
@@ -1,0 +1,476 @@
+#!/usr/bin/env python3
+"""Windows compatibility tests for the degraded (non-dirfd) vault paths.
+
+On POSIX these tests simulate the degraded platform by disabling the dirfd
+capability probes and removing ``os.O_DIRECTORY`` (safe: every test file runs
+in its own process).  On real Windows the same branches run natively with no
+patching, plus a few native-only assertions.
+
+What the simulation CANNOT prove (covered only by the windows-smoke CI job on
+real Windows): CRT text-mode translation (O_BINARY), ``os.open`` refusing
+directories (EACCES), Win32 filename stripping, junction/reparse semantics,
+case-insensitive ``Path.resolve`` normalization, and NTFS stat identity.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import errno
+import io
+import json
+import os
+import stat as stat_module
+import sys
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+import claude_obsidian.cli as cli_module
+import claude_obsidian.paths as paths_module
+import claude_obsidian.transaction as transaction_module
+from claude_obsidian.transaction import (
+    BUNDLE_SCHEMA,
+    TransactionValidationError,
+    apply_bundle,
+    inspect_bundle,
+)
+
+IS_WINDOWS = os.name == "nt"
+
+
+def make_vault(root: Path) -> Path:
+    root.mkdir(parents=True)
+    (root / ".obsidian").mkdir()
+    (root / "wiki").mkdir()
+    (root / ".raw").mkdir()
+    return root
+
+
+def bundle(operation_id: str, writes: list[dict], expected: dict | None = None) -> dict:
+    preconditions = {write["path"]: None for write in writes}
+    if expected is not None:
+        preconditions.update(expected)
+    return {
+        "schema": BUNDLE_SCHEMA,
+        "operation_id": operation_id,
+        "operation_type": "generic",
+        "expected_hashes": preconditions,
+        "writes": writes,
+    }
+
+
+@contextlib.contextmanager
+def windows_mode():
+    """Force the degraded non-dirfd branches on POSIX; no-op on Windows."""
+
+    if IS_WINDOWS:
+        yield
+        return
+    saved_flag = getattr(os, "O_DIRECTORY", None)
+    with (
+        mock.patch.object(paths_module, "supports_confined_dirfd", lambda: False),
+        mock.patch.object(
+            transaction_module, "_supports_confined_dirfd", lambda: False
+        ),
+    ):
+        if saved_flag is not None:
+            del os.O_DIRECTORY
+        try:
+            yield
+        finally:
+            if saved_flag is not None:
+                os.O_DIRECTORY = saved_flag
+
+
+def expect_validation_error(code: str, callable_, *args, **kwargs):
+    try:
+        callable_(*args, **kwargs)
+    except TransactionValidationError as exc:
+        assert exc.code == code, f"expected {code}, got {exc.code}: {exc}"
+        return exc
+    raise AssertionError(f"expected TransactionValidationError {code}")
+
+
+def test_inspect_dry_run_succeeds_without_dirfd() -> None:
+    with tempfile.TemporaryDirectory() as td, windows_mode():
+        vault = make_vault(Path(td) / "vault")
+        # CRLF bytes prove hash stability; on real Windows this additionally
+        # exercises O_BINARY (text-mode reads would strip the \r).
+        existing = vault / "wiki" / "Existing.md"
+        existing.write_bytes(b"# Existing\r\nline two\r\n")
+        existing_hash = transaction_module.sha256_file(existing)
+        plan = inspect_bundle(
+            vault,
+            bundle(
+                "win-dry-run",
+                [
+                    {"path": "wiki/A.md", "mode": "create", "content": "# A\n"},
+                    {
+                        "path": "wiki/Existing.md",
+                        "mode": "replace",
+                        "content": "# Replaced\n",
+                    },
+                ],
+                {"wiki/Existing.md": existing_hash},
+            ),
+        )
+        assert plan["valid"] is True
+        assert plan["changed_paths"] == ["wiki/A.md", "wiki/Existing.md"]
+        identity = plan["vault_identity"]
+        assert identity["state"] == "existing"
+        assert isinstance(identity["device"], int)
+        assert isinstance(identity["inode"], int)
+        assert plan["approval_sha256"]
+
+
+def test_vault_root_alias_rejected_without_dirfd() -> None:
+    with tempfile.TemporaryDirectory() as td, windows_mode():
+        import unicodedata
+
+        parent = Path(td) / "parent"
+        if IS_WINDOWS:
+            # NTFS cannot host a pure case alias; use an NFC/NFD pair of the
+            # same name, which it preserves as distinct directory entries
+            # sharing one portable key.
+            accented = "va" + chr(0xFA) + "lt"  # vault with u-acute
+            vault = make_vault(parent / unicodedata.normalize("NFC", accented))
+            alias = parent / unicodedata.normalize("NFD", accented)
+        else:
+            vault = make_vault(parent / "vault")
+            alias = parent / "Vault"
+        try:
+            alias.mkdir()
+        except (FileExistsError, OSError):
+            return  # case-insensitive POSIX volume: alias not constructible
+        expect_validation_error(
+            "CASEFOLD_PATH_ALIAS",
+            inspect_bundle,
+            vault,
+            bundle("root-alias", [{"path": "wiki/A.md", "mode": "create", "content": "x"}]),
+        )
+
+
+def test_write_path_alias_rejected_without_dirfd() -> None:
+    import unicodedata
+
+    with tempfile.TemporaryDirectory() as td, windows_mode():
+        vault = make_vault(Path(td) / "vault")
+        if IS_WINDOWS:
+            # On-disk NFD spelling vs NFC bundle path: same portable key,
+            # different entry name (bundle paths must themselves be NFC).
+            accented = "p" + chr(0xE1) + "ge.md"  # page with a-acute
+            on_disk = unicodedata.normalize("NFD", accented)
+            target = "wiki/" + unicodedata.normalize("NFC", accented)
+        else:
+            on_disk = "page.md"
+            target = "wiki/Page.md"
+        (vault / "wiki" / on_disk).write_text("x", encoding="utf-8")
+        expect_validation_error(
+            "CASEFOLD_PATH_ALIAS",
+            inspect_bundle,
+            vault,
+            bundle(
+                "write-alias",
+                [{"path": target, "mode": "create", "content": "y"}],
+            ),
+        )
+
+
+def test_no_self_alias_false_positive() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        parent = Path(td) / "parent"
+        vault = make_vault(parent / "vault")
+        operation = bundle(
+            "self-alias", [{"path": "wiki/A.md", "mode": "create", "content": "x"}]
+        )
+        with windows_mode():
+            assert inspect_bundle(vault, operation)["valid"] is True
+        if IS_WINDOWS:
+            # Case-insensitive resolve() must canonicalize the typed spelling
+            # so the vault is never reported as its own alias.
+            assert inspect_bundle(parent / "VAULT", operation)["valid"] is True
+        else:
+            # Unit-level equivalent of the case-insensitive-volume scenario:
+            # scandir shows "vault" while the caller spelled "VAULT"; with the
+            # vault's own lstat supplied and matching, the entry is recognized
+            # as the vault itself, not an alias.  (must not raise)
+            with mock.patch.object(
+                paths_module,
+                "is_same_object",
+                lambda left, right: True,
+            ):
+                transaction_module._assert_no_portable_vault_leaf_alias_at(
+                    parent, "VAULT", self_lstat=os.lstat(vault)
+                )
+
+
+def test_sibling_limit_enforced_without_dirfd() -> None:
+    with tempfile.TemporaryDirectory() as td, windows_mode():
+        parent = Path(td) / "parent"
+        vault = make_vault(parent / "vault")
+        (parent / "unrelated-sibling").mkdir()
+        with mock.patch.object(transaction_module, "MAX_PORTABLE_SIBLING_ENTRIES", 1):
+            expect_validation_error(
+                "VAULT_DIRECTORY_LIMIT",
+                inspect_bundle,
+                vault,
+                bundle(
+                    "limit", [{"path": "wiki/A.md", "mode": "create", "content": "x"}]
+                ),
+            )
+
+
+def test_unaliased_directory_rejects_indirection() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td)
+        real = base / "real"
+        real.mkdir()
+        value = paths_module.assert_unaliased_directory(real)
+        assert stat_module.S_ISDIR(value.st_mode)
+        regular = base / "file.txt"
+        regular.write_text("x", encoding="utf-8")
+        try:
+            paths_module.assert_unaliased_directory(regular)
+        except NotADirectoryError:
+            pass
+        else:
+            raise AssertionError("regular file must raise ENOTDIR")
+        if IS_WINDOWS:
+            import subprocess
+
+            junction = base / "junction"
+            probe = subprocess.run(
+                ["cmd", "/c", "mklink", "/J", str(junction), str(real)],
+                capture_output=True,
+            )
+            if probe.returncode == 0:
+                try:
+                    paths_module.assert_unaliased_directory(junction)
+                except OSError as exc:
+                    assert exc.errno == errno.ELOOP
+                else:
+                    raise AssertionError("junction must raise ELOOP")
+        else:
+            link = base / "link"
+            link.symlink_to(real, target_is_directory=True)
+            try:
+                paths_module.assert_unaliased_directory(link)
+            except OSError as exc:
+                assert exc.errno == errno.ELOOP
+            else:
+                raise AssertionError("symlink must raise ELOOP")
+
+
+def test_vault_identity_path_mode_states() -> None:
+    with tempfile.TemporaryDirectory() as td, windows_mode():
+        base = Path(td)
+        vault = make_vault(base / "vault")
+        existing = transaction_module._vault_object_identity(vault)
+        probe = os.lstat(vault)
+        assert existing == {
+            "state": "existing",
+            "device": probe.st_dev,
+            "inode": probe.st_ino,
+        }
+        absent = transaction_module._vault_object_identity(base / "not-yet")
+        assert absent["state"] == "absent"
+        assert absent["leaf"] == "not-yet"
+        assert isinstance(absent["parent_device"], int)
+        assert isinstance(absent["parent_inode"], int)
+        file_vault = base / "file-vault"
+        file_vault.write_text("x", encoding="utf-8")
+        expect_validation_error(
+            "VAULT_NOT_DIRECTORY",
+            transaction_module._vault_object_identity,
+            file_vault,
+        )
+
+
+def test_zero_inode_identity_fails_closed() -> None:
+    fake = os.stat_result((stat_module.S_IFDIR | 0o755, 0, 7, 1, 0, 0, 0, 0, 0, 0))
+    expect_validation_error(
+        "UNSAFE_VAULT_IDENTITY",
+        transaction_module._require_stable_identity,
+        fake,
+        Path("fat32-vault"),
+    )
+    assert paths_module.is_same_object(fake, fake) is False
+
+
+def test_apply_refused_before_any_side_effect() -> None:
+    with tempfile.TemporaryDirectory() as td, windows_mode():
+        vault = make_vault(Path(td) / "vault")
+        operation = bundle(
+            "refused", [{"path": "wiki/A.md", "mode": "create", "content": "x"}]
+        )
+        exc = expect_validation_error(
+            "UNSUPPORTED_PLATFORM", apply_bundle, vault, operation
+        )
+        assert "WSL" in str(exc)
+        assert not (vault / ".vault-meta").exists(), "refusal must be side-effect free"
+        assert not (vault / "wiki" / "A.md").exists()
+
+
+def test_cli_surfaces_platform_error_without_traceback() -> None:
+    with tempfile.TemporaryDirectory() as td, windows_mode():
+        vault = make_vault(Path(td) / "vault")
+        operation = bundle(
+            "cli-win", [{"path": "wiki/A.md", "mode": "create", "content": "# A\n"}]
+        )
+        bundle_path = Path(td) / "bundle.json"
+        bundle_path.write_text(json.dumps(operation), encoding="utf-8")
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            inspect_rc = cli_module.main(
+                ["transaction", "inspect", "--vault", str(vault), str(bundle_path)]
+            )
+        assert inspect_rc == 0, err.getvalue()
+        plan = json.loads(out.getvalue())
+        assert plan["valid"] is True
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            apply_rc = cli_module.main(
+                [
+                    "transaction",
+                    "apply",
+                    "--vault",
+                    str(vault),
+                    str(bundle_path),
+                    "--approved-plan-sha256",
+                    str(plan["approval_sha256"]),
+                ]
+            )
+        assert apply_rc == 2
+        assert err.getvalue().startswith("ERR UNSUPPORTED_PLATFORM:")
+        assert "Traceback" not in err.getvalue()
+
+
+def test_identity_change_detected_in_path_mode() -> None:
+    with tempfile.TemporaryDirectory() as td, windows_mode():
+        base = Path(td)
+        vault = make_vault(base / "vault")
+        original_prepare = transaction_module._prepare_writes
+
+        def swapping_prepare(*args, **kwargs):
+            result = original_prepare(*args, **kwargs)
+            os.rename(vault, base / "vault-taken")
+            replacement = make_vault(base / "vault")
+            del replacement
+            return result
+
+        with mock.patch.object(
+            transaction_module, "_prepare_writes", swapping_prepare
+        ):
+            expect_validation_error(
+                "VAULT_IDENTITY_CHANGED",
+                inspect_bundle,
+                vault,
+                bundle(
+                    "swap", [{"path": "wiki/A.md", "mode": "create", "content": "x"}]
+                ),
+            )
+
+
+def test_unportable_write_paths_rejected_on_every_platform() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        vault = make_vault(Path(td) / "vault")
+        for bad in (
+            "wiki/a:b.md",  # NTFS alternate data stream
+            "wiki/CON.md",  # reserved device name
+            "wiki/con.txt",
+            "wiki/trailing./x.md",
+            "wiki/foo.",
+            "wiki/trailing-space /x.md",
+        ):
+            expect_validation_error(
+                "UNPORTABLE_WRITE_PATH",
+                inspect_bundle,
+                vault,
+                bundle("bad-name", [{"path": bad, "mode": "create", "content": "x"}]),
+            )
+
+
+def test_native_windows_bundle_and_workspace_config_load() -> None:
+    # Settles the lstat-vs-fstat identity agreement question empirically on
+    # real NTFS; meaningless under POSIX simulation, so native-only.
+    if not IS_WINDOWS:
+        return
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td)
+        vault = make_vault(base / "vault")
+        operation = bundle(
+            "native", [{"path": "wiki/A.md", "mode": "create", "content": "x"}]
+        )
+        bundle_path = base / "bundle.json"
+        bundle_path.write_text(json.dumps(operation), encoding="utf-8")
+        assert inspect_bundle(vault, bundle_path)["valid"] is True
+        workspace = base / "workspace"
+        workspace.mkdir()
+        config = workspace / paths_module.WORKSPACE_CONFIG
+        config.write_text(
+            json.dumps({"schema": paths_module.VAULT_SCHEMA, "vault": str(vault)}),
+            encoding="utf-8",
+        )
+        selection = paths_module.resolve_vault_root(start=workspace)
+        assert selection.root == paths_module.canonical(vault)
+
+
+def test_capability_predicates_are_false_on_nt() -> None:
+    import claude_obsidian.legacy_lock as legacy_lock_module
+
+    with mock.patch.object(os, "name", "nt"):
+        assert paths_module.supports_confined_dirfd() is False
+        assert transaction_module._supports_confined_dirfd() is False
+        assert legacy_lock_module._supports_confined_runtime() is False
+        try:
+            transaction_module._require_lock_dirfd_support()
+        except OSError as exc:
+            assert exc.errno == errno.ENOTSUP
+        else:
+            raise AssertionError("lock support must be refused on nt")
+        expect_validation_error(
+            "UNSUPPORTED_PLATFORM", transaction_module._require_write_platform
+        )
+
+
+def test_crlf_page_hash_is_stable_across_read_paths() -> None:
+    # Regression for the retrieval staleness split: hashing CRLF content via
+    # bytes-decode must match hashing the same content read through the
+    # transaction reader (read_text would silently normalize and diverge).
+    with tempfile.TemporaryDirectory() as td:
+        vault = make_vault(Path(td) / "vault")
+        page = vault / "wiki" / "CRLF.md"
+        page.write_bytes(b"---\r\naddress: c1\r\n---\r\nbody line\r\n")
+        text_via_bytes = page.read_bytes().decode("utf-8", errors="replace")
+        raw = transaction_module.read_vault_regular(
+            vault, "wiki/CRLF.md", limit=1 << 20, missing_ok=False
+        )
+        assert raw is not None
+        assert raw.decode("utf-8", errors="replace") == text_via_bytes
+        assert "\r\n" in text_via_bytes
+
+
+def main() -> None:
+    test_inspect_dry_run_succeeds_without_dirfd()
+    test_vault_root_alias_rejected_without_dirfd()
+    test_write_path_alias_rejected_without_dirfd()
+    test_no_self_alias_false_positive()
+    test_sibling_limit_enforced_without_dirfd()
+    test_unaliased_directory_rejects_indirection()
+    test_vault_identity_path_mode_states()
+    test_zero_inode_identity_fails_closed()
+    test_apply_refused_before_any_side_effect()
+    test_cli_surfaces_platform_error_without_traceback()
+    test_identity_change_detected_in_path_mode()
+    test_unportable_write_paths_rejected_on_every_platform()
+    test_native_windows_bundle_and_workspace_config_load()
+    test_capability_predicates_are_false_on_nt()
+    test_crlf_page_hash_is_stable_across_read_paths()
+    print("All windows-compat tests passed.")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_windows_compat.py
+++ b/tests/test_windows_compat.py
@@ -194,17 +194,21 @@ def test_no_self_alias_false_positive() -> None:
             assert inspect_bundle(parent / "VAULT", operation)["valid"] is True
         else:
             # Unit-level equivalent of the case-insensitive-volume scenario:
-            # scandir shows "vault" while the caller spelled "VAULT"; with the
-            # vault's own lstat supplied and matching, the entry is recognized
-            # as the vault itself, not an alias.  (must not raise)
-            with mock.patch.object(
-                paths_module,
-                "is_same_object",
-                lambda left, right: True,
-            ):
+            # scandir shows "vault" while the caller spelled "VAULT".  Passing
+            # the actual on-disk entry's lstat as the vault's own identity makes
+            # _is_leaf_itself recognize the entry as the vault, not an alias.
+            # (must not raise; without self_lstat it must still raise)
+            transaction_module._assert_no_portable_vault_leaf_alias_at(
+                parent, "VAULT", self_lstat=os.lstat(vault)
+            )
+            try:
                 transaction_module._assert_no_portable_vault_leaf_alias_at(
-                    parent, "VAULT", self_lstat=os.lstat(vault)
+                    parent, "VAULT", self_lstat=None
                 )
+            except TransactionValidationError as exc:
+                assert exc.code == "CASEFOLD_PATH_ALIAS"
+            else:
+                raise AssertionError("alias must be flagged without self identity")
 
 
 def test_sibling_limit_enforced_without_dirfd() -> None:
@@ -348,6 +352,31 @@ def test_cli_surfaces_platform_error_without_traceback() -> None:
         assert "Traceback" not in err.getvalue()
 
 
+def test_init_apply_refused_before_mkdir() -> None:
+    # A refused init must not create-and-abandon the destination directory
+    # (failed Init roots are deliberately never path-deleted).
+    with tempfile.TemporaryDirectory() as td, windows_mode():
+        destination = Path(td) / "new-vault"
+        out, err = io.StringIO(), io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            rc = cli_module.main(
+                [
+                    "init",
+                    str(destination),
+                    "--generated-at",
+                    "2026-07-31T00:00:00Z",
+                    "--operation-id",
+                    "win-init",
+                    "--apply",
+                    "--approved-plan-sha256",
+                    "0" * 64,
+                ]
+            )
+        assert rc == 2, err.getvalue()
+        assert err.getvalue().startswith("ERR UNSUPPORTED_PLATFORM:")
+        assert not destination.exists(), "refused init must not create the root"
+
+
 def test_identity_change_detected_in_path_mode() -> None:
     with tempfile.TemporaryDirectory() as td, windows_mode():
         base = Path(td)
@@ -464,6 +493,7 @@ def main() -> None:
     test_zero_inode_identity_fails_closed()
     test_apply_refused_before_any_side_effect()
     test_cli_surfaces_platform_error_without_traceback()
+    test_init_apply_refused_before_mkdir()
     test_identity_change_detected_in_path_mode()
     test_unportable_write_paths_rejected_on_every_platform()
     test_native_windows_bundle_and_workspace_config_load()


### PR DESCRIPTION
# Pull request

## Summary
On native Windows every vault-touching command crashed with `AttributeError: module 'os' has no attribute 'O_DIRECTORY'` before producing any output (reported in #147 and by a user running `migrate` under Git Bash). This PR makes read-only inspection and dry-runs genuinely work on native Windows with *real equivalent* safety checks — path-based casefold-alias auditing with symlink **and** junction rejection, lstat-based vault identity, `O_BINARY` reads so CRLF content hashes byte-exactly — while vault writes stay fail-closed behind a single actionable `UNSUPPORTED_PLATFORM` error raised before any side effect (per the documented "use WSL for writes" policy). The naive `getattr(os, "O_DIRECTORY", 0)` fallback suggested in #147 was deliberately not used: it would silently disable security checks and still crash on Windows's fd-`scandir`/`os.open`-on-directory limitations. Along the way this fixes two latent bugs that also affect Linux/macOS: retrieval returning zero results on CRLF vaults (hash-computation split), and cp1252 `UnicodeEncodeError` crashes on redirected output; additionally, under a held mutation lock, a vault whose on-disk name differs only by case from the typed spelling is no longer misreported as its own alias on case-insensitive filesystems (inspect-time auditing deliberately keeps the shipped strict behavior — an absent init root on a case-insensitive volume cannot distinguish itself from an alien sibling, as the first CI round on real macOS proved).

## Type
- [x] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Documentation (`docs:`)
- [ ] Refactor (`refactor:`)
- [x] Test coverage (`test:`)
- [ ] Chore / build / maintenance (`chore:`)

## Related issue
Closes #147

## Changes
- `claude_obsidian/paths.py` — shared platform helpers: `supports_confined_dirfd()`, `directory_open_flags()`, `read_open_flags()` (adds `O_BINARY`), `assert_unaliased_directory()` (rejects symlinks + junctions via `st_reparse_tag` name-surrogate tags only, so OneDrive/Dropbox cloud placeholders are not false-flagged), `is_name_surrogate()`, `is_same_object()` (zero-inode aware)
- `claude_obsidian/transaction.py` — degraded (non-dirfd) branches for the portable-alias audits and `_vault_object_identity` (never `os.open`s a directory on Windows); `inspect_bundle` keeps `root_fd` unopened there and still re-checks vault identity; zero-inode filesystems (FAT/exFAT) fail closed; `O_BINARY` on all content reads; lexical portability pre-pass for **new writes only** (`UNPORTABLE_WRITE_PATH` for reserved device names, `:<>|?*"`, trailing dots/spaces — reads and journal recovery of pre-existing names stay permissive); junction rejection in the degraded walkers; plan-hash mode bits normalized on Windows; `_require_write_platform()` hoisted ahead of all side effects; same-object self-alias skip at the descriptor-pinned `MutationLock` sites (fixes the shipped macOS lock-path false positive; inspect-time auditing unchanged)
- `claude_obsidian/capture.py`, `claude_obsidian/cli.py` — unified `UNSUPPORTED_PLATFORM` surfacing (exit 2) keyed on a dedicated exception type so a genuine filesystem `EOPNOTSUPP` keeps its original message; `init --apply` refuses before `mkdir` so no abandoned directory; UTF-8 stdout/stderr
- `claude_obsidian/checkpoint.py`, `claude_obsidian/hook_adapter.py` — guarded flags, `O_BINARY`, junction rejection in the degraded traversal
- `scripts/bm25-index.py`, `scripts/contextual-prefix.py`, `scripts/retrieve.py` — byte-identical page hashing (`read_bytes().decode`) across the fd/non-fd split; guarded flags; drive-prefix/rooted path rejection
- `scripts/rerank.py`, `scripts/tiling-check.py` — rooted-path guard; explicit UTF-8 reads
- `tests/test_windows_compat.py` (new, 16 tests) — runs degraded branches on all platforms via simulation plus native-only assertions; `tests/test_paths.py`, `tests/test_retrieve.py`, `tests/test_bm25_index.py`, `tests/test_contextual_prefix.py`, `tests/test_legacy_lock.py` — helper units and CRLF regression tests (verified to fail if the hashing fix is reverted); `tests/test_contracts.py` — one capability-verification test skips on native Windows (its verifiers exercise vault mutation, which Windows refuses by design)
- `.github/workflows/test.yml` — new `windows-smoke` job (explicit allowlist of portable suites + validators, `autocrlf` disabled before checkout); existing Linux/macOS matrix untouched
- `.gitattributes` (new, also added to the release allowlist), `README.md`, `docs/compound-vault-guide.md`, `CHANGELOG.md` — LF-exact checkouts; documented platform contract (native Windows: read-only works, writes require WSL, approval hashes bind to the reviewing environment)

## Safety self-review
- [x] Read every file before changing it
- [x] New identifiers named for the next reader
- [x] Smallest unit that works (no speculative abstraction)
- [x] Deletions kept up with additions where applicable
- [x] New behavior has hermetic test coverage
- [x] New failure modes have explicit handling + undo plan
- [x] Product code and mutable user-vault state remain separate
- [x] Knowledge writes use one recoverable transaction; workers only draft
- [x] Network/destructive/external actions have explicit consent
- [x] Claims and capability maturity are evidence-backed

## Testing
```
make test
```
```
All hermetic tests and executable contracts passed.
```
Additionally verified locally: the reproducible-release check (build twice, `cmp`, audit — identical and `"ok": true`); a simulated-Windows end-to-end run of the originally reported repro (`migrate --vault … --generated-at … --operation-id x` with `os.O_DIRECTORY` removed) now exits 0, and `transaction apply` exits 2 with `ERR UNSUPPORTED_PLATFORM` instead of a traceback; the CRLF retrieval regression test fails when the fix is reverted and passes with it.

The first CI round on the real OS matrix caught (and this branch fixed) two things Linux-local testing could not: a macOS APFS regression in the absent-root alias audit (case-insensitive `lstat` resolving any casing) and the Windows capability-verification expectation above.

## Verifier
Three independent adversarial review passes were run over the design and the final diff (design attack, latent-Windows-bug hunt, CI feasibility, plus post-implementation coverage audits of every commit):

- Verdict: SHIP
- BLOCKER: 0 / HIGH: 0 / MEDIUM: 3 / LOW: 6 — all findings fixed on this branch (missed `O_BINARY` site in the `content_file` reader; portable-name rules scoped to new writes so reads and pre-upgrade journal recovery are unaffected; precise ENOTSUP mapping; junction check in `hook_adapter`; CRLF regression tests; `init --apply` side-effect test; inert mock removal; release-allowlist and docs gaps; macOS absent-root alias regression)

## CHANGELOG
- [x] Added an entry under `## [Unreleased]` in `CHANGELOG.md`

## Screenshots / output
Before (native Windows, any vault command):
```
File "claude_obsidian/transaction.py", line 1023, in _assert_no_portable_vault_root_alias
    | os.O_DIRECTORY
AttributeError: module 'os' has no attribute 'O_DIRECTORY'
```
After:
```
$ python scripts/claude-obsidian.py transaction inspect --vault C:\vault plan.json   # exit 0, valid plan JSON
$ python scripts/claude-obsidian.py transaction apply --vault C:\vault plan.json --approved-plan-sha256 …
ERR UNSUPPORTED_PLATFORM: vault writes require directory-descriptor confinement (WSL/Linux or supported macOS); on native Windows run this command inside WSL — read-only inspection and dry-runs work natively   # exit 2
```

## Notes for reviewer
- The `windows-smoke` job's `test_windows_compat.py` leg is the first native-Windows execution of this code (the first run aborted earlier in the allowlist). Two things it empirically settles: NTFS lstat/fstat identity agreement (`test_native_windows_bundle_and_workspace_config_load`) and junction `ELOOP` behavior (`test_unaliased_directory_rejects_indirection`). If either misbehaves on the runner, the test file documents the designed contingencies.
- The portable-name tightening (`UNPORTABLE_WRITE_PATH`) intentionally applies to **new writes on every platform** so an approved plan means the same thing everywhere; reads, indexing, and recovery of pre-existing files with such names are unaffected (covered by tests).
- `RELEASE_MANIFEST.json`/`SHA256SUMS` become stale relative to these source changes until your next audited release refresh; verified this cannot fail any CI step.
- Windows `apply` moves from an accidental `LOCK_FAILED` exit 1 to a deliberate validation exit 2 — flagged in the CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EAiQCkG4JfmgdqE563r3Az