### PR TITLE
docs: ingest PDF/web/audio into the graph via cue-omni-reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,16 @@ machine-facing detail.
 | Contextual prefixes or remote models | Optional and gated by explicit egress consent |
 | Obsidian CLI | Optional for reads/search; filesystem transport remains available |
 
+Sources the vault intentionally fingerprints rather than extracts — PDF/EPUB
+semantic content, web pages with in-page video/attachments, local audio or
+video — still deserve a seat in the graph. Run them through
+[cue-omni-reader](https://github.com/sensedeal/cue-skills/tree/main/cue-omni-reader)
+first and you get the content as Markdown (web pages including in-page
+video/attachments, plus authorized local documents, audio, or video; several
+local files at once). Feed that into the capture flow and the note carries the
+material, not just the fingerprint. Install:
+`npx skills add sensedeal/cue-skills --skill cue-omni-reader` (MIT; may bill).
+
 High-risk accepted claims require two independent sources. Unsupported or
 contradictory evidence stays visible, and a grounded refusal is preferred over
 an invented citation. Model-based retrieval falls back to deterministic BM25


### PR DESCRIPTION
> **Disclosure:** I'm a maintainer of [sensedeal/cue-skills](https://github.com/sensedeal/cue-skills) (MIT). This PR adds a note pointing to cue-omni-reader, which I help maintain.

The honest capability boundaries table already says PDF/EPUB are fingerprint-only (metadata/hash/size, no semantic extract) and web/OCR need an external runner. A paper PDF or a lecture recording never reaches the content layer — the note in the graph is a hash, not the material.

This PR adds a path after that table: run [cue-omni-reader](https://github.com/sensedeal/cue-skills/tree/main/cue-omni-reader) to Markdown first (pages including in-page video/attachments, plus authorized local documents, audio, or video; several local files at once), then capture, so the note carries the material. One-line install, MIT, may bill.

```sh
npx skills add sensedeal/cue-skills --skill cue-omni-reader
```
