### PR TITLE
fix: harden recovery and response boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ implementation record for older releases.
 
 ## [Unreleased]
 
+### Fixed
+
+- `stop_status` now reads transaction journals up to the package's existing
+  8 MiB runtime JSON bound, so large valid journals are not misreported as
+  unreadable. Unsafe or unreadable journals now require manual inspection, and
+  recovery advice is scoped to journals with a recognized recoverable state.
+- `checkpoint` now honors Git's false values for `core.filemode`. Git ignores
+  working-tree executable-bit differences in that mode, so checkpoint keeps
+  strict content verification while skipping executable-mode comparison.
+- Anthropic contextual-prefix responses now have a 256 KiB read cap in addition
+  to the existing timeout, preventing an oversized response from consuming
+  unbounded memory. Response-body read failures, invalid UTF-8, excessive JSON
+  nesting, and malformed response shapes fail closed.
+
 ## [2.1.1] - 2026-08-26
 
 Legacy migration safety and clearer Windows and WSL support guidance.

--- a/claude_obsidian/checkpoint.py
+++ b/claude_obsidian/checkpoint.py
@@ -799,6 +799,21 @@ def _tree_diff_paths(root: Path, base: str, tree: str) -> set[str]:
     return set(_decode_paths(completed.stdout))
 
 
