### PR TITLE
fix: stop_status misreports large complete journals as unreadable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@ implementation record for older releases.
 - The `UNSUPPORTED_PLATFORM` refusal message now points to
   `docs/windows-wsl.md` for users whose WSL setup is itself misbehaving.
 
+### Fixed
+
+- `stop_status` no longer misreports large, complete transaction journals as
+  unreadable: the probe's read cap now matches
+  `MAX_TRANSACTION_RUNTIME_JSON_BYTES` (8 MiB), the package's own bound for
+  runtime JSON of this kind, instead of an inline 64 KiB limit far below what
+  a sanctioned 1024-write transaction can produce. The "unreadable
+  transaction journal(s)" warning also no longer suggests
+  `transaction recover`, which cannot resolve that state.
+
 ## [2.1.0] - 2026-07-31
 
 Native Windows compatibility.

--- a/claude_obsidian/hook_adapter.py
+++ b/claude_obsidian/hook_adapter.py
@@ -20,6 +20,7 @@ from .paths import (
     is_relative_to,
     resolve_vault_root,
 )
+from .transaction import MAX_TRANSACTION_RUNTIME_JSON_BYTES
 
 
 MAX_CONTEXT_BYTES = 32 * 1024
@@ -273,7 +274,9 @@ def stop_status(
                 break
             journal = directory / "journal.json"
             try:
-                payload = _bounded_regular_bytes(root, journal, 64 * 1024)
+                payload = _bounded_regular_bytes(
+                    root, journal, MAX_TRANSACTION_RUNTIME_JSON_BYTES
+                )
                 if payload is None:
                     if journal.exists() or journal.is_symlink():
                         unsafe_journals += 1
@@ -296,7 +299,8 @@ def stop_status(
             warnings.append(f"{unsafe_journals} unsafe transaction journal(s) detected")
         if unreadable_journals:
             warnings.append(
-                f"{unreadable_journals} unreadable transaction journal(s) detected"
+                f"{unreadable_journals} unreadable transaction journal(s) detected "
+                "(not resolved by `transaction recover`; inspect manually)"
             )
     if not warnings:
         return ""

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -260,6 +260,37 @@ def test_stop_status_is_bounded_and_emitted_as_supported_json() -> None:
         assert payload == {"systemMessage": status}
 
 
+def test_stop_status_reads_large_complete_journals_within_transaction_bound() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td)
+        vault = make_vault(base / "vault", "safe\n")
+        transactions = vault / ".vault-meta/transactions"
+        directory = transactions / "operation-000"
+        directory.mkdir(parents=True)
+        # A journal well past the old 64 KiB probe cap but still a valid,
+        # complete transaction record (writes legitimately scale to ~400 KB).
+        padding = "x" * (200 * 1024)
+        (directory / "journal.json").write_text(
+            json.dumps({"state": "complete", "padding": padding}),
+            encoding="utf-8",
+        )
+        status = stop_status(start=vault, environ={}, plugin_root=base / "plugin")
+        assert status == ""
+
+
+def test_stop_status_unreadable_journal_warning_does_not_recommend_recover() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td)
+        vault = make_vault(base / "vault", "safe\n")
+        transactions = vault / ".vault-meta/transactions"
+        directory = transactions / "operation-000"
+        directory.mkdir(parents=True)
+        (directory / "journal.json").write_text("not json", encoding="utf-8")
+        status = stop_status(start=vault, environ={}, plugin_root=base / "plugin")
+        assert "1 unreadable transaction journal(s) detected" in status
+        assert "not resolved by `transaction recover`" in status
+
+
 def main() -> None:
     test_hook_schema_uses_supported_session_start_shape()
     test_context_is_bounded_and_delimiter_safe()
@@ -269,6 +300,8 @@ def main() -> None:
     test_context_rejects_symlinked_hot_cache_and_parent()
     test_context_parent_swap_reads_only_from_pinned_directory()
     test_stop_status_is_bounded_and_emitted_as_supported_json()
+    test_stop_status_reads_large_complete_journals_within_transaction_bound()
+    test_stop_status_unreadable_journal_warning_does_not_recommend_recover()
     print("All hook tests passed.")
 
 


### PR DESCRIPTION
## Problem

`stop_status()` reports healthy, completed transaction journals as "unreadable" whenever the journal exceeds 64 KiB, even though they parse as valid JSON with `"state": "complete"`. The recommended remedy (`claude-obsidian transaction recover`) cannot clear the warning, since it only acts on journals whose state is `prepared`/`applying`/`rollback-failed` — a `complete` journal is skipped, so the fix silently no-ops and the count only grows.

## Root cause

`claude_obsidian/hook_adapter.py`'s journal probe read a bounded prefix through an inline `64 * 1024` cap and immediately parsed it as complete JSON:

```python
payload = _bounded_regular_bytes(root, journal, 64 * 1024)
...
state = strict_json_loads(payload.decode("utf-8")).get("state")
```

`MAX_TRANSACTION_WRITES = 1024` (`transaction.py`) permits transactions whose journals reach roughly 400 KB (~350-450 bytes/write), about 6x the probe's cap. Any journal past the cap is truncated mid-document, fails `json.loads`, and gets counted as unreadable -- in practice this triggers at ~150 writes, well inside documented usage (batch ingest, multi-file saves).

## Fix

- Read up to `MAX_TRANSACTION_RUNTIME_JSON_BYTES` (8 MiB) instead of the inline 64 KiB cap. This is already the package's own bound for runtime JSON of this shape (`transaction.py`), so it's a consistent limit rather than a new one.
- Reworded the `unreadable_journals` warning so it no longer implies `transaction recover` will fix it, since that command provably cannot touch a `complete`-state journal.

## Tests

Added two regression tests to `tests/test_hooks.py`:
- `test_stop_status_reads_large_complete_journals_within_transaction_bound` -- a 200+ KB `complete` journal (well past the old 64 KiB cap, well within the 1024-write ceiling) now reports zero warnings.
- `test_stop_status_unreadable_journal_warning_does_not_recommend_recover` -- a genuinely corrupt journal still reports as unreadable, but the message no longer points at `transaction recover`.

Both fail against the pre-fix code (verified red-before-green) and pass after.

## Verification

```
$ python3 tests/test_hooks.py
All hook tests passed.
```

Ran the full `make test` suite (test-python, test-shell, test-contracts, test-package) under WSL Ubuntu, Python 3.14.4, per `docs/windows-wsl.md`. One pre-existing failure (`test_contracts.py::test_canonical_core_capabilities_report_only_behavioral_verification`, a `wiki-lint` verifier timeout unrelated to this change) reproduces identically on unmodified `main` via `git stash` -- confirmed unrelated to this fix. Everything else passes, including `test-shell`'s 56 wiki-lock cases and `test-package`'s validator.

Closes #164