### PR TITLE
feat(hooks): warn on Stop when wiki/log.md nears the fold batch size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ implementation record for older releases.
 
 ## [Unreleased]
 
+### Added
+
+- Stop hook: an advisory-only line when `wiki/log.md` holds at least 85% of a
+  wiki-fold batch (`2**k` entries, default `k=4`, override with
+  `CLAUDE_OBSIDIAN_FOLD_BATCH_EXPONENT`) above its most recent `fold` marker.
+  It reads at most the first 512 KiB of the log, is appended after any
+  recovery warnings, never recommends `transaction recover`, and never runs
+  wiki-fold or writes to the vault, since folding stays human-invoked per
+  `skills/wiki-fold/SKILL.md`.
+
 ## [2.2.0] - 2026-09-10
 
 Backlog triage: lint scoping, lock recovery, host validation, the `bin/`

--- a/claude_obsidian/hook_adapter.py
+++ b/claude_obsidian/hook_adapter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import math
 import os
 import re
 import stat
@@ -27,9 +28,13 @@ MAX_CONTEXT_BYTES = 32 * 1024
 MAX_STATUS_BYTES = 4 * 1024
 MAX_STATUS_ITEMS = 8
 MAX_TRANSACTION_SCAN = 256
+MAX_LOG_SCAN_BYTES = 512 * 1024
+DEFAULT_FOLD_BATCH_EXPONENT = 4
+FOLD_BACKLOG_WARN_FRACTION = 0.85
 OPEN_TAG = '<claude-obsidian-context trust="local-data" instructions="never">'
 CLOSE_TAG = "</claude-obsidian-context>"
 _SAFE_OPERATION_ID = re.compile(r"^[A-Za-z0-9_.-]{1,128}$")
+_LOG_ENTRY_OP = re.compile(rb"^## \[\d{4}-\d{2}-\d{2}\] (\S+)", re.MULTILINE)
 
 
 def _bounded_regular_bytes(root: Path, path: Path, limit: int) -> bytes | None:
@@ -215,6 +220,72 @@ def session_start_context(
     return f"{header}\n{OPEN_TAG}\n{cleaned}{trailer}\n{CLOSE_TAG}"
 
 
+def _fold_batch_exponent(environ: Mapping[str, str]) -> int:
+    """Resolve the wiki-fold batch exponent k (batch size 2**k, default 4)."""
+
+    raw = environ.get("CLAUDE_OBSIDIAN_FOLD_BATCH_EXPONENT")
+    if raw is None:
+        return DEFAULT_FOLD_BATCH_EXPONENT
+    try:
+        value = int(raw)
+    except ValueError:
+        return DEFAULT_FOLD_BATCH_EXPONENT
+    if value < 1 or value > 10:
+        return DEFAULT_FOLD_BATCH_EXPONENT
+    return value
+
+
+def _fold_backlog_count(root: Path) -> int | None:
+    """Count wiki/log.md entries above the most recent fold marker.
+
+    wiki-fold rolls up the newest ``2**k`` entries and prepends one ``fold |``
+    marker entry to the top of the log. It never trims the entries it folded,
+    so the marker sits directly above the entries it covers, and every entry
+    logged since then sits above the marker. The unfolded backlog is therefore
+    the run of entries before the first ``fold`` op in the file. A vault that
+    has never been folded has no marker, so every entry counts.
+
+    The scan is bounded to ``MAX_LOG_SCAN_BYTES`` from the top of the file.
+    Because the log is newest-first, that window holds the most recent
+    entries, so a backlog longer than the window only ever undercounts, never
+    overcounts. An explicit-range fold of older entries also only undercounts.
+    """
+
+    data = _bounded_regular_bytes(root, root / "wiki" / "log.md", MAX_LOG_SCAN_BYTES)
+    if data is None:
+        return None
+    backlog = 0
+    for match in _LOG_ENTRY_OP.finditer(data[:MAX_LOG_SCAN_BYTES]):
+        if match.group(1) == b"fold":
+            break
+        backlog += 1
+    return backlog
+
+
+def _fold_backlog_warning(root: Path, environ: Mapping[str, str]) -> str | None:
+    """Advisory-only: never mutates the vault or triggers a fold itself.
+
+    wiki-fold is deliberately human-invoked (see skills/wiki-fold/SKILL.md:
+    "Do not perform fold-of-folds or trigger a fold automatically"). This only
+    reuses the bounded, silent-unless-needed Stop status channel, and never
+    sets ``recommend_recover``.
+    """
+
+    count = _fold_backlog_count(root)
+    if not count:
+        return None
+    batch_exponent = _fold_batch_exponent(environ)
+    batch_size = 1 << batch_exponent
+    threshold = math.ceil(batch_size * FOLD_BACKLOG_WARN_FRACTION)
+    if count < threshold:
+        return None
+    return (
+        f"{count} wiki log entries since the last fold, at or above "
+        f"{round(FOLD_BACKLOG_WARN_FRACTION * 100)}% of the k={batch_exponent} "
+        f"fold batch ({batch_size}); consider running wiki-fold"
+    )
+
+
 def stop_status(
     *,
     start: Path | str | None = None,
@@ -237,7 +308,8 @@ def stop_status(
     recommend_recover = False
     meta = root / ".vault-meta"
     if not meta.exists():
-        return ""
+        fold_warning = _fold_backlog_warning(root, env)
+        return _bounded_status([fold_warning]) if fold_warning else ""
     if not _safe_directory(root, meta):
         warnings.append("vault metadata path is unsafe")
         return _bounded_status(warnings)
@@ -315,6 +387,11 @@ def stop_status(
                 f"{unreadable_journals} unsafe or unreadable transaction "
                 "journal(s) detected; inspect manually"
             )
+    # Appended last so the advisory never displaces a recovery warning
+    # within MAX_STATUS_ITEMS.
+    fold_warning = _fold_backlog_warning(root, env)
+    if fold_warning:
+        warnings.append(fold_warning)
     if not warnings:
         return ""
     return _bounded_status(warnings, recommend_recover=recommend_recover)

--- a/docs/compound-vault-guide.md
+++ b/docs/compound-vault-guide.md
@@ -148,7 +148,9 @@ Read [the provenance reference](../skills/wiki/references/provenance.md).
 Claude's SessionStart hook is silent by default. It emits bounded, sanitized hot
 context only when a user vault resolves and the user has explicitly exported
 `CLAUDE_OBSIDIAN_SESSION_CONTEXT=1`; hook stdout becomes model context, so this
-opt-in is an egress decision. The Stop hook reports incomplete transactions.
+opt-in is an egress decision. The Stop hook reports incomplete transactions and,
+advisory-only, a `wiki/log.md` backlog nearing the wiki-fold batch size. It
+never runs a fold itself, since wiki-fold stays human-invoked.
 Hooks do not update notes, capture conversations, stage files, or commit Git.
 Hosts without hooks use the same core workflows.
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -12,7 +12,7 @@ for native Windows setup.
 | Event | Matcher | Behavior |
 |---|---|---|
 | `SessionStart` | `startup|resume|clear|compact` | Silent by default. With `CLAUDE_OBSIDIAN_SESSION_CONTEXT=1`, resolves a real user vault and emits a bounded, sanitized `wiki/hot.md` data block. A workspace-configured vault outside that project also requires an exact `CLAUDE_OBSIDIAN_SESSION_CONTEXT_VAULT` path. |
-| `Stop` | unsupported/omitted | Emits a bounded, aggregate JSON `systemMessage` when recovery is needed. It omits operation identifiers, paths, and note content; otherwise it is silent. |
+| `Stop` | unsupported/omitted | Emits a bounded, aggregate JSON `systemMessage` when recovery is needed. It also emits one advisory line, after any recovery warnings, when `wiki/log.md` holds at least 85% of a wiki-fold batch (`2**k` entries, default `k=4`, override with `CLAUDE_OBSIDIAN_FOLD_BATCH_EXPONENT`) above its most recent `fold` marker. That check reads at most the first 512 KiB of the log, never recommends `transaction recover`, never runs wiki-fold, and never writes. It omits operation identifiers, paths, and note content; otherwise it is silent. |
 
 Both are `command` hooks using an executable plus an argument array and
 `${CLAUDE_PLUGIN_ROOT}` only to locate plugin code. They do not use the plugin

--- a/skills/wiki-fold/SKILL.md
+++ b/skills/wiki-fold/SKILL.md
@@ -82,7 +82,10 @@ When the user explicitly says to apply or commit the fold, build one
 
 - `wiki/folds/{FOLD_ID}.md` in `create` mode by default;
 - the fold catalog entry in `wiki/index.md`;
-- one new top-of-file fold entry in `wiki/log.md`.
+- one new top-of-file fold entry in `wiki/log.md`, using the literal op token
+  `fold` (`## [DATE] fold | ...`). That token is reserved for this marker: the
+  Stop hook's fold-backlog check treats the entries above the topmost marker as
+  the unfolded backlog, so no other skill or manual entry should reuse it.
 
 Do not update `wiki/hot.md`. Record SHA-256 preconditions for all three targets.
 Do not use host Write/Edit, Obsidian transport writes, deprecated locks, automatic

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -31,6 +31,24 @@ def make_vault(root: Path, hot: str) -> Path:
     return root
 
 
+def _log_entries(ops: list[str], detail: str = "- detail") -> str:
+    header = (
+        "---\ntype: meta\ntitle: Wiki Log\ncreated: 2026-06-22\n"
+        "updated: 2026-08-04\ntags: []\nstatus: active\n---\n"
+    )
+    body = "\n".join(
+        f"## [2026-08-0{index % 9 + 1}] {op} | entry {index}\n{detail}"
+        for index, op in enumerate(ops)
+    )
+    return header + body + "\n"
+
+
+def _backlog(vault: Path) -> int | None:
+    # _fold_backlog_count expects an already-canonical root, exactly as
+    # stop_status passes it (selection.root from resolve_vault_root).
+    return hook_adapter._fold_backlog_count(hook_adapter.canonical(vault))
+
+
 def opted_in() -> dict[str, str]:
     return {"CLAUDE_OBSIDIAN_SESSION_CONTEXT": "1"}
 
@@ -428,6 +446,144 @@ def test_stop_status_scopes_recovery_advice_for_mixed_journals() -> None:
         assert "inspect manually" in status
 
 
+def test_fold_backlog_counts_only_entries_above_the_latest_fold_marker() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        vault = make_vault(Path(td) / "vault", "safe\n")
+        ops = ["save"] * 5 + ["fold"] * 2 + ["save"] * 40 + ["fold"] + ["save"] * 3
+        (vault / "wiki/log.md").write_text(_log_entries(ops), encoding="utf-8")
+        assert _backlog(vault) == 5
+
+
+def test_fold_backlog_is_silent_right_after_a_fold() -> None:
+    # wiki-fold prepends its marker above the entries it just folded, so a
+    # marker at the top of the log means there is no backlog at all.
+    with tempfile.TemporaryDirectory() as td:
+        vault = make_vault(Path(td) / "vault", "safe\n")
+        ops = ["fold"] + ["save"] * 16 + ["fold"] + ["save"] * 16
+        (vault / "wiki/log.md").write_text(_log_entries(ops), encoding="utf-8")
+        assert _backlog(vault) == 0
+        assert (
+            stop_status(start=vault, environ={}, plugin_root=Path(td) / "plugin") == ""
+        )
+
+
+def test_fold_backlog_count_handles_crlf_line_endings() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        vault = make_vault(Path(td) / "vault", "safe\n")
+        text = _log_entries(["save"] * 9 + ["fold"] + ["save"] * 2)
+        (vault / "wiki/log.md").write_bytes(text.replace("\n", "\r\n").encode("utf-8"))
+        assert _backlog(vault) == 9
+
+
+def test_fold_backlog_counts_everything_when_never_folded() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        vault = make_vault(Path(td) / "vault", "safe\n")
+        (vault / "wiki/log.md").write_text(_log_entries(["save"] * 6), encoding="utf-8")
+        assert _backlog(vault) == 6
+
+
+def test_fold_backlog_scan_is_bounded() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        vault = make_vault(Path(td) / "vault", "safe\n")
+        detail = "x" * (64 * 1024)
+        (vault / "wiki/log.md").write_text(
+            _log_entries(["save"] * 20, detail=detail), encoding="utf-8"
+        )
+        # 20 entries of ~64 KiB exceed the 512 KiB window: undercount, never more.
+        count = _backlog(vault)
+        assert count is not None and 0 < count < 20
+
+
+def test_fold_backlog_ignores_symlinked_log() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td)
+        vault = make_vault(base / "vault", "safe\n")
+        outside = base / "outside-log.md"
+        outside.write_text(_log_entries(["save"] * 20), encoding="utf-8")
+        try:
+            (vault / "wiki/log.md").symlink_to(outside)
+        except OSError:
+            return
+        assert _backlog(vault) is None
+        assert stop_status(start=vault, environ={}, plugin_root=base / "plugin") == ""
+
+
+def test_stop_status_silent_below_fold_backlog_threshold() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        vault = make_vault(Path(td) / "vault", "safe\n")
+        (vault / "wiki/log.md").write_text(_log_entries(["save"] * 13), encoding="utf-8")
+        assert (
+            stop_status(start=vault, environ={}, plugin_root=Path(td) / "plugin") == ""
+        )
+
+
+def test_stop_status_warns_at_fold_backlog_threshold() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        vault = make_vault(Path(td) / "vault", "safe\n")
+        (vault / "wiki/log.md").write_text(_log_entries(["save"] * 14), encoding="utf-8")
+        status = stop_status(start=vault, environ={}, plugin_root=Path(td) / "plugin")
+        assert "14 wiki log entries since the last fold" in status
+        assert "consider running wiki-fold" in status
+        # Advisory-only: nothing to recover, and no vault path or note content.
+        assert "transaction recover" not in status
+        assert "wiki/log.md" not in status
+        assert "entry 0" not in status
+
+
+def test_stop_status_fold_backlog_respects_batch_exponent_override() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        vault = make_vault(Path(td) / "vault", "safe\n")
+        (vault / "wiki/log.md").write_text(_log_entries(["save"] * 7), encoding="utf-8")
+        plugin_root = Path(td) / "plugin"
+        default_k = stop_status(
+            start=vault,
+            environ={"CLAUDE_OBSIDIAN_FOLD_BATCH_EXPONENT": "4"},
+            plugin_root=plugin_root,
+        )
+        assert default_k == ""
+        smaller_batch = stop_status(
+            start=vault,
+            environ={"CLAUDE_OBSIDIAN_FOLD_BATCH_EXPONENT": "3"},
+            plugin_root=plugin_root,
+        )
+        assert "consider running wiki-fold" in smaller_batch
+
+
+def test_fold_batch_exponent_falls_back_on_invalid_override() -> None:
+    key = "CLAUDE_OBSIDIAN_FOLD_BATCH_EXPONENT"
+    assert hook_adapter._fold_batch_exponent({}) == 4
+    assert hook_adapter._fold_batch_exponent({key: "not-a-number"}) == 4
+    assert hook_adapter._fold_batch_exponent({key: "0"}) == 4
+    assert hook_adapter._fold_batch_exponent({key: "20"}) == 4
+    assert hook_adapter._fold_batch_exponent({key: "3"}) == 3
+
+
+def test_stop_status_fold_backlog_follows_recovery_warnings() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        vault = make_vault(Path(td) / "vault", "safe\n")
+        (vault / "wiki/log.md").write_text(_log_entries(["save"] * 14), encoding="utf-8")
+        journal = vault / ".vault-meta/transactions/operation-000/journal.json"
+        journal.parent.mkdir(parents=True)
+        journal.write_text(json.dumps({"state": "applying"}), encoding="utf-8")
+        status = stop_status(start=vault, environ={}, plugin_root=Path(td) / "plugin")
+        recovery = status.index("1 transaction journal(s) need recovery")
+        fold = status.index("consider running wiki-fold")
+        assert recovery < fold
+        assert "for the recognized recoverable journals" in status
+
+
+def test_stop_status_fold_backlog_does_not_recommend_recover_for_a_lock() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        vault = make_vault(Path(td) / "vault", "safe\n")
+        (vault / "wiki/log.md").write_text(_log_entries(["save"] * 14), encoding="utf-8")
+        (vault / ".vault-meta").mkdir()
+        (vault / ".vault-meta/mutation.lock").write_text("pid=1\n", encoding="utf-8")
+        status = stop_status(start=vault, environ={}, plugin_root=Path(td) / "plugin")
+        assert "a vault mutation lock is still present" in status
+        assert "consider running wiki-fold" in status
+        assert "transaction recover" not in status
+
+
 def main() -> None:
     test_hook_schema_uses_supported_session_start_shape()
     test_context_is_bounded_and_delimiter_safe()
@@ -445,6 +601,18 @@ def main() -> None:
     test_stop_status_actual_read_failure_requires_manual_inspection()
     test_stop_status_regular_journal_read_failure_requires_manual_inspection()
     test_stop_status_scopes_recovery_advice_for_mixed_journals()
+    test_fold_backlog_counts_only_entries_above_the_latest_fold_marker()
+    test_fold_backlog_is_silent_right_after_a_fold()
+    test_fold_backlog_count_handles_crlf_line_endings()
+    test_fold_backlog_counts_everything_when_never_folded()
+    test_fold_backlog_scan_is_bounded()
+    test_fold_backlog_ignores_symlinked_log()
+    test_stop_status_silent_below_fold_backlog_threshold()
+    test_stop_status_warns_at_fold_backlog_threshold()
+    test_stop_status_fold_backlog_respects_batch_exponent_override()
+    test_fold_batch_exponent_falls_back_on_invalid_override()
+    test_stop_status_fold_backlog_follows_recovery_warnings()
+    test_stop_status_fold_backlog_does_not_recommend_recover_for_a_lock()
     print("All hook tests passed.")
 
 


### PR DESCRIPTION
## Goal

Surface a growing, un-folded `wiki/log.md` backlog before it gets forgotten
between sessions, without ever auto-triggering a fold, since
`skills/wiki-fold/SKILL.md` is explicit that folding stays human-invoked.

## Summary

- Adds one advisory line to the Stop hook's existing bounded `systemMessage`
  once the number of `wiki/log.md` entries above the most recent `fold` marker
  reaches 85% of the wiki-fold batch size (`2**k`, default `k=4`, so 14 of 16;
  override with `CLAUDE_OBSIDIAN_FOLD_BATCH_EXPONENT`).
- Advisory only: never runs wiki-fold, never writes, never sets
  `recommend_recover`.
- Rebased onto v2.2.0. Built on #177's `recommend_recover`, so
  `_bounded_status` and every journal warning string are unchanged from main.
  No `hooks/hooks.json` changes.

## Why the Stop contract widens, and how narrowly

This moves the documented Stop behavior (`hooks/README.md`) from "recovery
state" to "recovery state plus one advisory". The reasoning:

- wiki-fold refuses automatic triggering, so a nudge is the only mechanism
  available, and Stop is the existing end-of-work status surface. SessionStart
  is opt-in egress into model context, so it is the wrong place.
- It reuses the same channel with the same bounds, adds no new output shape,
  and stays silent below the threshold.
- The line carries a count and the batch size only: no paths, no note content,
  no entry titles (asserted in tests).
- It is appended after all recovery warnings, so it can never push a recovery
  warning out of the `MAX_STATUS_ITEMS` cap, and it is skipped entirely on the
  early-return paths for unsafe metadata.

If an opt-in default (like `CLAUDE_OBSIDIAN_SESSION_CONTEXT=1`) is preferred,
that is a small follow-up.

## Cost inside the 5 second hook budget

One `_bounded_regular_bytes` read (same symlink and regular-file guard as the
hot cache and journals), capped at 512 KiB, and a bytes regex that stops at the
first marker. No decode, no second file. Worst case is bounded by the cap,
whatever the log size.

Measured against a real vault (1.1 MB `wiki/log.md`, 520 entries, Apple
Silicon, 200 runs):

| | median | max |
|---|---|---|
| `stop_status` without the check | 0.38 ms | 0.53 ms |
| `stop_status` with the check | 2.09 ms | 3.98 ms |
| full `claude-obsidian.py hook stop` process | 22 ms | 25 ms |

## How it works

wiki-fold rolls up the newest `2**k` entries and prepends its `fold |` marker
above them without trimming anything. So the entries above the topmost marker
are exactly the ones logged since the last fold. The count stops there; a vault
that was never folded counts every entry. The `fold` op token is now documented
as reserved in `skills/wiki-fold/SKILL.md`.

## Verification

- `make test` on Python 3.13: all hermetic tests and executable contracts
  passed.
- `python3 tests/test_hooks.py`: 12 new tests, covering the threshold edge
  (13 vs 14 of 16), silence right after a fold, CRLF, never-folded logs, the
  512 KiB bound, a symlinked log being ignored, no path or content in the
  output, the exponent override and invalid values, ordering after a recovery
  warning, and no `transaction recover` advice for a lock plus a backlog.
- `git diff --check` clean.

## Limitations

- The count only ever errs low: a backlog larger than the 512 KiB window, or an
  explicit-range fold of older entries, can undercount. It never overcounts.

## Rollback

Single commit; revert it.