+def _filemode_is_tracked(root: Path) -> bool:
+    """Return false only when Git explicitly disables file mode tracking."""
+
+    completed = _git(
+        root, ["config", "--bool", "--get", "core.filemode"], check=False
+    )
+    value = completed.stdout.strip().lower()
+    if completed.returncode == 1 and not value:
+        return True
+    if completed.returncode != 0 or value not in {"true", "false"}:
+        detail = completed.stderr.strip() or value or "cannot read core.filemode"
+        raise CheckpointError("GIT_FAILED", detail)
+    return value == "true"
+
+
 def _verify_tree(
     root: Path,
     *,
@@ -815,13 +830,17 @@ def _verify_tree(
             "COMMITTED_CONTENT_MISMATCH",
             "candidate tree is missing transaction paths: " + ", ".join(missing),
         )
+    check_modes = _filemode_is_tracked(root)
     for relative in paths:
-        expected_git_mode = "100755" if expected_modes[relative] & 0o111 else "100644"
-        if entries[relative][0] != expected_git_mode:
-            raise CheckpointError(
-                "COMMITTED_MODE_MISMATCH",
-                f"Git mode differs from the transaction result for {relative}",
+        if check_modes:
+            expected_git_mode = (
+                "100755" if expected_modes[relative] & 0o111 else "100644"
             )
+            if entries[relative][0] != expected_git_mode:
+                raise CheckpointError(
+                    "COMMITTED_MODE_MISMATCH",
+                    f"Git mode differs from the transaction result for {relative}",
+                )
         blob = _git_bytes(root, ["cat-file", "blob", entries[relative][1]]).stdout
         if hashlib.sha256(blob).hexdigest() != expected_hashes[relative]:
             raise CheckpointError(

--- a/claude_obsidian/hook_adapter.py
+++ b/claude_obsidian/hook_adapter.py
@@ -20,6 +20,7 @@ from .paths import (
     is_relative_to,
     resolve_vault_root,
 )
+from .transaction import MAX_TRANSACTION_RUNTIME_JSON_BYTES
 
 
 MAX_CONTEXT_BYTES = 32 * 1024
@@ -233,6 +234,7 @@ def stop_status(
         return ""
     root = selection.root
     warnings: list[str] = []
+    recommend_recover = False
     meta = root / ".vault-meta"
     if not meta.exists():
         return ""
@@ -249,7 +251,6 @@ def stop_status(
     if transactions.is_dir():
         directories: list[Path] = []
         recovery_counts = {"prepared": 0, "applying": 0, "rollback-failed": 0}
-        unsafe_journals = 0
         unreadable_journals = 0
         try:
             with os.scandir(transactions) as entries:
@@ -266,52 +267,71 @@ def stop_status(
                     elif entry.is_symlink():
                         warnings.append("an unsafe transaction entry is present")
         except OSError:
-            warnings.append("transaction journal directory is unreadable")
+            warnings.append(
+                "transaction journal directory is unreadable; inspect manually"
+            )
             return _bounded_status(warnings)
         for directory in sorted(directories, key=lambda path: path.name):
             if len(warnings) >= MAX_STATUS_ITEMS:
                 break
             journal = directory / "journal.json"
             try:
-                payload = _bounded_regular_bytes(root, journal, 64 * 1024)
+                payload = _bounded_regular_bytes(
+                    root, journal, MAX_TRANSACTION_RUNTIME_JSON_BYTES
+                )
                 if payload is None:
                     if journal.exists() or journal.is_symlink():
-                        unsafe_journals += 1
+                        unreadable_journals += 1
                     continue
-                state = strict_json_loads(payload.decode("utf-8")).get("state")
-            except (UnicodeDecodeError, json.JSONDecodeError, ValueError):
+                if len(payload) > MAX_TRANSACTION_RUNTIME_JSON_BYTES:
+                    unreadable_journals += 1
+                    continue
+                document = strict_json_loads(payload.decode("utf-8"))
+                if not isinstance(document, dict):
+                    unreadable_journals += 1
+                    continue
+                state = document.get("state")
+            except (
+                UnicodeDecodeError,
+                json.JSONDecodeError,
+                RecursionError,
+                ValueError,
+            ):
                 unreadable_journals += 1
                 continue
             if state in recovery_counts:
                 recovery_counts[state] += 1
         recovery_total = sum(recovery_counts.values())
         if recovery_total:
+            recommend_recover = True
             detail = ", ".join(
                 f"{state}={count}" for state, count in recovery_counts.items() if count
             )
             warnings.append(
                 f"{recovery_total} transaction journal(s) need recovery ({detail})"
             )
-        if unsafe_journals:
-            warnings.append(f"{unsafe_journals} unsafe transaction journal(s) detected")
         if unreadable_journals:
             warnings.append(
-                f"{unreadable_journals} unreadable transaction journal(s) detected"
+                f"{unreadable_journals} unsafe or unreadable transaction "
+                "journal(s) detected; inspect manually"
             )
     if not warnings:
         return ""
-    return _bounded_status(warnings)
+    return _bounded_status(warnings, recommend_recover=recommend_recover)
 
 
-def _bounded_status(warnings: list[str]) -> str:
+def _bounded_status(
+    warnings: list[str], *, recommend_recover: bool = False
+) -> str:
     selected = warnings[:MAX_STATUS_ITEMS]
     if len(warnings) > len(selected):
         selected.append(f"{len(warnings) - len(selected)} additional warnings omitted")
-    value = (
-        "CLAUDE_OBSIDIAN_STATUS: "
-        + "; ".join(selected)
-        + ". Run `claude-obsidian transaction recover` before the next mutation."
-    )
+    value = "CLAUDE_OBSIDIAN_STATUS: " + "; ".join(selected) + "."
+    if recommend_recover:
+        value += (
+            " Run `claude-obsidian transaction recover` for the recognized "
+            "recoverable journals before the next mutation."
+        )
     encoded = value.encode("utf-8")
     if len(encoded) <= MAX_STATUS_BYTES:
         return value

--- a/scripts/contextual-prefix.py
+++ b/scripts/contextual-prefix.py
@@ -75,6 +75,7 @@ Exit codes:
 
 import argparse
 import hashlib
+import http.client
 import json
 import os
 import re
@@ -119,6 +120,7 @@ CONTEXT_PREFIX_MAX_CHARS = 1000
 ANTHROPIC_MODEL = "claude-haiku-4-5-20251001"
 ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages"
 ANTHROPIC_TIMEOUT_SEC = 30
+ANTHROPIC_RESPONSE_MAX_BYTES = 256 * 1024
 CLAUDE_CLI_TIMEOUT_SEC = 60
 
 # Anthropic prompt caching ignores any cached prefix below the model's minimum
@@ -593,21 +595,50 @@ def anthropic_api_prefix(api_key, page_title, page_body, chunk_text):
     try:
         # The request target is the module-level fixed HTTPS Anthropic API URL.
         with urllib.request.urlopen(req, timeout=ANTHROPIC_TIMEOUT_SEC) as resp:  # nosec B310
-            data = json.loads(resp.read().decode("utf-8"))
+            raw = resp.read(ANTHROPIC_RESPONSE_MAX_BYTES + 1)
+            if len(raw) > ANTHROPIC_RESPONSE_MAX_BYTES:
+                log("  anthropic-api response exceeded the safe byte limit")
+                return None
+            data = json.loads(raw.decode("utf-8"))
+            if not isinstance(data, dict):
+                log("  anthropic-api response has an invalid object shape")
+                return None
             # Local cache statistics: integer token counts only, never page content, so
             # the data-egress posture holds. Confirms whether the body cache is
             # actually firing given the Haiku floor (wrote>0 on chunk 0, read>0
             # on later chunks of the same page).
             usage = data.get("usage", {})
+            if not isinstance(usage, dict):
+                usage = {}
             log(
                 f"  cache: wrote={usage.get('cache_creation_input_tokens', 0)} "
                 f"read={usage.get('cache_read_input_tokens', 0)} tok"
             )
-            for block in data.get("content", []):
+            content = data.get("content", [])
+            if not isinstance(content, list):
+                log("  anthropic-api response has an invalid content shape")
+                return None
+            for block in content:
+                if not isinstance(block, dict):
+                    log("  anthropic-api response has an invalid content block")
+                    return None
                 if block.get("type") == "text":
-                    return block["text"].strip().splitlines()[0]
-    except (urllib.error.URLError, json.JSONDecodeError, KeyError) as e:
-        log(f"  anthropic-api call failed: {e}")
+                    text = block.get("text")
+                    if not isinstance(text, str):
+                        log("  anthropic-api response has invalid text content")
+                        return None
+                    lines = text.strip().splitlines()
+                    return lines[0] if lines else None
+    except (
+        http.client.HTTPException,
+        OSError,
+        RecursionError,
+        urllib.error.URLError,
+        UnicodeDecodeError,
+        ValueError,
+        KeyError,
+    ):
+        log("  anthropic-api call failed safely")
         return None
     return None
 

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 import subprocess
 import sys
@@ -245,6 +246,74 @@ def test_executable_mode_drift_is_rejected_before_ref_update() -> None:
         )
         assert git(root, "rev-list", "--count", "HEAD") == "1"
         assert note.stat().st_mode & 0o111
+
+
+def test_executable_mode_drift_is_ignored_when_core_filemode_is_false() -> None:
+    for false_value in ("false", "no", "off", "0"):
+        with tempfile.TemporaryDirectory() as td:
+            root = make_repo(Path(td) / "vault")
+            git(root, "config", "core.filemode", false_value)
+            note = root / "wiki/Note.md"
+            original = "---\ntitle: Note\ntype: concept\nstatus: developing\ncreated: 2026-01-01\nupdated: 2026-01-01\ntags: [test]\n---\n# Note\nOriginal.\n"
+            note.write_text(original)
+            note.chmod(0o777)
+            git(root, "add", ".")
+            git(root, "commit", "-qm", "add executable note")
+            assert git(root, "ls-files", "-s", "wiki/Note.md").startswith("100644")
+
+            updated = original.replace("Original.", "Updated.")
+            transaction_result = apply_bundle(
+                root,
+                {
+                    "schema": BUNDLE_SCHEMA,
+                    "operation_id": "save-two",
+                    "operation_type": "save",
+                    "expected_hashes": {
+                        "wiki/Note.md": hashlib.sha256(original.encode()).hexdigest()
+                    },
+                    "writes": [
+                        {
+                            "path": "wiki/Note.md",
+                            "mode": "replace",
+                            "content": updated,
+                        }
+                    ],
+                },
+            )
+            assert transaction_result["modes"]["wiki/Note.md"] & 0o111
+
+            result = checkpoint_operation(root, "save-two", run_lint=False)
+            assert result["paths"] == ["wiki/Note.md"]
+            assert git(root, "rev-list", "--count", "HEAD") == "3"
+
+
+def test_invalid_core_filemode_fails_closed() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = make_repo(Path(td) / "vault")
+        transaction(root)
+        git(root, "config", "core.filemode", "invalid")
+
+        expect_code(
+            "GIT_FAILED",
+            lambda: checkpoint_module._filemode_is_tracked(root),
+        )
+
+
+def test_core_filemode_false_still_rejects_content_mismatch() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = make_repo(Path(td) / "vault")
+        transaction(root)
+        git(root, "config", "core.filemode", "false")
+        result_path = root / ".vault-meta/transactions/save-one/changed-paths.json"
+        result = json.loads(result_path.read_text(encoding="utf-8"))
+        result["hashes"]["wiki/Note.md"] = "0" * 64
+        result_path.write_text(json.dumps(result), encoding="utf-8")
+
+        expect_code(
+            "TRANSACTION_DRIFT",
+            lambda: checkpoint_operation(root, "save-one", run_lint=False),
+        )
+        assert git(root, "rev-list", "--count", "HEAD") == "1"
 
 
 def test_operation_ids_and_transaction_directories_are_confined() -> None:
@@ -536,6 +605,9 @@ def main() -> None:
     test_unrelated_staging_and_drift_are_rejected()
     test_intent_to_add_index_state_is_rejected_and_preserved()
     test_executable_mode_drift_is_rejected_before_ref_update()
+    test_executable_mode_drift_is_ignored_when_core_filemode_is_false()
+    test_invalid_core_filemode_fails_closed()
+    test_core_filemode_false_still_rejects_content_mismatch()
     test_operation_ids_and_transaction_directories_are_confined()
     test_temporary_index_freezes_verified_bytes()
     test_retry_finalizes_one_commit_after_final_record_failure()

--- a/tests/test_contextual_prefix.py
+++ b/tests/test_contextual_prefix.py
@@ -87,7 +87,7 @@ def test_payload_attaches_cache_control_by_body_size():
         def __init__(self, d):
             self._d = json.dumps(d).encode()
 
-        def read(self):
+        def read(self, limit=None):
             return self._d
 
         def __enter__(self):
@@ -121,6 +121,142 @@ def test_payload_attaches_cache_control_by_body_size():
         assert_true(
             "below-floor body omits cache_control",
             "cache_control" not in captured["body"]["system"][1],
+        )
+
+
+def test_anthropic_api_response_read_is_bounded():
+    captured = {}
+
+    class _Resp:
+        def read(self, limit):
+            captured["limit"] = limit
+            return b"x" * limit
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    with mock.patch.object(cp.urllib.request, "urlopen", return_value=_Resp()):
+        result = cp.anthropic_api_prefix("KEY", "T", "body", "chunk")
+
+    assert_eq("oversized Anthropic response is rejected", None, result)
+    assert_eq(
+        "Anthropic response read is bounded",
+        cp.ANTHROPIC_RESPONSE_MAX_BYTES + 1,
+        captured["limit"],
+    )
+
+
+def test_anthropic_api_response_boundaries_and_shapes():
+    class _Resp:
+        def __init__(self, raw):
+            self.raw = raw
+
+        def read(self, limit):
+            assert_eq(
+                "Anthropic response boundary read uses sentinel",
+                cp.ANTHROPIC_RESPONSE_MAX_BYTES + 1,
+                limit,
+            )
+            return self.raw
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    valid = json.dumps(
+        {"content": [{"type": "text", "text": "exact boundary"}], "usage": {}},
+        separators=(",", ":"),
+    ).encode("utf-8")
+    valid += b" " * (cp.ANTHROPIC_RESPONSE_MAX_BYTES - len(valid))
+    with mock.patch.object(cp.urllib.request, "urlopen", return_value=_Resp(valid)):
+        assert_eq(
+            "exact-size Anthropic response is accepted",
+            "exact boundary",
+            cp.anthropic_api_prefix("KEY", "T", "body", "chunk"),
+        )
+
+    malformed_payloads = [
+        b'"not an object"',
+        json.dumps({"content": {"type": "text"}}).encode("utf-8"),
+        json.dumps({"content": [1]}).encode("utf-8"),
+        json.dumps({"content": [{"type": "text", "text": 1}]}).encode("utf-8"),
+        b'{"content":[]}\xff',
+    ]
+    for index, malformed in enumerate(malformed_payloads):
+        with mock.patch.object(
+            cp.urllib.request, "urlopen", return_value=_Resp(malformed)
+        ):
+            assert_eq(
+                f"malformed Anthropic response {index} fails closed",
+                None,
+                cp.anthropic_api_prefix("KEY", "T", "body", "chunk"),
+            )
+
+    class _ReadFailureResp:
+        def read(self, limit):
+            raise OSError("simulated response-body read failure")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    with mock.patch.object(
+        cp.urllib.request, "urlopen", return_value=_ReadFailureResp()
+    ):
+        assert_eq(
+            "Anthropic response read failure fails closed",
+            None,
+            cp.anthropic_api_prefix("KEY", "T", "body", "chunk"),
+        )
+
+    with mock.patch.object(
+        cp.urllib.request,
+        "urlopen",
+        side_effect=cp.urllib.error.URLError("simulated HTTP transport failure"),
+    ):
+        assert_eq(
+            "Anthropic HTTP failure fails closed",
+            None,
+            cp.anthropic_api_prefix("KEY", "T", "body", "chunk"),
+        )
+
+    with (
+        mock.patch.object(cp.urllib.request, "urlopen", return_value=_Resp(b"{}")),
+        mock.patch.object(cp.json, "loads", side_effect=RecursionError),
+    ):
+        assert_eq(
+            "Anthropic JSON recursion failure fails closed",
+            None,
+            cp.anthropic_api_prefix("KEY", "T", "body", "chunk"),
+        )
+
+    with (
+        mock.patch.object(cp.urllib.request, "urlopen", return_value=_Resp(b"{}")),
+        mock.patch.object(cp.json, "loads", side_effect=ValueError),
+    ):
+        assert_eq(
+            "Anthropic JSON value failure fails closed",
+            None,
+            cp.anthropic_api_prefix("KEY", "T", "body", "chunk"),
+        )
+
+    empty_text = json.dumps(
+        {"content": [{"type": "text", "text": " \n "}], "usage": {}}
+    ).encode("utf-8")
+    with mock.patch.object(
+        cp.urllib.request, "urlopen", return_value=_Resp(empty_text)
+    ):
+        assert_eq(
+            "empty Anthropic text fails closed",
+            None,
+            cp.anthropic_api_prefix("KEY", "T", "body", "chunk"),
         )
 
 
@@ -716,6 +852,8 @@ def main():
     test_at_floor_returns_ephemeral()
     test_above_floor_returns_ephemeral()
     test_payload_attaches_cache_control_by_body_size()
+    test_anthropic_api_response_read_is_bounded()
+    test_anthropic_api_response_boundaries_and_shapes()
     test_remote_prefix_tiers_remain_explicit_opt_in()
     test_claude_cli_prompt_uses_stdin_not_process_argv()
     test_long_single_paragraph_is_hard_split_with_bounded_prefixes()

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -251,6 +251,7 @@ def test_stop_status_is_bounded_and_emitted_as_supported_json() -> None:
         status = stop_status(start=vault, environ={}, plugin_root=base / "plugin")
         assert 0 < len(status.encode("utf-8")) <= MAX_STATUS_BYTES
         assert "20 transaction journal(s) need recovery (applying=20)" in status
+        assert "transaction recover" in status
         assert "operation-000" not in status
         stream = io.StringIO()
         emit_stop_status(
@@ -258,6 +259,173 @@ def test_stop_status_is_bounded_and_emitted_as_supported_json() -> None:
         )
         payload = json.loads(stream.getvalue())
         assert payload == {"systemMessage": status}
+
+
+def test_stop_status_reads_journals_at_transaction_bound() -> None:
+    for state in ("complete", "applying"):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            vault = make_vault(base / "vault", "safe\n")
+            transactions = vault / ".vault-meta/transactions"
+            directory = transactions / "operation-000"
+            directory.mkdir(parents=True)
+            prefix = json.dumps({"state": state}).encode("utf-8")
+            (directory / "journal.json").write_bytes(
+                prefix
+                + b" "
+                * (hook_adapter.MAX_TRANSACTION_RUNTIME_JSON_BYTES - len(prefix))
+            )
+
+            status = stop_status(
+                start=vault, environ={}, plugin_root=base / "plugin"
+            )
+
+            if state == "complete":
+                assert status == ""
+            else:
+                assert "1 transaction journal(s) need recovery" in status
+                assert "transaction recover" in status
+
+
+def test_stop_status_rejects_journals_above_transaction_bound() -> None:
+    for state in ("complete", "applying"):
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            vault = make_vault(base / "vault", "safe\n")
+            transactions = vault / ".vault-meta/transactions"
+            directory = transactions / "operation-000"
+            directory.mkdir(parents=True)
+            prefix = json.dumps({"state": state}).encode("utf-8")
+            (directory / "journal.json").write_bytes(
+                prefix
+                + b" "
+                * (hook_adapter.MAX_TRANSACTION_RUNTIME_JSON_BYTES + 1 - len(prefix))
+            )
+
+            status = stop_status(
+                start=vault, environ={}, plugin_root=base / "plugin"
+            )
+
+            assert "1 unsafe or unreadable transaction journal(s) detected" in status
+            assert "transaction recover" not in status
+
+
+def test_stop_status_unreadable_journal_warning_does_not_recommend_recover() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td)
+        vault = make_vault(base / "vault", "safe\n")
+        transactions = vault / ".vault-meta/transactions"
+        directory = transactions / "operation-000"
+        directory.mkdir(parents=True)
+        (directory / "journal.json").write_text("not json", encoding="utf-8")
+
+        status = stop_status(start=vault, environ={}, plugin_root=base / "plugin")
+
+        assert "1 unsafe or unreadable transaction journal(s) detected" in status
+        assert "transaction recover" not in status
+
+
+def test_stop_status_non_object_journal_requires_manual_inspection() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td)
+        vault = make_vault(base / "vault", "safe\n")
+        journal = vault / ".vault-meta/transactions/operation-000/journal.json"
+        journal.parent.mkdir(parents=True)
+        journal.write_text("[]", encoding="utf-8")
+
+        status = stop_status(start=vault, environ={}, plugin_root=base / "plugin")
+
+        assert "1 unsafe or unreadable transaction journal(s) detected" in status
+        assert "inspect manually" in status
+        assert "transaction recover" not in status
+
+
+def test_stop_status_journal_recursion_failure_requires_manual_inspection() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td)
+        vault = make_vault(base / "vault", "safe\n")
+        journal = vault / ".vault-meta/transactions/operation-000/journal.json"
+        journal.parent.mkdir(parents=True)
+        journal.write_text("{}", encoding="utf-8")
+        original_loader = hook_adapter.strict_json_loads
+
+        def recursive_loader(_payload):
+            raise RecursionError
+
+        hook_adapter.strict_json_loads = recursive_loader
+        try:
+            status = stop_status(
+                start=vault, environ={}, plugin_root=base / "plugin"
+            )
+        finally:
+            hook_adapter.strict_json_loads = original_loader
+
+        assert "1 unsafe or unreadable transaction journal(s) detected" in status
+        assert "inspect manually" in status
+        assert "transaction recover" not in status
+
+
+def test_stop_status_actual_read_failure_requires_manual_inspection() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td)
+        vault = make_vault(base / "vault", "safe\n")
+        journal = vault / ".vault-meta/transactions/operation-000/journal.json"
+        journal.mkdir(parents=True)
+
+        status = stop_status(start=vault, environ={}, plugin_root=base / "plugin")
+
+        assert "1 unsafe or unreadable transaction journal(s) detected" in status
+        assert "inspect manually" in status
+        assert "transaction recover" not in status
+
+
+def test_stop_status_regular_journal_read_failure_requires_manual_inspection() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td)
+        vault = make_vault(base / "vault", "safe\n")
+        journal = vault / ".vault-meta/transactions/operation-000/journal.json"
+        journal.parent.mkdir(parents=True)
+        journal.write_text(json.dumps({"state": "complete"}), encoding="utf-8")
+        original_reader = hook_adapter._bounded_regular_bytes
+
+        def failing_reader(root, path, limit):
+            if path == journal:
+                return None
+            return original_reader(root, path, limit)
+
+        hook_adapter._bounded_regular_bytes = failing_reader
+        try:
+            status = stop_status(
+                start=vault, environ={}, plugin_root=base / "plugin"
+            )
+        finally:
+            hook_adapter._bounded_regular_bytes = original_reader
+
+        assert "1 unsafe or unreadable transaction journal(s) detected" in status
+        assert "inspect manually" in status
+        assert "transaction recover" not in status
+
+
+def test_stop_status_scopes_recovery_advice_for_mixed_journals() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td)
+        vault = make_vault(base / "vault", "safe\n")
+        transactions = vault / ".vault-meta/transactions"
+        applying = transactions / "operation-applying"
+        malformed = transactions / "operation-malformed"
+        applying.mkdir(parents=True)
+        malformed.mkdir(parents=True)
+        (applying / "journal.json").write_text(
+            json.dumps({"state": "applying"}), encoding="utf-8"
+        )
+        (malformed / "journal.json").write_text("not json", encoding="utf-8")
+
+        status = stop_status(start=vault, environ={}, plugin_root=base / "plugin")
+
+        assert "1 transaction journal(s) need recovery" in status
+        assert "1 unsafe or unreadable transaction journal(s) detected" in status
+        assert "for the recognized recoverable journals" in status
+        assert "inspect manually" in status
 
 
 def main() -> None:
