### PR TITLE
fix(migration): preserve unresolved legacy batch labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ implementation record for older releases.
 - The `UNSUPPORTED_PLATFORM` refusal message now points to
   `docs/windows-wsl.md` for users whose WSL setup is itself misbehaving.
 
+### Fixed
+
+- Legacy migration and adoption no longer fail when a manifest source key is a
+  valid batch label rather than a file. Unresolved labels are preserved as
+  unreviewed manual sources without inventing payload mappings or hashes.
+  Apply now rejects a reviewed migration if a legacy locator's file state
+  changes or becomes unsafe before the transaction writes.
+
 ## [2.1.0] - 2026-07-31
 
 Native Windows compatibility.

--- a/claude_obsidian/ledgers.py
+++ b/claude_obsidian/ledgers.py
@@ -1236,7 +1236,14 @@ def migrate_legacy_manifest(
                 }
             )
             continue
-        source_id = stable_source_id("file", locator, digest)
+        # Some legacy generators used a canonical path-shaped batch label
+        # rather than a file locator.  _safe_hash returns None only when that
+        # safely inspected path is absent; unsafe and non-regular nodes raise.
+        # Preserve an absent legacy identity without inventing a payload or
+        # treating its short legacy hash as SHA-256.
+        origin_kind = "file" if digest is not None else "manual"
+        content_kind = "document" if digest is not None else "other"
+        source_id = stable_source_id(origin_kind, locator, digest)
         if source_id in source_ledger["sources"]:
             migration_errors.append(
                 {
@@ -1274,8 +1281,8 @@ def migrate_legacy_manifest(
             )
             continue
         source_ledger["sources"][source_id] = {
-            "origin": {"kind": "file", "locator": locator},
-            "content_kind": "document",
+            "origin": {"kind": origin_kind, "locator": locator},
+            "content_kind": content_kind,
             "title": Path(locator).stem,
             "authority": "unknown",
             "content_sha256": digest,
@@ -1306,6 +1313,10 @@ def migration_bundle(
 ) -> dict[str, Any]:
     root = canonical(vault_root)
     sources, claims = migrate_legacy_manifest(root, generated_at=generated_at)
+    read_preconditions = {
+        record["origin"]["locator"]: record["content_sha256"]
+        for record in sources["sources"].values()
+    }
     validate_existing_canonical_state(root, fallback_source_ledger=sources)
     writes: list[dict[str, Any]] = []
     expected: dict[str, str | None] = {}
@@ -1342,10 +1353,13 @@ def migration_bundle(
                 + "\n",
             }
         )
-    return {
+    bundle = {
         "schema": BUNDLE_SCHEMA,
         "operation_id": operation_id,
         "operation_type": "migration",
         "expected_hashes": expected,
         "writes": writes,
     }
+    if SOURCE_PATH in expected:
+        bundle["read_preconditions"] = read_preconditions
+    return bundle

--- a/claude_obsidian/transaction.py
+++ b/claude_obsidian/transaction.py
@@ -2311,11 +2311,21 @@ def _remove_pinned_runtime_tree_at(
         )
     if remaining is None:
         remaining = [MAX_TRANSACTION_RUNTIME_TREE_ENTRIES]
-    child_names = _bounded_runtime_names(
-        directory_fd,
-        limit=remaining[0],
-        label=f"transaction runtime {component}",
-    )
+    scan_fd = _open_runtime_directory_at(parent_fd, component, create=False)
+    try:
+        pinned = os.fstat(directory_fd)
+        scanned = os.fstat(scan_fd)
+        if (pinned.st_dev, pinned.st_ino) != (scanned.st_dev, scanned.st_ino):
+            raise _LockIdentityChanged(
+                f"runtime directory changed before enumeration: {component}"
+            )
+        child_names = _bounded_runtime_names(
+            scan_fd,
+            limit=remaining[0],
+            label=f"transaction runtime {component}",
+        )
+    finally:
+        os.close(scan_fd)
     remaining[0] -= len(child_names)
     for child_name in child_names:
         metadata = os.stat(child_name, dir_fd=directory_fd, follow_symlinks=False)

--- a/claude_obsidian/transaction.py
+++ b/claude_obsidian/transaction.py
@@ -3339,6 +3339,12 @@ def _prepare_writes(
                 f"expected hash for {normalized_path} must be SHA-256 or null",
             )
         normalized_expected[normalized_path] = digest
+    _assert_read_preconditions(
+        vault_root,
+        bundle,
+        root_fd=root_fd,
+        meta_fd=meta_fd,
+    )
     seen: set[str] = set()
     seen_casefold: dict[str, str] = {}
     prepared: list[PreparedWrite] = []
@@ -3511,6 +3517,75 @@ def _prepare_writes(
     _validate_operation_bundle_scope(str(bundle.get("operation_type")), prepared)
     _validate_provenance_writes(vault_root, prepared, root_fd=root_fd, meta_fd=meta_fd)
     return prepared
+
+
+def _assert_read_preconditions(
+    vault_root: Path,
+    bundle: Mapping[str, Any],
+    *,
+    root_fd: int | None = None,
+    meta_fd: int | None = None,
+) -> None:
+    """Require non-write inputs to retain their reviewed file state."""
+
+    raw = bundle.get("read_preconditions", {})
+    if not isinstance(raw, dict):
+        raise TransactionValidationError(
+            "INVALID_READ_PRECONDITIONS",
+            "read_preconditions must be an object",
+        )
+    if len(raw) > MAX_TRANSACTION_WRITES:
+        raise TransactionValidationError(
+            "TRANSACTION_WRITE_LIMIT",
+            f"read preconditions exceed the {MAX_TRANSACTION_WRITES}-path limit",
+        )
+    normalized: dict[str, str | None] = {}
+    casefolded: dict[str, str] = {}
+    for raw_path, digest in raw.items():
+        path = (
+            _normalize_vault_path(raw_path)
+            if root_fd is not None
+            else _safe_vault_path(vault_root, raw_path)[0]
+        )
+        folded = _portable_name_key(path)
+        prior = casefolded.get(folded)
+        if prior is not None and prior != path:
+            raise TransactionValidationError(
+                "CASEFOLD_PATH_COLLISION",
+                f"read preconditions contain case-colliding paths: {prior}, {path}",
+            )
+        casefolded[folded] = path
+        if digest is not None and (
+            not isinstance(digest, str)
+            or len(digest) != 64
+            or digest != digest.lower()
+            or any(character not in "0123456789abcdef" for character in digest)
+        ):
+            raise TransactionValidationError(
+                "INVALID_READ_PRECONDITION",
+                f"read precondition for {path} must be SHA-256 or null",
+            )
+        normalized[path] = digest
+    for path, expected in normalized.items():
+        try:
+            observed = _safe_hash(
+                vault_root,
+                path,
+                root_fd=root_fd,
+                meta_fd=meta_fd,
+            )
+        except TransactionValidationError:
+            raise
+        except OSError as exc:
+            raise TransactionValidationError(
+                "UNSAFE_READ_PRECONDITION",
+                f"cannot inspect read precondition {path}: {exc}",
+            ) from exc
+        if observed != expected:
+            raise TransactionConflict(
+                "READ_PRECONDITION_MISMATCH",
+                f"{path} changed since the operation was drafted",
+            )
 
 
 def _validate_provenance_writes(
@@ -4601,6 +4676,12 @@ def apply_bundle(
                 _assert_transaction_namespaces(mutation_lock, runtime, operation)
 
                 try:
+                    _assert_read_preconditions(
+                        vault,
+                        bundle,
+                        root_fd=runtime.root_fd,
+                        meta_fd=runtime.meta_fd,
+                    )
                     for index, write in enumerate(prepared, start=1):
                         _assert_transaction_namespaces(
                             mutation_lock, runtime, operation

--- a/claude_obsidian/vault_ops.py
+++ b/claude_obsidian/vault_ops.py
@@ -105,10 +105,15 @@ def build_vault_bundle(
         source_ledger, claim_ledger = migrate_legacy_manifest(
             vault, generated_at=generated_at
         )
+        read_preconditions = {
+            record["origin"]["locator"]: record["content_sha256"]
+            for record in source_ledger["sources"].values()
+        }
         validate_existing_canonical_state(vault, fallback_source_ledger=source_ledger)
     else:
         source_ledger = empty_source_ledger(generated_at=generated_at)
         claim_ledger = empty_claim_ledger(generated_at=generated_at)
+        read_preconditions = {}
     planned[SOURCE_PATH] = (
         json.dumps(
             source_ledger,
@@ -150,10 +155,13 @@ def build_vault_bundle(
                 "sha256": new_hash,
             }
         )
-    return {
+    bundle = {
         "schema": BUNDLE_SCHEMA,
         "operation_id": operation_id,
         "operation_type": operation_type,
         "expected_hashes": expected,
         "writes": writes,
     }
+    if adopt and SOURCE_PATH in expected:
+        bundle["read_preconditions"] = read_preconditions
+    return bundle

--- a/skills/wiki/references/provenance.md
+++ b/skills/wiki/references/provenance.md
@@ -62,4 +62,13 @@ python3 "$CORE" migrate --vault VAULT \
 
 Migration leaves `.raw/.manifest.json` byte-for-byte unchanged, creates missing
 ledgers, defaults unknown evidence fields honestly, and never extracts claims
-from legacy prose automatically.
+from legacy prose automatically. A legacy source key that resolves to a regular
+file remains a file source with its computed SHA-256. A valid key with no file
+is preserved as an unreviewed manual source with unknown authority and no
+verified payload hash. This unresolved record preserves the legacy identity,
+date, and page links; it does not prove a batch-to-file relationship. Migration
+never enumerates raw payloads to invent that relationship or promotes the
+legacy short hash to SHA-256.
+The reviewed migration bundle also pins each legacy locator's observed file
+state. Apply fails if an unresolved label appears, becomes unsafe, cannot be
+inspected, or if a file source changes after review.

--- a/tests/test_ledgers.py
+++ b/tests/test_ledgers.py
@@ -3,8 +3,10 @@
 
 from __future__ import annotations
 
-import json
 import hashlib
+import json
+import os
+import socket
 import sys
 import tempfile
 from datetime import date, datetime
@@ -26,9 +28,12 @@ from claude_obsidian.ledgers import (
 )
 from claude_obsidian.transaction import (
     BUNDLE_SCHEMA,
+    TransactionConflict,
     TransactionValidationError,
     apply_bundle,
+    inspect_bundle,
 )
+import claude_obsidian.transaction as transaction_module
 
 
 def make_vault(root: Path) -> Path:
@@ -92,6 +97,456 @@ def test_migration_preserves_manifest_and_is_idempotent() -> None:
         )
         assert validate_source_ledger(sources, vault_root=vault) == []
         assert claims["claims"] == {}
+
+
+def test_migration_preserves_unresolved_legacy_batch_as_manual_source() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        vault = make_vault(Path(td) / "vault")
+        batch_locator = "sources/day0/2026-07-16-day0-exports"
+        payload = vault / ".raw/sources/day0/export.json"
+        payload.parent.mkdir(parents=True)
+        payload.write_text('{"source":"real payload"}\n', encoding="utf-8")
+        page = vault / "wiki/sources/Day 0.md"
+        page.parent.mkdir(parents=True)
+        page.write_text("# Day 0\n", encoding="utf-8")
+        manifest = {
+            "version": 1,
+            "sources": {
+                batch_locator: {
+                    "hash": "52ffa724ac942c32",
+                    "ingested_at": "2026-07-16",
+                    "pages_created": ["wiki/sources/Day 0.md"],
+                    "note": "Batch of 4 read-only files",
+                }
+            },
+        }
+        legacy_path = vault / ".raw/.manifest.json"
+        legacy_path.write_text(
+            json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8"
+        )
+        legacy_before = legacy_path.read_bytes()
+
+        raw_root = vault / ".raw/sources"
+        raw_identities = {
+            (raw_root.stat().st_dev, raw_root.stat().st_ino),
+            (payload.parent.stat().st_dev, payload.parent.stat().st_ino),
+        }
+        real_listdir = os.listdir
+        real_scandir = os.scandir
+
+        def is_raw_payload_directory(value: object) -> bool:
+            try:
+                metadata = (
+                    os.fstat(value)
+                    if isinstance(value, int)
+                    else os.stat(value)  # type: ignore[arg-type]
+                )
+            except (OSError, TypeError, ValueError):
+                return False
+            return (metadata.st_dev, metadata.st_ino) in raw_identities
+
+        def guarded_listdir(path: object = ".") -> list[str]:
+            if is_raw_payload_directory(path):
+                raise AssertionError("migration must not enumerate raw payloads")
+            return real_listdir(path)  # type: ignore[arg-type]
+
+        def guarded_scandir(path: object = ".") -> os.ScandirIterator[str]:
+            if is_raw_payload_directory(path):
+                raise AssertionError("migration must not enumerate raw payloads")
+            return real_scandir(path)  # type: ignore[arg-type]
+
+        transaction_module.os.listdir = guarded_listdir
+        transaction_module.os.scandir = guarded_scandir
+        try:
+            sources, claims = migrate_legacy_manifest(
+                vault, generated_at="2026-07-17T00:00:00Z"
+            )
+        finally:
+            transaction_module.os.listdir = real_listdir
+            transaction_module.os.scandir = real_scandir
+        source_id = stable_source_id("manual", batch_locator, None)
+        assert sources["sources"] == {
+            source_id: {
+                "origin": {"kind": "manual", "locator": batch_locator},
+                "content_kind": "other",
+                "title": "2026-07-16-day0-exports",
+                "authority": "unknown",
+                "content_sha256": None,
+                "ingested_at": "2026-07-16",
+                "retrieved_at": None,
+                "refresh_due": None,
+                "review_status": "unreviewed",
+                "independence_key": None,
+                "pages": ["wiki/sources/Day 0.md"],
+                "supersedes": None,
+            }
+        }
+        assert validate_source_ledger(sources, vault_root=vault) == []
+        assert claims["claims"] == {}
+        assert "52ffa724ac942c32" not in json.dumps(sources)
+        assert ".raw/sources/day0/export.json" not in json.dumps(sources)
+
+        operation = migration_bundle(
+            vault,
+            operation_id="migrate-batch",
+            generated_at="2026-07-17T00:00:00Z",
+        )
+        apply_bundle(vault, operation)
+        assert legacy_path.read_bytes() == legacy_before
+        assert payload.read_text(encoding="utf-8") == '{"source":"real payload"}\n'
+        canonical_path = vault / "wiki/meta/ledgers/source-ledger.json"
+        canonical_before = canonical_path.read_bytes()
+
+        file_path = vault / batch_locator
+        file_path.parent.mkdir(parents=True)
+        file_path.write_text("later file\n", encoding="utf-8")
+        rerun = migration_bundle(
+            vault,
+            operation_id="migrate-batch-again",
+            generated_at="2026-07-18T00:00:00Z",
+        )
+        assert rerun["writes"] == []
+        assert canonical_path.read_bytes() == canonical_before
+
+
+def test_migration_plan_changes_if_batch_locator_appears_before_apply() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        vault = make_vault(Path(td) / "vault")
+        locator = "sources/research/2026-07-17-batch"
+        (vault / ".raw/.manifest.json").write_text(
+            json.dumps(
+                {
+                    "sources": {
+                        locator: {
+                            "hash": "163d1efedba075cb",
+                            "ingested_at": "2026-07-17",
+                            "pages_created": [],
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        absent = migration_bundle(
+            vault,
+            operation_id="batch-absent",
+            generated_at="2026-07-17T00:00:00Z",
+        )
+        reviewed = inspect_bundle(vault, absent)
+        absent_write = next(
+            write
+            for write in absent["writes"]
+            if write["path"] == "wiki/meta/ledgers/source-ledger.json"
+        )
+        absent_sources = json.loads(absent_write["content"])["sources"]
+        assert set(absent_sources) == {stable_source_id("manual", locator, None)}
+        assert absent["read_preconditions"] == {locator: None}
+
+        source_path = vault / locator
+        source_path.parent.mkdir(parents=True)
+        source_path.write_text("now present\n", encoding="utf-8")
+        try:
+            apply_bundle(
+                vault,
+                absent,
+                approved_plan_sha256=reviewed["approval_sha256"],
+            )
+        except TransactionConflict as exc:
+            assert exc.code == "READ_PRECONDITION_MISMATCH"
+        else:
+            raise AssertionError(
+                "the original approved absent-source plan must be rejected"
+            )
+        assert not (vault / "wiki/meta/ledgers/source-ledger.json").exists()
+
+        digest = hashlib.sha256(b"now present\n").hexdigest()
+        present = migration_bundle(
+            vault,
+            operation_id="batch-absent",
+            generated_at="2026-07-17T00:00:00Z",
+        )
+        present_write = next(
+            write
+            for write in present["writes"]
+            if write["path"] == "wiki/meta/ledgers/source-ledger.json"
+        )
+        present_sources = json.loads(present_write["content"])["sources"]
+        assert set(present_sources) == {stable_source_id("file", locator, digest)}
+        assert present["read_preconditions"] == {locator: digest}
+        assert present != absent
+        try:
+            apply_bundle(
+                vault,
+                present,
+                approved_plan_sha256=reviewed["approval_sha256"],
+            )
+        except TransactionValidationError as exc:
+            assert exc.code == "PLAN_CHANGED"
+        else:
+            raise AssertionError("stale manual-source approval must be rejected")
+        assert not (vault / "wiki/meta/ledgers/source-ledger.json").exists()
+
+
+def test_migration_original_plan_rejects_unsafe_locator_state_changes() -> None:
+    node_kinds = ["directory", "symlink", "broken_symlink"]
+    if hasattr(socket, "AF_UNIX"):
+        node_kinds.append("socket")
+    for node_kind in node_kinds:
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            vault = make_vault(base / "vault")
+            locator = ".raw/u"
+            (vault / ".raw/.manifest.json").write_text(
+                json.dumps(
+                    {
+                        "sources": {
+                            locator: {
+                                "ingested_at": "2026-07-17",
+                                "pages_created": [],
+                            }
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            operation = migration_bundle(
+                vault,
+                operation_id=f"stale-{node_kind}",
+                generated_at="2026-07-17T00:00:00Z",
+            )
+            reviewed = inspect_bundle(vault, operation)
+            target = vault / locator
+            target.parent.mkdir(parents=True, exist_ok=True)
+            unix_socket: socket.socket | None = None
+            if node_kind == "directory":
+                target.mkdir()
+            elif node_kind == "symlink":
+                outside = base / "outside.txt"
+                outside.write_text("outside\n", encoding="utf-8")
+                target.symlink_to(outside)
+            elif node_kind == "broken_symlink":
+                target.symlink_to(base / "missing.txt")
+            else:
+                unix_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                unix_socket.bind(str(target))
+            try:
+                try:
+                    apply_bundle(
+                        vault,
+                        operation,
+                        approved_plan_sha256=reviewed["approval_sha256"],
+                    )
+                except (TransactionConflict, TransactionValidationError) as exc:
+                    assert exc.code in {
+                        "READ_PRECONDITION_MISMATCH",
+                        "SYMLINK_WRITE_PATH",
+                        "UNSAFE_READ_PRECONDITION",
+                        "UNSAFE_VAULT_PATH",
+                    }
+                else:
+                    raise AssertionError(
+                        f"the original plan must reject a new {node_kind} locator"
+                    )
+                assert not (
+                    vault / "wiki/meta/ledgers/source-ledger.json"
+                ).exists()
+            finally:
+                if unix_socket is not None:
+                    unix_socket.close()
+
+
+def test_migration_original_plan_rejects_uninspectable_locator() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        vault = make_vault(Path(td) / "vault")
+        locator = "sources/research/uninspectable-batch"
+        (vault / ".raw/.manifest.json").write_text(
+            json.dumps(
+                {
+                    "sources": {
+                        locator: {
+                            "ingested_at": "2026-07-17",
+                            "pages_created": [],
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        operation = migration_bundle(
+            vault,
+            operation_id="uninspectable-after-review",
+            generated_at="2026-07-17T00:00:00Z",
+        )
+        reviewed = inspect_bundle(vault, operation)
+        real_safe_hash = transaction_module._safe_hash
+
+        def denied_safe_hash(
+            vault_root: Path,
+            relative: str,
+            *,
+            root_fd: int | None = None,
+            meta_fd: int | None = None,
+        ) -> str | None:
+            if relative == locator:
+                raise PermissionError("synthetic permission denial")
+            return real_safe_hash(
+                vault_root,
+                relative,
+                root_fd=root_fd,
+                meta_fd=meta_fd,
+            )
+
+        transaction_module._safe_hash = denied_safe_hash
+        try:
+            try:
+                apply_bundle(
+                    vault,
+                    operation,
+                    approved_plan_sha256=reviewed["approval_sha256"],
+                )
+            except TransactionValidationError as exc:
+                assert exc.code == "UNSAFE_READ_PRECONDITION"
+            else:
+                raise AssertionError("an uninspectable locator must fail closed")
+        finally:
+            transaction_module._safe_hash = real_safe_hash
+        assert not (vault / "wiki/meta/ledgers/source-ledger.json").exists()
+
+
+def test_migration_locked_recheck_rolls_back_and_allows_clean_retry() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        vault = make_vault(Path(td) / "vault")
+        locator = ".raw/locked-batch"
+        (vault / ".raw/.manifest.json").write_text(
+            json.dumps(
+                {
+                    "sources": {
+                        locator: {
+                            "ingested_at": "2026-07-17",
+                            "pages_created": [],
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        operation = migration_bundle(
+            vault,
+            operation_id="locked-read-recheck",
+            generated_at="2026-07-17T00:00:00Z",
+        )
+        reviewed = inspect_bundle(vault, operation)
+        target = vault / locator
+        real_check = transaction_module._assert_read_preconditions
+        checks = 0
+
+        def change_after_locked_prepare(
+            vault_root: Path,
+            bundle: dict[str, object],
+            *,
+            root_fd: int | None = None,
+            meta_fd: int | None = None,
+        ) -> None:
+            nonlocal checks
+            checks += 1
+            if checks == 3:
+                target.write_text("appeared after locked prepare\n", encoding="utf-8")
+            real_check(
+                vault_root,
+                bundle,
+                root_fd=root_fd,
+                meta_fd=meta_fd,
+            )
+
+        transaction_module._assert_read_preconditions = change_after_locked_prepare
+        try:
+            try:
+                apply_bundle(
+                    vault,
+                    operation,
+                    approved_plan_sha256=reviewed["approval_sha256"],
+                )
+            except TransactionConflict as exc:
+                assert exc.code == "READ_PRECONDITION_MISMATCH"
+            else:
+                raise AssertionError("the locked prewrite recheck must reject drift")
+        finally:
+            transaction_module._assert_read_preconditions = real_check
+        assert checks == 3
+        source_path = vault / "wiki/meta/ledgers/source-ledger.json"
+        claim_path = vault / "wiki/meta/ledgers/claim-ledger.json"
+        assert not source_path.exists()
+        assert not claim_path.exists()
+        transaction_path = (
+            vault
+            / ".vault-meta/transactions/locked-read-recheck/journal.json"
+        )
+        journal = json.loads(transaction_path.read_text(encoding="utf-8"))
+        assert journal["state"] == "rolled-back"
+        assert journal["applied"] == []
+
+        target.unlink()
+        result = apply_bundle(
+            vault,
+            operation,
+            approved_plan_sha256=reviewed["approval_sha256"],
+        )
+        assert result["status"] == "complete"
+        assert source_path.is_file()
+        assert claim_path.is_file()
+        retry_journal = json.loads(transaction_path.read_text(encoding="utf-8"))
+        assert retry_journal["state"] == "complete"
+
+
+def test_migration_missing_fallback_never_masks_unsafe_existing_nodes() -> None:
+    node_kinds = ["directory", "symlink", "broken_symlink"]
+    if hasattr(socket, "AF_UNIX"):
+        node_kinds.append("socket")
+    for node_kind in node_kinds:
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            vault = make_vault(base / "vault")
+            locator = ".raw/unsafe-source"
+            target = vault / locator
+            unix_socket: socket.socket | None = None
+            if node_kind == "directory":
+                target.mkdir()
+            elif node_kind == "symlink":
+                outside = base / "outside.txt"
+                outside.write_text("outside\n", encoding="utf-8")
+                target.symlink_to(outside)
+            elif node_kind == "broken_symlink":
+                target.symlink_to(base / "missing.txt")
+            else:
+                unix_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+                unix_socket.bind(str(target))
+            (vault / ".raw/.manifest.json").write_text(
+                json.dumps(
+                    {
+                        "sources": {
+                            locator: {
+                                "ingested_at": "2026-07-17",
+                                "pages_created": [],
+                            }
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+            try:
+                try:
+                    migrate_legacy_manifest(
+                        vault, generated_at="2026-07-17T00:00:00Z"
+                    )
+                except LedgerValidationError as exc:
+                    assert "cannot inspect source safely" in str(exc)
+                else:
+                    raise AssertionError(
+                        f"{node_kind} source must not become a manual legacy record"
+                    )
+            finally:
+                if unix_socket is not None:
+                    unix_socket.close()
 
 
 def test_migration_rejects_non_nfc_file_aliases_portably() -> None:
@@ -1190,6 +1645,12 @@ def test_datetime_audit_inputs_are_rejected_explicitly() -> None:
 def main() -> None:
     test_stable_source_ids()
     test_migration_preserves_manifest_and_is_idempotent()
+    test_migration_preserves_unresolved_legacy_batch_as_manual_source()
+    test_migration_plan_changes_if_batch_locator_appears_before_apply()
+    test_migration_original_plan_rejects_unsafe_locator_state_changes()
+    test_migration_original_plan_rejects_uninspectable_locator()
+    test_migration_locked_recheck_rolls_back_and_allows_clean_retry()
+    test_migration_missing_fallback_never_masks_unsafe_existing_nodes()
     test_migration_rejects_non_nfc_file_aliases_portably()
     test_migration_never_reads_a_symlinked_legacy_manifest()
     test_migration_rejects_malformed_existing_canonical_ledgers()

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -2206,6 +2206,39 @@ def test_runtime_directory_cardinality_and_removal_are_bounded() -> None:
             transaction_module.MAX_TRANSACTION_RUNTIME_TREE_ENTRIES = original_tree
 
 
+def test_runtime_removal_enumerates_through_a_fresh_descriptor() -> None:
+    if not transaction_module._supports_confined_dirfd():
+        return
+    with tempfile.TemporaryDirectory() as td:
+        vault = make_vault(Path(td) / "vault")
+        transactions = vault / ".vault-meta/transactions"
+        operation = transactions / "cursor-at-end"
+        backups = operation / "backups"
+        backups.mkdir(parents=True)
+        (operation / "bundle.json").write_text("{}\n", encoding="utf-8")
+        (backups / "original.bin").write_bytes(b"original\n")
+
+        parent_fd = os.open(
+            transactions,
+            os.O_RDONLY | os.O_DIRECTORY | getattr(os, "O_CLOEXEC", 0),
+        )
+        operation_fd = transaction_module._open_runtime_directory_at(
+            parent_fd, "cursor-at-end", create=False
+        )
+        try:
+            try:
+                os.lseek(operation_fd, 0, os.SEEK_END)
+            except OSError:
+                return
+            transaction_module._remove_pinned_runtime_tree_at(
+                parent_fd, "cursor-at-end", operation_fd
+            )
+        finally:
+            os.close(operation_fd)
+            os.close(parent_fd)
+        assert not operation.exists()
+
+
 def test_mutation_and_runtime_descriptors_do_not_leak() -> None:
     descriptor_directory = next(
         (path for path in (Path("/proc/self/fd"), Path("/dev/fd")) if path.is_dir()),
@@ -2579,6 +2612,7 @@ def main() -> None:
     test_meta_managed_targets_rollback_inside_pinned_namespace()
     test_recovery_never_reads_a_replaced_external_operation()
     test_runtime_directory_cardinality_and_removal_are_bounded()
+    test_runtime_removal_enumerates_through_a_fresh_descriptor()
     test_mutation_and_runtime_descriptors_do_not_leak()
     test_recover_interrupted_journal()
     test_recovery_rejects_unbound_or_indirect_backups_before_any_write()

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -150,6 +150,34 @@ def test_expected_hash_conflict_changes_nothing() -> None:
         assert target.read_text() == "current\n"
 
 
+def test_read_preconditions_are_bound_into_plan_approval() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        vault = make_vault(Path(td) / "vault")
+        original = bundle(
+            "read-precondition-approval",
+            [{"path": "wiki/A.md", "mode": "create", "content": "# A\n"}],
+        )
+        reviewed = inspect_bundle(vault, original)
+        with_probe = json.loads(json.dumps(original))
+        with_probe["read_preconditions"] = {".raw/reviewed-input": None}
+        probed = inspect_bundle(vault, with_probe)
+        assert reviewed["changed_paths"] == probed["changed_paths"]
+        assert reviewed["hashes"] == probed["hashes"]
+        assert reviewed["modes"] == probed["modes"]
+        assert reviewed["approval_sha256"] != probed["approval_sha256"]
+        try:
+            apply_bundle(
+                vault,
+                with_probe,
+                approved_plan_sha256=reviewed["approval_sha256"],
+            )
+        except TransactionValidationError as exc:
+            assert exc.code == "PLAN_CHANGED"
+        else:
+            raise AssertionError("read preconditions must be approval-bound")
+        assert not (vault / "wiki/A.md").exists()
+
+
 def test_every_write_requires_a_canonical_precondition() -> None:
     with tempfile.TemporaryDirectory() as td:
         vault = make_vault(Path(td) / "vault")
@@ -2572,6 +2600,7 @@ def main() -> None:
     test_failure_rolls_back_every_write()
     test_rolled_back_operation_can_be_retried()
     test_expected_hash_conflict_changes_nothing()
+    test_read_preconditions_are_bound_into_plan_approval()
     test_every_write_requires_a_canonical_precondition()
     test_paths_require_nfc_and_file_bundles_reject_duplicate_json_keys()
     test_mapping_bundle_is_a_deep_snapshot_before_hash_and_apply()

--- a/tests/test_vault_ops.py
+++ b/tests/test_vault_ops.py
@@ -2,16 +2,18 @@
 
 from __future__ import annotations
 
+import json
+import os
 import sys
 import tempfile
-import json
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 from claude_obsidian.transaction import apply_bundle
-from claude_obsidian.ledgers import LedgerValidationError
+import claude_obsidian.transaction as transaction_module
+from claude_obsidian.ledgers import LedgerValidationError, stable_source_id
 from claude_obsidian.vault_ops import (
     VaultOperationError,
     build_vault_bundle,
@@ -103,10 +105,120 @@ def test_adopt_rejects_invalid_canonical_state_without_replacing_it() -> None:
             assert target.read_bytes() == before
 
 
+def test_adopt_preserves_unresolved_legacy_batch_without_raw_inference() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        vault = Path(td) / "vault"
+        (vault / ".obsidian").mkdir(parents=True)
+        raw_payload = vault / ".raw/sources/research/result.json"
+        raw_payload.parent.mkdir(parents=True)
+        raw_payload.write_text('{"result":1}\n', encoding="utf-8")
+        batch_locator = "sources/dataforseo/2026-07-17-research-pl"
+        page = vault / "wiki/sources/DataForSEO PL.md"
+        page.parent.mkdir(parents=True)
+        page.write_text("# DataForSEO PL\n", encoding="utf-8")
+        legacy_path = vault / ".raw/.manifest.json"
+        legacy_path.write_text(
+            json.dumps(
+                {
+                    "sources": {
+                        batch_locator: {
+                            "hash": "163d1efedba075cb",
+                            "ingested_at": "2026-07-17",
+                            "pages_created": ["wiki/sources/DataForSEO PL.md"],
+                            "note": "Batch of 165 JSON files",
+                        }
+                    }
+                },
+                indent=2,
+                sort_keys=True,
+            ),
+            encoding="utf-8",
+        )
+        legacy_before = legacy_path.read_bytes()
+
+        raw_identities = {
+            (raw_payload.parent.stat().st_dev, raw_payload.parent.stat().st_ino),
+            (
+                raw_payload.parent.parent.stat().st_dev,
+                raw_payload.parent.parent.stat().st_ino,
+            ),
+        }
+        real_listdir = os.listdir
+        real_scandir = os.scandir
+
+        def is_raw_payload_directory(value: object) -> bool:
+            try:
+                metadata = (
+                    os.fstat(value)
+                    if isinstance(value, int)
+                    else os.stat(value)  # type: ignore[arg-type]
+                )
+            except (OSError, TypeError, ValueError):
+                return False
+            return (metadata.st_dev, metadata.st_ino) in raw_identities
+
+        def guarded_listdir(path: object = ".") -> list[str]:
+            if is_raw_payload_directory(path):
+                raise AssertionError("adoption must not enumerate raw payloads")
+            return real_listdir(path)  # type: ignore[arg-type]
+
+        def guarded_scandir(path: object = ".") -> os.ScandirIterator[str]:
+            if is_raw_payload_directory(path):
+                raise AssertionError("adoption must not enumerate raw payloads")
+            return real_scandir(path)  # type: ignore[arg-type]
+
+        transaction_module.os.listdir = guarded_listdir
+        transaction_module.os.scandir = guarded_scandir
+        try:
+            operation = build_vault_bundle(
+                vault,
+                operation_id="adopt-batch",
+                operation_type="migration",
+                generated_at="2026-07-17T00:00:00Z",
+                adopt=True,
+            )
+            apply_bundle(vault, operation)
+        finally:
+            transaction_module.os.listdir = real_listdir
+            transaction_module.os.scandir = real_scandir
+        assert operation["read_preconditions"] == {batch_locator: None}
+        ledger_write = next(
+            write
+            for write in operation["writes"]
+            if write["path"] == "wiki/meta/ledgers/source-ledger.json"
+        )
+        sources = json.loads(ledger_write["content"])["sources"]
+        source_id = stable_source_id("manual", batch_locator, None)
+        assert set(sources) == {source_id}
+        assert sources[source_id]["origin"] == {
+            "kind": "manual",
+            "locator": batch_locator,
+        }
+        assert sources[source_id]["content_kind"] == "other"
+        assert sources[source_id]["authority"] == "unknown"
+        assert sources[source_id]["content_sha256"] is None
+        assert sources[source_id]["ingested_at"] == "2026-07-17"
+        assert sources[source_id]["review_status"] == "unreviewed"
+        assert sources[source_id]["pages"] == ["wiki/sources/DataForSEO PL.md"]
+        assert ".raw/sources/research/result.json" not in ledger_write["content"]
+
+        assert legacy_path.read_bytes() == legacy_before
+        assert raw_payload.read_text(encoding="utf-8") == '{"result":1}\n'
+        rerun = build_vault_bundle(
+            vault,
+            operation_id="adopt-batch-again",
+            operation_type="migration",
+            generated_at="2026-07-18T00:00:00Z",
+            adopt=True,
+        )
+        assert rerun["writes"] == []
+
+
 def main() -> None:
     test_init_and_adopt_are_non_destructive()
     test_init_refuses_existing_content_without_force()
     test_adopt_rejects_invalid_canonical_state_without_replacing_it()
+    test_adopt_preserves_unresolved_legacy_batch_without_raw_inference()
     print("All vault operation tests passed.")
 
 


### PR DESCRIPTION
## Summary

This safely preserves valid path-shaped legacy batch labels during migration
and adoption instead of rejecting them as hashless files. It also promotes the
descriptor-safe transaction cleanup prerequisite that the public baseline
needs for the new adversarial rollback tests. The verified private defect is
tracked at https://github.com/AI-Marketing-Hub/claude-obsidian/issues/4.

## Changes

Transaction prerequisite:

- enumerate runtime cleanup through a fresh pinned directory descriptor
- preserve identity checks and bounded removal behavior
- cover the previously failing nonempty transaction cleanup path

Migration and adoption:

- classify regular files as file/document with computed SHA-256
- classify only safely absent legacy labels as manual/other
- preserve locator, ingestion date, and generated page links
- avoid inferring raw payload mappings or promoting legacy short hashes

Plan and apply safety:

- bind legacy locator states through optional read preconditions
- include read preconditions in the reviewed approval hash
- recheck locator state under the mutation lock before writes
- roll back cleanly on late state changes and permit a safe retry

Tests and documentation:

- cover files, directories, symlinks, broken symlinks, sockets, and
  uninspectable paths
- isolate approval binding from unchanged writes, hashes, modes, and paths
- exercise locked prewrite failure, rollback, and clean retry order
- guard migration and adoption against raw-payload enumeration
- document unresolved-record semantics and limitations

## Verification

Public-baseline verification:

- base commit:
  `1c1bc49c03a685ee8f5d09c99efe52b42d6673f5`
- applying only the migration patch reproduced the public cleanup prerequisite
  failure as `TransactionRecoveryError`
- adding the prerequisite cleanup commit removed that failure
- combined public candidate tree matches the independently reviewed private
  candidate tree exactly
- `python3 tests/test_ledgers.py`: passed
- `python3 tests/test_transaction.py`: passed
- `python3 tests/test_vault_ops.py`: passed
- `make test`: passed all hermetic tests and executable contracts
- `git diff public/main..HEAD --check`: passed
- deterministic release build: two byte-identical artifacts
- release artifact audit: passed with zero errors
- artifact SHA-256:
  `ce4608c77bfb5ec1791b5be6f6d7f384e80b580f053dd8ec9489719faedd990f`
- artifact summary: 199 files, 3,044,160 archive bytes, and 2,959,446
  payload bytes
- fresh-context Sol 5.6 xhigh Secretary review of the final tree: `pass`

GitHub-hosted verification:

- Ubuntu Python 3.11, 3.12, 3.13, and 3.14: passed
- macOS Python 3.11, 3.12, 3.13, and 3.14: passed
- Windows Python 3.12 portable surface: passed
- reproducible release artifact: passed
- total: 10 passed, 0 failed, 0 skipped, 0 pending

No failures were suppressed.

## Risk and rollback

Low to moderate risk. Read preconditions are optional, so existing transaction
bundles without them retain existing behavior. Migration and adoption gain
stricter reviewed-state checks, and transaction cleanup receives a previously
verified descriptor-safety correction. Revert the two commits or the merge to
roll back.

## Open items

- Validate sanitized copies of the reporter's affected vaults when available.
- Perform one native Windows interactive migration acceptance run.
- The private repository PR remains separate because its organization Actions
  runner is blocked by an account billing or spending-limit condition.
