### PR TITLE
fix(setup): pin scaffolded vault to absolute wikilink format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ implementation record for older releases.
 
 ### Fixed
 
+- The scaffolded vault's `.obsidian/app.json` now pins Obsidian's "New link
+  format" setting to `absolute`. It was previously left unset, defaulting to
+  Obsidian's own "shortest path when possible" — links created through
+  Obsidian's UI under that default resolve fine inside Obsidian but are
+  unresolvable (or, once a second file shares a basename, silently wrong) to
+  every other link-touching part of the product, which all resolve wikilinks
+  by exact vault-relative path with no fuzzy resolution: resync scripts, the
+  terminology linker, and lint's dead/ambiguous-link detection.
 - `stop_status` now reads transaction journals up to the package's existing
   8 MiB runtime JSON bound, so large valid journals are not misreported as
   unreadable. Unsafe or unreadable journals now require manual inspection, and

--- a/examples/sample-vault/.obsidian/app.json
+++ b/examples/sample-vault/.obsidian/app.json
@@ -1,4 +1,5 @@
 {
+  "newLinkFormat": "absolute",
   "userIgnoreFilters": [
     ".raw/",
     ".vault-meta/"

--- a/templates/vault/.obsidian/app.json
+++ b/templates/vault/.obsidian/app.json
@@ -1,4 +1,5 @@
 {
+  "newLinkFormat": "absolute",
   "userIgnoreFilters": [
     ".raw/",
     ".vault-meta/"

--- a/tests/test_setup_vault.py
+++ b/tests/test_setup_vault.py
@@ -125,6 +125,27 @@ class SetupVaultTests(unittest.TestCase):
             self.assertTrue(report["ok"])
             self.assertEqual(before, _snapshot(vault))
 
+    def test_init_sets_absolute_new_link_format(self) -> None:
+        # Obsidian's "New link format" setting defaults to "shortest path
+        # when possible" when unset. Every other link-touching part of the
+        # product (worksync-style resync scripts, the terminology linker,
+        # lint's dead/ambiguous-link detection) resolves wikilinks by exact
+        # vault-relative path with no fuzzy or duplicate-basename resolution,
+        # so a link Obsidian's own UI inserts under the default setting can
+        # resolve fine inside Obsidian while being unresolvable — or silently
+        # wrong once a second file shares a basename — to every other tool
+        # in the pipeline. The scaffolded vault must pin the setting to
+        # "absolute" so links created through Obsidian's own UI are already
+        # in the form the rest of the product expects.
+        with tempfile.TemporaryDirectory() as directory:
+            vault = Path(directory) / "vault"
+            result = _reviewed_apply("--apply", "--init", "--vault", str(vault))
+            self.assertEqual(0, result.returncode, result.stderr)
+            app_json = json.loads(
+                (vault / ".obsidian" / "app.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual("absolute", app_json.get("newLinkFormat"))
+
     def test_apply_supports_legacy_positional_unicode_path_and_is_idempotent(
         self,
     ) -> None:


### PR DESCRIPTION
## Summary

Obsidian's "New link format" setting is left unset in the scaffolded vault's `.obsidian/app.json`, which defaults to Obsidian's own "shortest path when possible". Every link-touching part of the product resolves wikilinks by exact vault-relative path with no fuzzy resolution — resync scripts, the terminology linker, and lint's dead/ambiguous-link detection. A link created through Obsidian's own UI (autocomplete, drag-drop) under the default setting resolves fine inside Obsidian but is unresolvable to the rest of the product, and becomes silently wrong (not just unresolvable) the moment a second file shares a basename, since Obsidian's shortest-path resolution and the product's exact-path resolution can then disagree about which file the link points to.

This surfaced as a real bug in a production vault: a hand-created `[[taxonomy|taxonomies]]`-style link resolved correctly in Obsidian but was invisible to `wiki-lint` and the terminology linker, which both expect the fully-qualified `wiki/entities/taxonomy` form.

Checked history and current `main` — this has been present since the template file was first added in the v2.0.0 release commit and is still unaddressed on `main` as of this PR; no existing open issue tracks it.

## Behavior change

`templates/vault/.obsidian/app.json` and `examples/sample-vault/.obsidian/app.json` now set `"newLinkFormat": "absolute"`. This only affects **new** vaults (or vaults re-adopting the template); it does not retroactively touch any existing vault's `.obsidian/app.json` — `setup`'s adopt-mode behavior (preserving an existing custom `app.json`) is unchanged and covered by the existing test suite.

## Test plan

- Added `test_init_sets_absolute_new_link_format` to `tests/test_setup_vault.py`, confirmed it fails against the prior template (`AssertionError: 'absolute' != None`) and passes with the fix.
- `make test` — all hermetic tests and executable contracts pass.

## Compatibility / rollback

Additive change to two static JSON template files; no code path changes. Rollback is reverting the JSON key.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>