@@ -269,6 +437,14 @@ def main() -> None:
     test_context_rejects_symlinked_hot_cache_and_parent()
     test_context_parent_swap_reads_only_from_pinned_directory()
     test_stop_status_is_bounded_and_emitted_as_supported_json()
+    test_stop_status_reads_journals_at_transaction_bound()
+    test_stop_status_rejects_journals_above_transaction_bound()
+    test_stop_status_unreadable_journal_warning_does_not_recommend_recover()
+    test_stop_status_non_object_journal_requires_manual_inspection()
+    test_stop_status_journal_recursion_failure_requires_manual_inspection()
+    test_stop_status_actual_read_failure_requires_manual_inspection()
+    test_stop_status_regular_journal_read_failure_requires_manual_inspection()
+    test_stop_status_scopes_recovery_advice_for_mixed_journals()
     print("All hook tests passed.")
 
 

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -389,7 +389,7 @@ def test_stop_status_regular_journal_read_failure_requires_manual_inspection() -
         original_reader = hook_adapter._bounded_regular_bytes
 
         def failing_reader(root, path, limit):
-            if path == journal:
+            if path.name == "journal.json" and path.parent.name == "operation-000":
                 return None
             return original_reader(root, path, limit)
 


### PR DESCRIPTION
## Summary

