### PR TITLE
fix(lint): drop gitignored candidates from ambiguous wikilink resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,17 @@ implementation record for older releases.
   and accepting the content only if the bytes are identical to the first
   read. Any size, inode, device, or mode change, and any content change
   during the read, still fails closed with `CORRUPT_RUNTIME_STATE`.
+- Lint link resolution no longer reports a wikilink as ambiguous when the
+  extra candidates are gitignored files (for example a compiled binary whose
+  name shadows a page, such as `bin/env8oy` next to `wiki/projects/env8oy.md`).
+  A new pure-Python `.gitignore` evaluator (`claude_obsidian/gitignore.py`)
+  reads only `.gitignore` files inside the vault root — never
+  `.git/info/exclude`, global excludes, or a `git` subprocess — keeping
+  reports deterministic and process-free. Gitignored files remain valid link
+  targets when they are the only candidate, so no new dead links are
+  introduced; ambiguity among only-gitignored candidates is still reported.
+  This unblocks `checkpoint` runs that previously failed `LINT_FAILED`
+  whenever a build artifact existed.
 
 ## [2.1.1] - 2026-08-26
 

--- a/claude_obsidian/gitignore.py
+++ b/claude_obsidian/gitignore.py
@@ -1,0 +1,203 @@
+"""Pure-Python ``.gitignore`` evaluation for the deterministic lint engine.
+
+This module reads ``.gitignore`` files found inside a scan root and answers
+whether a relative path is ignored, following the documented gitignore
+semantics that matter for link resolution:
+
+- later patterns override earlier ones; deeper ``.gitignore`` files override
+  shallower ones;
+- ``!`` negation re-includes a previously excluded path;
+- a pattern containing a non-trailing ``/`` is anchored to its
+  ``.gitignore`` directory, otherwise it matches at any depth;
+- a trailing ``/`` restricts a pattern to directories;
+- ``*`` and ``?`` never cross ``/``; ``**`` does;
+- everything inside an excluded directory stays excluded (``.gitignore``
+  files inside excluded directories are not read).
+
+Scope is deliberately narrow and deterministic: only ``.gitignore`` files
+within the scan root are consulted — never ``.git/info/exclude``, the global
+``core.excludesFile``, or a ``git`` subprocess. Matching is always
+case-sensitive (git's default), even on case-insensitive filesystems where
+git with ``core.ignorecase=true`` would fold case; reading git config would
+break the process-free contract. Symlinked ``.gitignore`` files are skipped,
+matching the engine's symlink hygiene.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+
+_MAX_GITIGNORE_BYTES = 1024 * 1024
+
+
+@dataclass(frozen=True)
+class _Rule:
+    regex: re.Pattern[str]
+    negate: bool
+    dir_only: bool
+
+
+def _translate_segment(segment: str) -> str:
+    parts: list[str] = []
+    index = 0
+    while index < len(segment):
+        char = segment[index]
+        if char == "\\" and index + 1 < len(segment):
+            parts.append(re.escape(segment[index + 1]))
+            index += 2
+            continue
+        if char == "*":
+            parts.append("[^/]*")
+        elif char == "?":
+            parts.append("[^/]")
+        elif char == "[":
+            end = segment.find("]", index + 2)
+            if end < 0:
+                parts.append(re.escape(char))
+            else:
+                inner = segment[index + 1 : end]
+                if inner.startswith("!"):
+                    inner = "^" + inner[1:]
+                parts.append(f"[{inner}]")
+                index = end + 1
+                continue
+        else:
+            parts.append(re.escape(char))
+        index += 1
+    return "".join(parts)
+
+
+def _translate(pattern: str) -> str:
+    segments = pattern.split("/")
+    parts: list[str] = []
+    for position, segment in enumerate(segments):
+        last = position == len(segments) - 1
+        if segment == "**":
+            if position == 0:
+                parts.append("(?:[^/]+/)*" if not last else ".*")
+            elif last:
+                parts.append(".*")
+            else:
+                parts.append("(?:[^/]+/)*")
+            continue
+        parts.append(_translate_segment(segment) + ("" if last else "/"))
+    return "".join(parts)
+
+
+def _parse_line(line: str) -> _Rule | None:
+    line = line.rstrip("\r\n")
+    if not line or line.startswith("#"):
+        return None
+    while line.endswith(" ") and not line.endswith("\\ "):
+        line = line[:-1]
+    if not line:
+        return None
+    negate = line.startswith("!")
+    if negate:
+        line = line[1:]
+    elif line.startswith("\\!") or line.startswith("\\#"):
+        line = line[1:]
+    dir_only = line.endswith("/")
+    if dir_only:
+        line = line.rstrip("/")
+    if not line:
+        return None
+    anchored = line.startswith("/") or "/" in line
+    line = line.lstrip("/")
+    if not line:
+        return None
+    prefix = "" if anchored else "(?:.*/)?"
+    try:
+        regex = re.compile(prefix + _translate(line))
+    except re.error:
+        return None
+    return _Rule(regex=regex, negate=negate, dir_only=dir_only)
+
+
+def _parse_gitignore(path: Path) -> tuple[_Rule, ...]:
+    try:
+        if path.is_symlink() or not path.is_file():
+            return ()
+        if path.stat().st_size > _MAX_GITIGNORE_BYTES:
+            return ()
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return ()
+    rules = []
+    for line in text.splitlines():
+        rule = _parse_line(line)
+        if rule is not None:
+            rules.append(rule)
+    return tuple(rules)
+
+
+class GitignoreMatcher:
+    """Lazily evaluate gitignore status for paths relative to ``root``.
+
+    Paths use POSIX separators and are relative to the scan root. Results are
+    cached; the matcher performs only file reads and never writes.
+    """
+
+    def __init__(self, root: Path) -> None:
+        self._root = root
+        self._rules: dict[str, tuple[_Rule, ...]] = {}
+        self._dir_ignored: dict[str, bool] = {"": False}
+
+    def _rules_for(self, rel_dir: str) -> tuple[_Rule, ...]:
+        cached = self._rules.get(rel_dir)
+        if cached is None:
+            absolute = self._root if rel_dir == "" else self._root / rel_dir
+            cached = _parse_gitignore(absolute / ".gitignore")
+            self._rules[rel_dir] = cached
+        return cached
+
+    def _match(self, rel_path: str, is_dir: bool) -> bool | None:
+        """Return the last matching rule's verdict across scopes, or None."""
+        parent = str(PurePosixPath(rel_path).parent)
+        if parent == ".":
+            parent = ""
+        scopes = [""]
+        if parent:
+            pieces = parent.split("/")
+            for index in range(len(pieces)):
+                scopes.append("/".join(pieces[: index + 1]))
+        verdict: bool | None = None
+        for scope in scopes:
+            if scope == "":
+                candidate = rel_path
+            else:
+                candidate = rel_path[len(scope) + 1 :]
+            for rule in self._rules_for(scope):
+                if rule.dir_only and not is_dir:
+                    continue
+                if rule.regex.fullmatch(candidate):
+                    verdict = not rule.negate
+        return verdict
+
+    def _is_dir_ignored(self, rel_dir: str) -> bool:
+        cached = self._dir_ignored.get(rel_dir)
+        if cached is not None:
+            return cached
+        parent = str(PurePosixPath(rel_dir).parent)
+        if parent == ".":
+            parent = ""
+        if self._is_dir_ignored(parent):
+            result = True
+        else:
+            result = self._match(rel_dir, is_dir=True) is True
+        self._dir_ignored[rel_dir] = result
+        return result
+
+    def is_ignored(self, rel_path: str) -> bool:
+        """Return True when the file at ``rel_path`` is gitignored."""
+        normalized = rel_path.strip("/")
+        if not normalized:
+            return False
+        parent = str(PurePosixPath(normalized).parent)
+        if parent == ".":
+            parent = ""
+        if parent and self._is_dir_ignored(parent):
+            return True
+        return self._match(normalized, is_dir=False) is True

