### PR TITLE
fix(contextual-prefix): parse CRLF frontmatter

### DIFF
--- a/scripts/contextual-prefix.py
+++ b/scripts/contextual-prefix.py
@@ -141,7 +141,7 @@ EXIT_CHUNK_DIR = 4
 EXIT_ADDRESS_COLLISION = 5
 EXIT_LOCK = 6
 
-FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n", re.DOTALL)
+FRONTMATTER_RE = re.compile(r"^---\r?\n(.*?)\r?\n---\r?\n", re.DOTALL)
 ADDRESS_RE = re.compile(r"^address:\s*([cl]-\d{6})\s*$", re.MULTILINE)
 TITLE_RE = re.compile(r"^title:\s*['\"]?(.+?)['\"]?\s*$", re.MULTILINE)
 

--- a/tests/test_contextual_prefix.py
+++ b/tests/test_contextual_prefix.py
@@ -845,6 +845,15 @@ def test_read_page_preserves_crlf_bytes() -> None:
         assert "\r\n" in text, "read_page must not normalize line endings"
 
 
+def test_parse_frontmatter_accepts_crlf() -> None:
+    frontmatter, content = cp.parse_frontmatter(
+        "---\r\naddress: c-000777\r\ntitle: Windows page\r\n---\r\nBody\r\n"
+    )
+    assert_eq("CRLF frontmatter address is parsed", "c-000777", frontmatter["address"])
+    assert_eq("CRLF frontmatter title is parsed", "Windows page", frontmatter["title"])
+    assert_eq("CRLF frontmatter body is separated", "Body\r\n", content)
+
+
 def main():
     print("=== test_contextual_prefix.py ===")
     test_below_floor_returns_none()
@@ -867,6 +876,7 @@ def main():
     test_pinned_contextual_write_survives_root_replacement()
     test_chunk_parent_swap_never_redirects_atomic_publication()
     test_read_page_preserves_crlf_bytes()
+    test_parse_frontmatter_accepts_crlf()
     print("\nAll contextual-prefix tests passed.")
 
 


### PR DESCRIPTION
Closes #179

## Root cause
`read_page` intentionally preserves bytes, but `FRONTMATTER_RE` accepted LF delimiters only. Files created with native Windows CRLF therefore lost their explicit address and wrote chunks under a synthetic address.

## Changes
- accept LF and CRLF frontmatter delimiters
- add a direct CRLF parsing regression test

## Verification
- reproduced the original FileNotFoundError on native Windows before the fix
- long-paragraph write/read regression passes after the fix
- direct CRLF address, title, and body assertions pass
- `git diff --check`

`make test` could not run because GNU Make is unavailable in this Windows environment; the affected Python tests were invoked directly.