Hardens three audited failure boundaries in transaction status reporting,
checkpoint verification, and Anthropic contextual-prefix handling. The result
is fail-closed behavior for malformed or oversized inputs, clearer recovery
guidance, and regression coverage for the exact boundary and error paths.

## Changes

- Transaction status:
  - accept valid journals through the existing 8 MiB runtime bound
  - classify oversized, unreadable, non-object, and recursive journals safely
  - scope recovery commands to recognized recoverable journal states
- Checkpoint verification:
  - parse `core.filemode` through Git's boolean semantics
  - preserve content verification when executable-mode comparison is disabled
  - fail closed on invalid configuration values
- Contextual prefixes:
  - cap Anthropic response reads at 256 KiB plus one sentinel byte
  - validate response structure before accessing content
  - fail closed on transport, I/O, UTF-8, JSON, recursion, and shape failures
- Tests and documentation:
  - add focused boundary and failure-path regressions
  - make journal fault injection portable across Linux and macOS paths
  - document the fixes in the Unreleased changelog

## Verification

- `python3 tests/test_hooks.py`: passed
- `python3 tests/test_checkpoint.py`: passed
- `python3 tests/test_contextual_prefix.py`: passed
- `make test`: passed all hermetic tests and executable contracts
- `git diff --check`: passed
- Added-line secret, absolute-path, conflict-marker, and em-dash scans: passed
- Initial PR CI on `4f5a950` exposed a macOS-only lexical temporary-path
  assumption in the new journal fault-injection test. Product code was not the
  failing path. Commit `c92682b` made the test path-independent.
- Replacement PR CI on `c92682b`: 10 of 10 checks passed across macOS, Ubuntu,
  Windows, and the reproducible release artifact.
- Post-merge CI on `ad67087`: 10 of 10 checks passed, including a twice-built
  and audited public artifact.
- Five source-only benchmark helper tests were explicitly skipped by the
  existing suite. No changed behavior depends on them.

## Risk and rollback

Low risk. Changes are confined to defensive parsing, status wording, Git mode
interpretation, response bounds, corresponding tests, and release notes. Revert
the merge commit to restore the prior behavior.

## Open items

- No live Anthropic endpoint was exercised.
- No additional native operating-system or alternate Git-version matrix was
  exercised beyond the repository's hermetic, macOS, Ubuntu, and Windows CI.
