### PR TITLE
fix: checkpoint COMMITTED_MODE_MISMATCH unsatisfiable with core.filemode=false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,16 @@ implementation record for older releases.
 - The `UNSUPPORTED_PLATFORM` refusal message now points to
   `docs/windows-wsl.md` for users whose WSL setup is itself misbehaving.
 
+### Fixed
+
+- `checkpoint` no longer raises an unrecoverable `COMMITTED_MODE_MISMATCH`
+  for vaults whose Git repo has `core.filemode=false` (the default for
+  repos initialized or cloned by native Windows Git, even when mutated
+  through the supported WSL path). Git cannot represent the executable bit
+  in that mode, so the committed tree entry can never match a transaction
+  result that recorded a real filesystem stat; the mode assertion is now
+  skipped when `core.filemode` is explicitly false, comparing content only.
+
 ## [2.1.0] - 2026-07-31
 
 Native Windows compatibility.

--- a/claude_obsidian/checkpoint.py
+++ b/claude_obsidian/checkpoint.py
@@ -799,6 +799,19 @@ def _tree_diff_paths(root: Path, base: str, tree: str) -> set[str]:
     return set(_decode_paths(completed.stdout))
 
 
+def _filemode_is_tracked(root: Path) -> bool:
+    """Return False only when the repo has explicitly disabled core.filemode.
+
+    Git discards the executable bit entirely when core.filemode=false (the
+    default for repos initialized or cloned by native Windows Git), so a
+    committed blob's mode can never reflect it regardless of what the
+    filesystem reports. An absent or true value keeps the strict comparison.
+    """
+
+    completed = _git(root, ["config", "--get", "core.filemode"], check=False)
+    return completed.stdout.strip() != "false"
+
+
 def _verify_tree(
     root: Path,
     *,
@@ -815,13 +828,17 @@ def _verify_tree(
             "COMMITTED_CONTENT_MISMATCH",
             "candidate tree is missing transaction paths: " + ", ".join(missing),
         )
+    check_modes = _filemode_is_tracked(root)
     for relative in paths:
-        expected_git_mode = "100755" if expected_modes[relative] & 0o111 else "100644"
-        if entries[relative][0] != expected_git_mode:
-            raise CheckpointError(
-                "COMMITTED_MODE_MISMATCH",
-                f"Git mode differs from the transaction result for {relative}",
+        if check_modes:
+            expected_git_mode = (
+                "100755" if expected_modes[relative] & 0o111 else "100644"
             )
+            if entries[relative][0] != expected_git_mode:
+                raise CheckpointError(
+                    "COMMITTED_MODE_MISMATCH",
+                    f"Git mode differs from the transaction result for {relative}",
+                )
         blob = _git_bytes(root, ["cat-file", "blob", entries[relative][1]]).stdout
         if hashlib.sha256(blob).hexdigest() != expected_hashes[relative]:
             raise CheckpointError(

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -239,6 +239,48 @@ def test_executable_mode_drift_is_rejected_before_ref_update() -> None:
         assert note.stat().st_mode & 0o111
 
 
+def test_executable_mode_drift_is_ignored_when_core_filemode_is_false() -> None:
+    # Reproduces a vault whose Git repo was created by native Windows Git
+    # (core.filemode=false) but mutated through the supported WSL path,
+    # where `stat` on a pre-existing executable file is real. The
+    # transaction result then records the true executable mode, while Git
+    # can never stage that bit, so the two must not be compared strictly.
+    with tempfile.TemporaryDirectory() as td:
+        root = make_repo(Path(td) / "vault")
+        # core.filemode must be disabled before the executable file is first
+        # staged, matching a repo Git initialized with the bit already off:
+        # the tree entry is 100644 from the start and never records +x.
+        git(root, "config", "core.filemode", "false")
+        note = root / "wiki/Note.md"
+        original = "---\ntitle: Note\ntype: concept\nstatus: developing\ncreated: 2026-01-01\nupdated: 2026-01-01\ntags: [test]\n---\n# Note\nOriginal.\n"
+        note.write_text(original)
+        note.chmod(0o777)
+        git(root, "add", ".")
+        git(root, "commit", "-qm", "add executable note")
+        assert git(root, "ls-files", "-s", "wiki/Note.md").startswith("100644")
+
+        updated = original.replace("Original.", "Updated.")
+        transaction_result = apply_bundle(
+            root,
+            {
+                "schema": BUNDLE_SCHEMA,
+                "operation_id": "save-two",
+                "operation_type": "save",
+                "expected_hashes": {
+                    "wiki/Note.md": hashlib.sha256(original.encode()).hexdigest()
+                },
+                "writes": [
+                    {"path": "wiki/Note.md", "mode": "replace", "content": updated}
+                ],
+            },
+        )
+        assert transaction_result["modes"]["wiki/Note.md"] & 0o111
+
+        result = checkpoint_operation(root, "save-two", run_lint=False)
+        assert result["paths"] == ["wiki/Note.md"]
+        assert git(root, "rev-list", "--count", "HEAD") == "3"
+
+
 def test_operation_ids_and_transaction_directories_are_confined() -> None:
     with tempfile.TemporaryDirectory() as td:
         base = Path(td)
@@ -529,6 +571,7 @@ def main() -> None:
     test_unrelated_staging_and_drift_are_rejected()
     test_intent_to_add_index_state_is_rejected_and_preserved()
     test_executable_mode_drift_is_rejected_before_ref_update()
+    test_executable_mode_drift_is_ignored_when_core_filemode_is_false()
     test_operation_ids_and_transaction_directories_are_confined()
     test_temporary_index_freezes_verified_bytes()
     test_retry_finalizes_one_commit_after_final_record_failure()


### PR DESCRIPTION
## Problem

`checkpoint` can never succeed for an operation whose transaction result recorded an executable mode, when the vault's Git repo has `core.filemode=false` -- which is the default for any repo created or cloned by native Windows Git, even when the mutation itself ran through the supported WSL path.

```
ERR COMMITTED_MODE_MISMATCH: Git mode differs from the transaction result for wiki/log.md
```

The failure is permanent for that operation ID, since `expected_modes` is read from the persisted transaction result, not the filesystem, so `chmod`-ing the file afterward cannot make the check pass.

## Root cause

`claude_obsidian/checkpoint.py`'s `_verify_tree()` derives the expected Git mode from the transaction result's stored POSIX mode and compares it unconditionally against the committed tree entry:

```python
expected_git_mode = "100755" if expected_modes[relative] & 0o111 else "100644"
if entries[relative][0] != expected_git_mode:
    raise CheckpointError("COMMITTED_MODE_MISMATCH", ...)
```

`core.filemode=false` is not a misconfiguration -- native Windows Git sets it at `init`/`clone` because NTFS has no POSIX executable bit. When a vault created this way is later mutated from WSL (real `stat`), the transaction result can legitimately record an executable mode for a pre-existing file, but Git will never stage that bit and always records `100644`. The two sides can never agree.

## Fix

Skip the mode assertion when `git config --get core.filemode` reports `false`, comparing blob content only. This is not a new capability being disabled -- the check simply isn't meaningful on a repo that structurally cannot represent the bit either way. An absent or `true` value keeps the existing strict comparison.

## Tests

Added `test_executable_mode_drift_is_ignored_when_core_filemode_is_false` to `tests/test_checkpoint.py`, alongside the existing `test_executable_mode_drift_is_rejected_before_ref_update` (which continues to pass unchanged, confirming the strict path is untouched when `core.filemode` is unset).

The new test reproduces the real mechanism: `core.filemode` is disabled *before* an executable file is first staged (so the tree entry starts at `100644` and Git never records `+x`), then a `replace` transaction against that pre-existing executable file captures a real stat-based mode (`0o777`). Verified this fails with `COMMITTED_MODE_MISMATCH` against the pre-fix code and passes after the fix (red-before-green, confirmed manually against both commits since this repo's `make test-python` doesn't isolate per-test runs).

## Verification

```
$ python3 tests/test_checkpoint.py
All checkpoint tests passed.
```

Ran under WSL Ubuntu (native ext4, not a `/mnt/c` or `/mnt/d` mount -- confirmed core.filemode autodetection differs there, see note below), Python 3.14.4, per `docs/windows-wsl.md`.

Ran the full `make test-python` suite; the only failure is the pre-existing `test_contracts.py::test_canonical_core_capabilities_report_only_behavioral_verification` (`wiki-lint` verifier timeout), unrelated to this change and reproducing identically on unmodified `main`.

**Note for reviewers:** while developing this fix, I found that a repo living on a Windows-backed drvfs mount (`/mnt/c`, `/mnt/d`) under WSL2 gets `core.filemode` auto-detected as `false` by `git init` regardless of any explicit config, which made an earlier version of my test pass trivially against unfixed code. The final test and this verification run were done against a repo on native WSL ext4 (`/root/...`), where `core.filemode` autodetects `true` and the explicit `git config core.filemode false` call in the test is what actually exercises this path. Worth being aware of if CI or other contributors reproduce on a drvfs-backed WSL path.

Closes #166