### PR TITLE
fix(tests): reconfigure stdout to UTF-8 so Windows test runs don't crash on arrow labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ implementation record for older releases.
   to the existing timeout, preventing an oversized response from consuming
   unbounded memory. Response-body read failures, invalid UTF-8, excessive JSON
   nesting, and malformed response shapes fail closed.
+- `tests/test_contextual_prefix.py` and `tests/test_wiki_mode.py` no longer
+  crash on native Windows before their assertions finish running. Both print
+  `→` in test labels; Windows' default `cp1252` console encoding raised
+  `UnicodeEncodeError` on the first such print. Both files now reconfigure
+  stdout to UTF-8 on startup, guarded so a captured/redirected runner without
+  a `reconfigure`-capable stdout still runs.
 
 ## [2.1.1] - 2026-08-26
 

--- a/tests/test_contextual_prefix.py
+++ b/tests/test_contextual_prefix.py
@@ -19,6 +19,9 @@ import tempfile
 from pathlib import Path
 from unittest import mock
 
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8")
+
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT))
 

--- a/tests/test_wiki_mode.py
+++ b/tests/test_wiki_mode.py
@@ -20,6 +20,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 from unittest import mock
 
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8")
+
 ROOT = Path(__file__).resolve().parent.parent
 HELPER = ROOT / "scripts" / "wiki-mode.py"
 os.environ["CLAUDE_OBSIDIAN_VAULT"] = str(ROOT)


### PR DESCRIPTION
A contributor running the test suite on native Windows today has `tests/test_contextual_prefix.py` and `tests/test_wiki_mode.py` abort with an unhandled `UnicodeEncodeError` before a single assertion result is reported — the run looks broken, not just failing. This matters for exactly the population the `windows-smoke` CI job is trying to widen support for: someone validating a change locally on Windows outside of WSL.

**Problem**

At HEAD (`ad67087c`), both files print assertion labels containing the `→` glyph (e.g. `tests/test_contextual_prefix.py:53`, `"body 1 char below floor → None"`). Windows' default console encoding is `cp1252`, which cannot encode `→`, so the very first such `print()` raises:

```
UnicodeEncodeError: 'charmap' codec can't encode character '→' in position 29: character maps to <undefined>
```

and the process exits before running the rest of the file's assertions.

**Behavior**

Both files now reconfigure `stdout` to UTF-8 immediately after their imports:

```python
if hasattr(sys.stdout, "reconfigure"):
    sys.stdout.reconfigure(encoding="utf-8")
```

The `hasattr` guard means a captured/redirected runner whose `stdout` isn't a real console-backed stream (and so lacks `.reconfigure`) still runs unaffected. Added a `## [Unreleased]` / `### Fixed` entry to `CHANGELOG.md`.

**Compatibility / rollback**

Additive, two-file, three-line-each change to test setup only — no product code touched. Fully backward compatible on Linux/macOS (where stdout is already UTF-8, so `reconfigure` is a no-op). Revert is a plain revert of this commit.

**Verification (exact commands run)**

- `make test` in WSL (Ubuntu, Python 3.12) on `main` at `ad67087c`: exit 0, "All hermetic tests and executable contracts passed." (259 `OK` assertions across 16 test files) — baseline.
- `make test` in WSL on this branch: exit 0, same 259 `OK` assertions, byte-identical label set to baseline — no regression.
- Native Windows (Python 3.12, no env override), `main` at `ad67087c`: `python tests/test_contextual_prefix.py` crashes immediately with the `UnicodeEncodeError` above at line 53.
- Native Windows, this branch: `python tests/test_wiki_mode.py` → exit 0, "All wiki-mode tests passed." (fully green, was previously untestable natively).
- Native Windows, this branch: `python tests/test_contextual_prefix.py` → the encoding crash is gone; the run progresses through 40 `OK` assertions and then fails at `test_long_single_paragraph_is_hard_split_with_bounded_prefixes` (`tests/test_contextual_prefix.py:356` at HEAD) with:
  ```
  FileNotFoundError: [Errno 2] No such file or directory: '...\.vault-meta\chunks\c-000777\chunk-000.json'
  ```
  Reproduced deterministically across two separate runs (different temp dirs, same failure). This is a **separate, pre-existing native-Windows bug** in the chunk-write path — unrelated to stdout encoding, not touched or introduced by this PR, and out of scope here. I've filed it as its own issue for tracking: #179. This PR is a prerequisite that makes that bug observable outside WSL, not a regression it causes: previously the encoding crash masked it entirely, since it happens earlier in the same file's execution order.

**Limitation**

`tests/test_contextual_prefix.py` still does not pass end-to-end natively on Windows after this change, for the unrelated reason above; `windows-smoke`'s current allowlist (`test_package_validation.py`, `test_knowledge_contracts.py`, `test_contracts.py`, `test_benchmark_tools.py`, `test_windows_compat.py`) already does not run either touched file, so this doesn't change CI's pass/fail surface — it only fixes what a contributor sees running these two files by hand on Windows.

found while maintaining a downstream fork

