### PR TITLE
docs(wiki-ingest): prefer markdown links for citable URLs

### DIFF
--- a/skills/wiki-ingest/SKILL.md
+++ b/skills/wiki-ingest/SKILL.md
@@ -80,7 +80,11 @@ new immutable capture or an honest ledger update, not an overwrite.
    be read completely, label the result partial and record the missing range.
 6. Extract source metadata, falsifiable claims, entities, concepts,
    contradictions, and open questions. Separate source statements from your
-   synthesis.
+   synthesis. When citing a URL in page prose, render it as a markdown link
+   (`[descriptive label](url)`) so it stays clickable; reserve backtick
+   code-spans for literal code, CLI flags, and exact identifiers, not for
+   citable URLs. This guidance applies only to narrative prose; ledger and
+   manifest locator fields keep the raw URL string.
 7. Reuse existing canonical pages and stable addresses. Request new addresses
    through `address_requests`; never call a counter allocator from a worker.
 


### PR DESCRIPTION
## Summary
- tell wiki-ingest agents to render citable page-prose URLs as clickable markdown links
- clarify that backticks remain for code/identifiers and ledger/manifest locator fields keep raw URL strings

Closes #171.

## Verification
- git diff --check
- python3 assertion that the guidance is present and frontmatter shape is unchanged