--- a/claude_obsidian/lint_engine.py
+++ b/claude_obsidian/lint_engine.py
@@ -22,6 +22,13 @@ own indexer, so a duplicated or archived page under a hidden folder (a
 globs, passed to ``lint_vault`` or set vault-side, scope specific paths out of
 every finding category.
 
+Link resolution is gitignore-aware: when a wikilink resolves to multiple
+candidates and at least one is not gitignored, gitignored candidates (for
+example build artifacts shadowing a page's name) are dropped before ambiguity
+is reported. Only ``.gitignore`` files inside the vault root are consulted —
+never ``.git/info/exclude``, global excludes, or a ``git`` subprocess — so
+reports stay deterministic and process-free.
+
 This module never creates directories or files. Even its command-line entry
 point writes only to stdout. Provenance freshness uses the explicit ``as_of``
 date when supplied and the current UTC calendar date otherwise.
@@ -48,6 +55,7 @@ from typing import Any, Iterable, Mapping, Sequence, cast
 if __package__ in {None, ""}:
     sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 
+from claude_obsidian.gitignore import GitignoreMatcher
 from claude_obsidian.json_utils import strict_json_loads
 
 REPORT_VERSION = 1
@@ -1032,6 +1040,7 @@ def lint_vault(
         wiki_pages = []
 
     resolver = _Resolver(targets, wiki_prefix)
+    gitignore = GitignoreMatcher(root_path)
     incoming: dict[str, set[str]] = {page.path: set() for page in wiki_pages}
     dead_links: list[dict[str, Any]] = []
     ambiguous_targets: list[dict[str, Any]] = []
@@ -1044,6 +1053,14 @@ def lint_vault(
         for link in _parse_links(page):
             links_scanned += 1
             candidates = resolver.resolve(link)
+            if len(candidates) > 1:
+                unignored = [
+                    candidate
+                    for candidate in candidates
+                    if not gitignore.is_ignored(candidate.path)
+                ]
+                if unignored:
+                    candidates = unignored
             if len(candidates) > 1:
                 entry = {
                     "source": link.source,

--- a/config/capabilities.json
+++ b/config/capabilities.json
@@ -500,6 +500,7 @@
       "read_scope": [
         "plugin:skills/wiki-lint/**",
         "plugin:skills/wiki/references/operation-transactions.md",
+        "vault:**/.gitignore",
         "vault:.vault-meta/lint-allowlist.json",
         "vault:.vault-meta/lint-allowlist.txt",
         "vault:.vault-meta/lint.json",

--- a/skills/wiki-lint/SKILL.md
+++ b/skills/wiki-lint/SKILL.md
@@ -41,7 +41,10 @@ The command remains read-only either way.
 The deterministic parser understands Obsidian wikilinks and embeds, Markdown
 links, aliases, heading and block fragments, escaped aliases, and code fences.
 It skips dot-prefixed directories by default, mirroring Obsidian's own
-indexer. It reports such categories as dead or ambiguous links, orphan pages, required
+indexer. Link resolution honors `.gitignore` files inside the vault (no `git`
+subprocess): when a link is ambiguous between a page and a gitignored file
+such as a build artifact, the gitignored candidate is dropped.
+It reports such categories as dead or ambiguous links, orphan pages, required
 frontmatter gaps (including `title`), empty sections, stale index entries, and
 source/claim ledger contract violations. Report only the
 checks and counts present in its output; do not claim that it performed

--- a/tests/test_gitignore.py
+++ b/tests/test_gitignore.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Hermetic tests for pure-Python ``.gitignore`` evaluation."""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT))
+
+from claude_obsidian.gitignore import GitignoreMatcher
+
+
+class GitignoreMatcherTests(unittest.TestCase):
+    def _matcher(self, files: dict[str, str]) -> GitignoreMatcher:
+        self._directory = tempfile.TemporaryDirectory()
+        self.addCleanup(self._directory.cleanup)
+        root = Path(self._directory.name)
+        for relative, content in files.items():
+            path = root / relative
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(content, encoding="utf-8")
+        return GitignoreMatcher(root)
+
+    def test_no_gitignore_means_nothing_is_ignored(self) -> None:
+        matcher = self._matcher({"wiki/page.md": "x"})
+        self.assertFalse(matcher.is_ignored("wiki/page.md"))
+
+    def test_unanchored_pattern_matches_any_depth(self) -> None:
+        matcher = self._matcher({".gitignore": "build\n"})
+        self.assertTrue(matcher.is_ignored("build"))
+        self.assertTrue(matcher.is_ignored("deep/nested/build"))
+        self.assertFalse(matcher.is_ignored("buildinfo"))
+
+    def test_anchored_pattern_matches_only_at_scope_root(self) -> None:
+        matcher = self._matcher({".gitignore": "/build\n"})
+        self.assertTrue(matcher.is_ignored("build"))
+        self.assertFalse(matcher.is_ignored("deep/build"))
+
+    def test_dir_only_pattern_excludes_contents_but_not_same_named_file(self) -> None:
+        matcher = self._matcher({".gitignore": "bin/\n", "bin/tool": "x"})
+        self.assertTrue(matcher.is_ignored("bin/tool"))
+        self.assertTrue(matcher.is_ignored("sub/bin/tool"))
+        self.assertFalse(matcher.is_ignored("docs/bin"))
+
+    def test_negation_reincludes_a_file(self) -> None:
+        matcher = self._matcher({".gitignore": "*.log\n!keep.log\n"})
+        self.assertTrue(matcher.is_ignored("debug.log"))
+        self.assertFalse(matcher.is_ignored("keep.log"))
+
+    def test_contents_of_excluded_directory_stay_excluded(self) -> None:
+        matcher = self._matcher(
+            {".gitignore": "out/\n", "out/.gitignore": "!wanted.txt\n"}
+        )
+        self.assertTrue(matcher.is_ignored("out/wanted.txt"))
+
+    def test_nested_gitignore_is_scoped_to_its_directory(self) -> None:
+        matcher = self._matcher({"sub/.gitignore": "local.txt\n"})
+        self.assertTrue(matcher.is_ignored("sub/local.txt"))
+        self.assertFalse(matcher.is_ignored("local.txt"))
+
+    def test_deeper_gitignore_overrides_shallower(self) -> None:
+        matcher = self._matcher(
+            {".gitignore": "*.tmp\n", "sub/.gitignore": "!special.tmp\n"}
+        )
+        self.assertTrue(matcher.is_ignored("sub/other.tmp"))
+        self.assertFalse(matcher.is_ignored("sub/special.tmp"))
+
+    def test_double_star_patterns(self) -> None:
+        matcher = self._matcher({".gitignore": "docs/**\n**/node.bin\na/**/b\n"})
+        self.assertTrue(matcher.is_ignored("docs/x/y.md"))
+        self.assertFalse(matcher.is_ignored("docs"))
+        self.assertTrue(matcher.is_ignored("deep/tree/node.bin"))
+        self.assertTrue(matcher.is_ignored("a/b"))
+        self.assertTrue(matcher.is_ignored("a/x/y/b"))
+        self.assertFalse(matcher.is_ignored("a/x/c"))
+
+    def test_character_classes_and_question_mark(self) -> None:
+        matcher = self._matcher({".gitignore": "*.py[cod]\nfile?.txt\n"})
+        self.assertTrue(matcher.is_ignored("mod.pyc"))
+        self.assertFalse(matcher.is_ignored("mod.py"))
+        self.assertTrue(matcher.is_ignored("file1.txt"))
+        self.assertFalse(matcher.is_ignored("file10.txt"))
+
+    def test_comments_blanks_and_escapes(self) -> None:
+        matcher = self._matcher({".gitignore": "# note\n\n\\#literal\n"})
+        self.assertTrue(matcher.is_ignored("#literal"))
+        self.assertFalse(matcher.is_ignored("# note"))
+
+    def test_symlinked_gitignore_is_not_read(self) -> None:
+        matcher = self._matcher({"real-ignore.txt": "secret\n"})
+        root = Path(self._directory.name)
+        try:
+            os.symlink(root / "real-ignore.txt", root / ".gitignore")
+        except (OSError, NotImplementedError):
+            self.skipTest("platform does not support symlinks")
+        self.assertFalse(matcher.is_ignored("secret"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_lint_engine.py
+++ b/tests/test_lint_engine.py
@@ -844,5 +844,82 @@ class WalkScopeTests(unittest.TestCase):
         )
 
 
+class GitignoreDisambiguationTests(unittest.TestCase):
+    """Gitignored files must not shadow pages into ambiguity findings."""
+
+    def _lint(self, files: dict[str, str]) -> dict:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory) / "vault"
+            for relative, content in files.items():
+                path = root / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text(content, encoding="utf-8")
+            return lint_engine.lint_vault(root)
+
+    def test_gitignored_shadow_candidate_is_dropped(self) -> None:
+        report = self._lint(
+            {
+                ".gitignore": "/bin/\n",
+                "bin/Thing": "binary artifact\n",
+                "wiki/concepts/Thing.md": "# Thing\n",
+                "wiki/Note.md": "[[Thing]]\n",
+            }
+        )
+        self.assertEqual([], report["ambiguous_targets"])
+        self.assertEqual([], report["dead_links"])
+
+    def test_same_shadow_without_gitignore_stays_ambiguous(self) -> None:
+        report = self._lint(
+            {
+                "bin/Thing": "binary artifact\n",
+                "wiki/concepts/Thing.md": "# Thing\n",
+                "wiki/Note.md": "[[Thing]]\n",
+            }
+        )
+        self.assertEqual(1, len(report["ambiguous_targets"]))
+        self.assertEqual(
+            ["bin/Thing", "wiki/concepts/Thing.md"],
+            report["ambiguous_targets"][0]["candidates"],
+        )
+
+    def test_ambiguity_between_only_ignored_candidates_is_still_reported(self) -> None:
+        report = self._lint(
+            {
+                ".gitignore": "out/\n",
+                "out/a/Thing": "one\n",
+                "out/b/Thing": "two\n",
+                "wiki/Note.md": "[[Thing]]\n",
+            }
+        )
+        self.assertEqual(1, len(report["ambiguous_targets"]))
+        self.assertEqual(
+            ["out/a/Thing", "out/b/Thing"],
+            report["ambiguous_targets"][0]["candidates"],
+        )
+
+    def test_link_whose_only_candidate_is_ignored_still_resolves(self) -> None:
+        report = self._lint(
+            {
+                ".gitignore": "/bin/\n",
+                "bin/OnlyIgnored": "artifact\n",
+                "wiki/Note.md": "[[OnlyIgnored]]\n",
+            }
+        )
+        self.assertEqual([], report["ambiguous_targets"])
+        self.assertEqual([], report["dead_links"])
+
+    def test_index_shadow_no_longer_reports_stale_entry(self) -> None:
+        report = self._lint(
+            {
+                ".gitignore": "artifacts/\n",
+                "artifacts/Thing": "binary\n",
+                "wiki/concepts/Thing.md": "# Thing\n",
+                "wiki/index.md": "[[Thing]]\n",
+            }
+        )
+        self.assertEqual([], report["ambiguous_targets"])
+        self.assertEqual([], report["stale_index_entries"])
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
# Pull request

## Summary
When a vault is adopted at a repository root, gitignored build artifacts can shadow a page's basename and turn every wikilink to that page into a false `ambiguous_targets` finding (plus `stale_index_entries` from index pages), which blocks `checkpoint` with `LINT_FAILED` whenever the artifact exists. Real-world trigger: a compiled Go binary `src/env8oy/bin/env8oy` shadowing `wiki/projects/env8oy.md` made all 17 `[[env8oy]]` links ambiguous. This PR makes lint link resolution gitignore-aware: when a link resolves to multiple candidates and at least one is **not** gitignored, gitignored candidates are dropped before ambiguity is reported.

## Type
- [x] Bug fix (`fix:`)

## Related issue
None filed — happy to open one if you'd like the discussion tracked separately.

## Changes
- `claude_obsidian/gitignore.py` — **new** pure-Python `.gitignore` evaluator (`GitignoreMatcher`): documented gitignore semantics (anchoring, `!` negation, dir-only trailing `/`, `*`/`?`/`[...]`/`**`, nested-scope precedence with last-match-wins, excluded-directory containment). Reads only `.gitignore` files inside the scan root — never `.git/info/exclude`, global excludes, or a `git` subprocess — so the engine stays process-free and deterministic. Case-sensitive by design (git's default; reading `core.ignorecase` would need git config). Symlinked `.gitignore` files skipped; 1 MiB per-file cap; lazy + cached.
- `claude_obsidian/lint_engine.py` — filters gitignored candidates at the single `resolver.resolve()` call site, only when >1 candidates and a non-ignored candidate exists; module docstring updated. Report schema unchanged (`REPORT_VERSION` stays 1); no new keys.
- `tests/test_gitignore.py` — **new**, 12 matcher unit tests.
- `tests/test_lint_engine.py` — new `GitignoreDisambiguationTests` (5 tests), including a control proving the same shadow **without** a `.gitignore` still reports ambiguity, and the two easy-to-get-wrong edges: ambiguity among only-gitignored candidates is still reported, and a link whose only candidate is gitignored still resolves (no new dead links).
- `config/capabilities.json` — declares the new read surface (`vault:**/.gitignore`) in the wiki-lint capability's `read_scope`.
- `skills/wiki-lint/SKILL.md` — one sentence documenting gitignore-aware resolution.
- `CHANGELOG.md` — entry under `## [Unreleased]` / Fixed.

## Compatibility / rollback
- No report-schema change; no new findings categories. The only behavior delta: multi-candidate resolutions that previously reported ambiguity now resolve to the non-gitignored candidate(s). Vaults without `.gitignore` files are byte-identical (verified by the existing determinism tests).
- Gitignored files remain valid link targets when they are the only candidate, so no links become newly dead.
- Rollback is a clean revert of one commit; `gitignore.py` has no other consumers.

## Safety self-review
- [x] Read every file before changing it
- [x] New identifiers named for the next reader
- [x] Smallest unit that works (no speculative abstraction)
- [x] Deletions kept up with additions where applicable
- [x] New behavior has hermetic test coverage
- [x] New failure modes have explicit handling + undo plan (unreadable/oversized/symlinked `.gitignore` → no rules; invalid pattern lines skipped)
- [x] Product code and mutable user-vault state remain separate
- [x] Knowledge writes use one recoverable transaction; workers only draft (n/a — lint stays read-only)
- [x] Network/destructive/external actions have explicit consent (n/a — no egress, no subprocess)
- [x] Claims and capability maturity are evidence-backed

## Testing
```
make test
```
```
All hermetic tests and executable contracts passed.
```
Run from an isolated copy of the tree (a dev checkout nested inside a user vault trips `test_vault_root_separation.py`'s cwd-discovery test on unmodified `main` too — pre-existing location artifact, unrelated to this change). Also verified against the real vault that triggered this: 16 `ambiguous_targets` + 1 `stale_index_entries` → 0/0, and `checkpoint` unblocks.

## Verifier
`agents/verifier.md` dispatched on the worktree scope:

- Verdict: SHIP
- BLOCKER: 0 / HIGH: 0 / MEDIUM: 1 / LOW: 2

The MEDIUM (undeclared `.gitignore` read surface in `config/capabilities.json`) and first LOW (document case-sensitivity in the module docstring) are fixed in this PR. The second LOW noted that a leading `^` in a character class acts as negation; git's own wildmatch also accepts `^` as class negation (`NEGATE_CLASS2`), so behavior matches git and was left as is. The verifier also independently confirmed the regression tests fail against unmodified `main` (not tautological).

## CHANGELOG
- [x] Added an entry under `## [Unreleased]` in `CHANGELOG.md`

## Screenshots / output
Before (vault with a gitignored `bin/env8oy` next to `wiki/projects/env8oy.md`):
```
ERR LINT_FAILED: vault lint has blocking findings: ambiguous_targets=16, stale_index_entries=1
```
After: lint reports 0 `ambiguous_targets`, 0 `stale_index_entries`; `checkpoint` proceeds.

## Notes for reviewer
- The filter sits at the one `resolver.resolve()` call site rather than inside `_Resolver`, so exact-match resolution, backlink (`incoming`) tracking, and fragment validation are untouched; candidate ordering still comes from `_Resolver._deduplicate`.
- Known scope limits (documented in the module docstring): only `.gitignore` files inside the vault root are read; `.git/info/exclude`, global excludes, and `core.ignorecase` are intentionally out of scope to preserve the process-free/deterministic contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
