### PR TITLE
fix: backlog triage fixes (locks, lint exclusion, bin/ move, host validation, skill anchors, hook docs)

### DIFF
--- a/.cursor/rules/claude-obsidian.mdc
+++ b/.cursor/rules/claude-obsidian.mdc
@@ -25,8 +25,8 @@ mutable knowledge belongs in a separately resolved user vault.
 Preview and then install workspace-local skill links with:
 
 ```bash
-bash bin/setup-multi-agent.sh --host cursor --workspace "$PWD"
-bash bin/setup-multi-agent.sh --host cursor --workspace "$PWD" --apply
+bash scripts/setup-multi-agent.sh --host cursor --workspace "$PWD"
+bash scripts/setup-multi-agent.sh --host cursor --workspace "$PWD" --apply
 ```
 
 Public canonical: https://github.com/AgriciDaniel/claude-obsidian

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -26,7 +26,7 @@ Which existing surface(s) does this touch?
 
 ## Compatibility
 - Does this change behavior for existing v1.x vaults? Yes / No
-- Does it require a new opt-in (`bin/setup-*.sh`)? Yes / No
+- Does it require a new opt-in (`scripts/setup-*.sh`)? Yes / No
 - Does it introduce a new dependency? Yes / No
 
 ## Testing

--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,5 @@ _attachments/
 # v1.8 methodology mode (host-specific by default; `git add -f` to commit if desired)
 .vault-meta/mode.json
 .vault-meta/mode.*.tmp
+# Project-scope MCP config may carry commands or credentials; never commit the live file.
+.mcp.json

--- a/.windsurf/rules/claude-obsidian.md
+++ b/.windsurf/rules/claude-obsidian.md
@@ -2,7 +2,7 @@
 
 Read `AGENTS.md` as the canonical host-neutral contract. Preview and then
 install Cascade skill links with
-`bash bin/setup-multi-agent.sh --host windsurf --workspace "$PWD"` followed by
+`bash scripts/setup-multi-agent.sh --host windsurf --workspace "$PWD"` followed by
 the same command with `--apply`, and load the matching
 `skills/<name>/SKILL.md` when a request triggers it.
 

--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -47,6 +47,20 @@ manual installation guidance instead.
 
 ---
 
+## Adopted contributor designs
+
+Two community pull requests diagnosed retrieval bugs and proposed fixes that
+the v2.0.0 refoundation implemented in near-identical form. The pull requests
+were not merged as submitted because the surrounding files were rewritten, but
+the designs are theirs.
+
+| Change | Contributor | Pull request |
+|--------|-------------|--------------|
+| Nomic `search_query` and `search_document` task prefixes in the reranker, including the `with_task_prefix` helper and cache-scheme invalidation | maartengoet | https://github.com/AgriciDaniel/claude-obsidian/pull/77 |
+| BM25 fallback order preserved in reranker no-op paths (`bm25_score` before `score`) | vinsocci | https://github.com/AgriciDaniel/claude-obsidian/pull/62 |
+
+---
+
 ## claude-obsidian
 
 **Author:** AgriciDaniel / AI Marketing Hub

--- a/ATTRIBUTION.md
+++ b/ATTRIBUTION.md
@@ -42,7 +42,7 @@ through Obsidian under their respective licenses.
 | Obsidian Excalidraw | Zsolt Viczian | https://github.com/zsviczian/obsidian-excalidraw-plugin |
 | Obsidian Banners | Danny Hernandez | https://github.com/noatpad/obsidian-banners |
 
-`bin/setup-vault.sh` does not download unverified plugin binaries. It prints
+`scripts/setup-vault.sh` does not download unverified plugin binaries. It prints
 manual installation guidance instead.
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ implementation record for older releases.
 
 ## [Unreleased]
 
+### Added
+
+- `docs/windows-wsl.md`: a "Claude Code hooks and python3 on Windows" section
+  and a platform-support-matrix row documenting that hooks require an
+  interpreter reachable as `python3` on `PATH`, with native Windows setup
+  notes for the python.org installer and the Microsoft Store alias stub.
+- `hooks/README.md` and `README.md`: a stated minimum Claude Code
+  requirement (a current release; the exec-form `args` command hook and the
+  `compact` `SessionStart` matcher need it), linking to the Claude Code hooks
+  contract.
+
 ### Fixed
 
 - The scaffolded vault's `.obsidian/app.json` now pins Obsidian's "New link

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,16 @@ implementation record for older releases.
   archived page under a dot-prefixed folder became a real link-resolution
   candidate, turning a single healthy `[[Wikilink]]` into a spurious
   `ambiguous_targets` (and, on index pages, `stale_index_entries`) finding.
+- `--force-stale-lock` can now reap a mutation lock or capture queue lock
+  younger than `--stale-after` when the recorded owner PID is confirmed dead
+  on the same host. It still never reaps a live same-host owner before
+  `--stale-after` elapses and still keeps the age gate for a foreign-host or
+  unresolvable owner. Both `recover` help texts now describe this precisely.
+- Reading transaction runtime files now tolerates a single external
+  mtime-only touch (for example a sync client refreshing metadata) by
+  re-reading up to three times and accepting the content once two
+  consecutive reads are byte-identical. Any size, inode, device, or mode
+  change still fails closed immediately with `CORRUPT_RUNTIME_STATE`.
 
 ## [2.1.1] - 2026-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ implementation record for older releases.
 
 ### Changed
 
+- `ATTRIBUTION.md` now credits the contributor designs behind the reranker task
+  prefixes (PR #77, maartengoet) and the BM25 fallback order fix (PR #62,
+  vinsocci) that v2.0.0 adopted.
 - The five setup shell scripts (`setup-dragonscale.sh`, `setup-mode.sh`,
   `setup-multi-agent.sh`, `setup-retrieve.sh`, `setup-vault.sh`) moved from
   the top-level `bin/` directory to `scripts/`. claude.ai rejects any plugin

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@ implementation record for older releases.
   `UnicodeEncodeError` on the first such print. Both files now reconfigure
   stdout to UTF-8 on startup, guarded so a captured/redirected runner without
   a `reconfigure`-capable stdout still runs.
+- `capture.py`'s public-host validator now rejects hex-dotted, octal-dotted,
+  and short-form loopback spellings (`0x7f.0.0.1`, `0177.0.0.1`, `127.1`,
+  `0x7f.0x0.0x0.0x1`) that `ipaddress.ip_address()` does not parse and that
+  previously fell through to only a single-label check. Mirrors the existing
+  numeric-label rejection in the source-ledger URL canonicalizer.
 
 ## [2.1.1] - 2026-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,17 @@ implementation record for older releases.
   requirement (a current release; the exec-form `args` command hook and the
   `compact` `SessionStart` matcher need it), linking to the Claude Code hooks
   contract.
+### Changed
+
+- The five setup shell scripts (`setup-dragonscale.sh`, `setup-mode.sh`,
+  `setup-multi-agent.sh`, `setup-retrieve.sh`, `setup-vault.sh`) moved from
+  the top-level `bin/` directory to `scripts/`. claude.ai rejects any plugin
+  that ships a top-level `bin/` directory (it is reserved for the plugin's
+  Bash `PATH`); this repository never relied on that PATH behavior, so the
+  only change is the invocation path, for example `bash bin/setup-mode.sh`
+  becomes `bash scripts/setup-mode.sh`. Update any local scripts, aliases, or
+  CI that reference the old `bin/` paths. `RELEASE_MANIFEST.json` and
+  `SHA256SUMS` are refreshed at release time.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,11 @@ implementation record for older releases.
   `0x7f.0x0.0x0.0x1`) that `ipaddress.ip_address()` does not parse and that
   previously fell through to only a single-label check. Mirrors the existing
   numeric-label rejection in the source-ledger URL canonicalizer.
+- Twelve `SKILL.md` files that link into `skills/wiki/references/` now state
+  that a `../wiki/references/` link resolves relative to the skill's own
+  directory under `$PRODUCT_ROOT`, never the selected vault's `wiki/`
+  directory. Package validation now flags any such link missing that anchor
+  sentence.
 
 ## [2.1.1] - 2026-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ implementation record for older releases.
   becomes `bash scripts/setup-mode.sh`. Update any local scripts, aliases, or
   CI that reference the old `bin/` paths. `RELEASE_MANIFEST.json` and
   `SHA256SUMS` are refreshed at release time.
+- A repeatable `lint --exclude GLOB` CLI flag and a matching
+  `lint_vault(..., exclude=...)` engine parameter scope specific paths (for
+  example a `wiki/scratchpad/` folder) out of page, link-resolution, orphan,
+  frontmatter, empty-section, and stale-index scanning. The same glob list
+  may be set vault-side via an `exclude` (or `exclude_globs` /
+  `excluded_paths`) array in `.vault-meta/lint.json`, `lint-allowlist.json`,
+  or `wiki-lint.json`; CLI and vault-config patterns are combined. The
+  report's new `summary.excluded_paths` count reports how many walked files
+  were dropped.
 
 ### Fixed
 
@@ -66,6 +75,12 @@ implementation record for older releases.
   directory under `$PRODUCT_ROOT`, never the selected vault's `wiki/`
   directory. Package validation now flags any such link missing that anchor
   sentence.
+- Lint no longer walks dot-prefixed directories (`.raw/` ingest archives,
+  `.claude/` agent worktrees, Obsidian's own `.trash/`, and similar) by
+  default, matching Obsidian's own indexer. Previously a duplicated or
+  archived page under a dot-prefixed folder became a real link-resolution
+  candidate, turning a single healthy `[[Wikilink]]` into a spurious
+  `ambiguous_targets` (and, on index pages, `stale_index_entries`) finding.
 
 ## [2.1.1] - 2026-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ implementation record for older releases.
   requirement (a current release; the exec-form `args` command hook and the
   `compact` `SessionStart` matcher need it), linking to the Claude Code hooks
   contract.
+- A repeatable `lint --exclude GLOB` CLI flag and a matching
+  `lint_vault(..., exclude=...)` engine parameter scope specific paths (for
+  example a `wiki/scratchpad/` folder) out of page, link-resolution, orphan,
+  frontmatter, empty-section, and stale-index scanning. The same glob list
+  may be set vault-side via an `exclude` (or `exclude_globs` /
+  `excluded_paths`) array in `.vault-meta/lint.json`, `lint-allowlist.json`,
+  or `wiki-lint.json`; CLI and vault-config patterns are combined. The
+  report's new `summary.excluded_paths` count reports how many walked files
+  were dropped.
+
 ### Changed
 
 - The five setup shell scripts (`setup-dragonscale.sh`, `setup-mode.sh`,
@@ -28,15 +38,6 @@ implementation record for older releases.
   becomes `bash scripts/setup-mode.sh`. Update any local scripts, aliases, or
   CI that reference the old `bin/` paths. `RELEASE_MANIFEST.json` and
   `SHA256SUMS` are refreshed at release time.
-- A repeatable `lint --exclude GLOB` CLI flag and a matching
-  `lint_vault(..., exclude=...)` engine parameter scope specific paths (for
-  example a `wiki/scratchpad/` folder) out of page, link-resolution, orphan,
-  frontmatter, empty-section, and stale-index scanning. The same glob list
-  may be set vault-side via an `exclude` (or `exclude_globs` /
-  `excluded_paths`) array in `.vault-meta/lint.json`, `lint-allowlist.json`,
-  or `wiki-lint.json`; CLI and vault-config patterns are combined. The
-  report's new `summary.excluded_paths` count reports how many walked files
-  were dropped.
 
 ### Fixed
 
@@ -48,6 +49,9 @@ implementation record for older releases.
   every other link-touching part of the product, which all resolve wikilinks
   by exact vault-relative path with no fuzzy resolution: resync scripts, the
   terminology linker, and lint's dead/ambiguous-link detection.
+- The repository root `.gitignore` now ignores `.mcp.json`, matching the vault
+  template and the install guide, which treat a project-scope MCP config as a
+  potential credential carrier. Suggested by PR #44.
 - `stop_status` now reads transaction journals up to the package's existing
   8 MiB runtime JSON bound, so large valid journals are not misreported as
   unreadable. Unsafe or unreadable journals now require manual inspection, and
@@ -86,11 +90,11 @@ implementation record for older releases.
   on the same host. It still never reaps a live same-host owner before
   `--stale-after` elapses and still keeps the age gate for a foreign-host or
   unresolvable owner. Both `recover` help texts now describe this precisely.
-- Reading transaction runtime files now tolerates a single external
-  mtime-only touch (for example a sync client refreshing metadata) by
-  re-reading up to three times and accepting the content once two
-  consecutive reads are byte-identical. Any size, inode, device, or mode
-  change still fails closed immediately with `CORRUPT_RUNTIME_STATE`.
+- Reading transaction runtime files now tolerates an external mtime-only
+  touch (for example a sync client refreshing metadata) by re-reading once
+  and accepting the content only if the bytes are identical to the first
+  read. Any size, inode, device, or mode change, and any content change
+  during the read, still fails closed with `CORRUPT_RUNTIME_STATE`.
 
 ## [2.1.1] - 2026-08-26
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -6,8 +6,8 @@ Read `AGENTS.md` as the canonical host-neutral contract. Skills live in
 Install skill discovery with:
 
 ```bash
-bash bin/setup-multi-agent.sh --host gemini
-bash bin/setup-multi-agent.sh --host gemini --apply
+bash scripts/setup-multi-agent.sh --host gemini
+bash scripts/setup-multi-agent.sh --host gemini --apply
 ```
 
 The first command previews the links; the second applies that reviewed scope.

--- a/Makefile
+++ b/Makefile
@@ -41,13 +41,13 @@ test-package:
 validate: test-contracts test-package
 
 setup-dragonscale:
-	@bash bin/setup-dragonscale.sh
+	@bash scripts/setup-dragonscale.sh
 
 setup-retrieve:
-	@bash bin/setup-retrieve.sh
+	@bash scripts/setup-retrieve.sh
 
 setup-mode:
-	@bash bin/setup-mode.sh
+	@bash scripts/setup-mode.sh
 
 clean-test-state:
 	@rm -rf .vault-meta/mutation.lock .vault-meta/mutation.lock.reaping-* \

--- a/README.md
+++ b/README.md
@@ -141,8 +141,8 @@ For Codex, OpenCode, or Gemini, preview and then apply the portable skill links
 from the product checkout:
 
 ```bash
-bash bin/setup-multi-agent.sh --host codex
-bash bin/setup-multi-agent.sh --host codex --apply
+bash scripts/setup-multi-agent.sh --host codex
+bash scripts/setup-multi-agent.sh --host codex --apply
 ```
 
 Cursor and Windsurf use workspace-local skill discovery. Marketplace setup,

--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ The wrapper is `python3 scripts/claude-obsidian.py`.
 | `transaction inspect BUNDLE --vault PATH` | Validate a write bundle without mutation |
 | `transaction apply BUNDLE --vault PATH --approved-plan-sha256 HASH` | Apply one inspected, recoverable operation |
 | `transaction recover --vault PATH [--force-stale-lock]` | Restore an interrupted operation |
-| `lint --vault PATH [--as-of YYYY-MM-DD]` | Emit findings deterministic for the declared UTC date |
+| `lint --vault PATH [--as-of YYYY-MM-DD] [--exclude GLOB]...` | Emit findings deterministic for the declared UTC date |
 | `contracts --verify --vault PATH` | Execute capability readiness contracts |
 | `capture plan --vault PATH [SOURCE ...]` | Run a local capture preflight without writes |
 | `capture apply --vault PATH [SOURCE ...]` | Plan or create immutable content-addressed copies |

--- a/README.md
+++ b/README.md
@@ -345,6 +345,12 @@ remain yours.
   without it
 - Bash for setup, optional extensions, and shell test suites
 - Git only for development, releases, or an explicit knowledge checkpoint
+- A current Claude Code release for the Claude Code plugin path: the
+  exec-form `args` command hook and the `compact` `SessionStart` matcher used
+  by `hooks/hooks.json` need it (see the
+  [Claude Code hooks contract](https://code.claude.com/docs/en/hooks)). Other
+  supported hosts and the portable CLI have no Claude Code version
+  dependency.
 
 CI exercises Linux and macOS, plus a native-Windows smoke job for the portable
 surface. On native Windows (including Git Bash), read-only inspection and

--- a/agents/wiki-lint.md
+++ b/agents/wiki-lint.md
@@ -37,7 +37,9 @@ root, or selection is ambiguous.
    ```
 
    Use `--strict` only when the parent wants findings reflected in the exit
-   status. Capture stdout, stderr, and the exit code distinctly.
+   status. Capture stdout, stderr, and the exit code distinctly. Optional
+   `--exclude GLOB` (repeatable) scopes specific paths out of scanning when
+   the parent asks for it.
 2. Summarize page and link counts plus findings by rule and severity. Preserve
    each finding's exact path, line, target, and diagnostic.
 3. Read affected pages to validate surprising results, especially ambiguous

--- a/claude_obsidian/capture.py
+++ b/claude_obsidian/capture.py
@@ -15,6 +15,7 @@ import json
 import math
 import mimetypes
 import os
+import re
 import socket
 import stat
 import struct
@@ -1052,6 +1053,16 @@ def _normalize_host(host: str) -> str:
         ) from exc
 
 
+# Every dot-label is a bare decimal or 0x-hex numeral: this is never a real
+# public DNS name (numeric-only TLDs do not exist) and is instead an
+# alternate spelling of an IP address that ipaddress.ip_address() does not
+# parse, for example "0x7f.0.0.1", "0177.0.0.1", "127.1", "0x7f.0x0.0x0.0x1".
+# Mirrors the equivalent check in ledgers.py::_canonical_url_host. Wildcard
+# DNS services that map a name to loopback (for example 127.0.0.1.nip.io)
+# are a known residual gap and are deliberately not blocklisted here.
+_NUMERIC_OR_HEX_LABEL = re.compile(r"(?:[0-9]+|0x[0-9a-f]+)")
+
+
 def _validate_public_host(host: str) -> str:
     normalized = _normalize_host(host)
     if normalized == "localhost" or normalized.endswith(
@@ -1064,9 +1075,15 @@ def _validate_public_host(host: str) -> str:
     try:
         address = ipaddress.ip_address(unbracketed)
     except ValueError:
-        if "." not in normalized:
+        labels = normalized.split(".")
+        if len(labels) < 2:
             raise CaptureValidationError(
                 "URL_PRIVATE_HOST", "single-label URL hosts are forbidden"
+            )
+        if all(_NUMERIC_OR_HEX_LABEL.fullmatch(label) for label in labels):
+            raise CaptureValidationError(
+                "URL_PRIVATE_HOST",
+                "numeric or hex-encoded URL hosts are forbidden",
             )
     else:
         if not address.is_global:

--- a/claude_obsidian/capture.py
+++ b/claude_obsidian/capture.py
@@ -1502,13 +1502,19 @@ class CaptureQueueLock:
         pid, started = owner.get("pid"), owner.get("started_epoch")
         if not isinstance(pid, int) or not isinstance(started, (int, float)):
             return False
+        same_host = owner.get("host") == socket.gethostname()
+        alive = _process_alive(pid) if same_host else None
+        if self.force_stale_lock and same_host and alive is False:
+            # An explicit override may reap a confirmed-dead same-host owner
+            # immediately: age alone must never be what stands between an
+            # operator and a queue lock whose owner is provably gone on this
+            # host.
+            return True
         if now - float(started) <= self.stale_after:
             return False
         if self.force_stale_lock:
             return True
-        return (
-            owner.get("host") == socket.gethostname() and _process_alive(pid) is False
-        )
+        return same_host and alive is False
 
     def acquire(self) -> None:
         if self.acquired:

--- a/claude_obsidian/cli.py
+++ b/claude_obsidian/cli.py
@@ -218,7 +218,7 @@ def command_hook_stop(args: argparse.Namespace) -> int:
 
 def command_lint(args: argparse.Namespace) -> int:
     selection = _selection(args)
-    report = lint_vault(selection.root, as_of=args.as_of)
+    report = lint_vault(selection.root, as_of=args.as_of, exclude=args.exclude)
     if args.format == "markdown":
         sys.stdout.write(render_markdown(report))
     else:
@@ -978,6 +978,16 @@ def build_parser() -> argparse.ArgumentParser:
     _add_vault_argument(lint)
     lint.add_argument("--format", choices=("json", "markdown"), default="json")
     lint.add_argument("--as-of", help="ISO YYYY-MM-DD provenance freshness date")
+    lint.add_argument(
+        "--exclude",
+        action="append",
+        default=[],
+        metavar="GLOB",
+        help=(
+            "Exclude paths matching GLOB (relative to the resolved vault "
+            "root; '*' also matches '/'); repeatable"
+        ),
+    )
     lint.add_argument(
         "--strict", action="store_true", help="Exit 1 when findings exist"
     )

--- a/claude_obsidian/cli.py
+++ b/claude_obsidian/cli.py
@@ -953,8 +953,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--force-stale-lock",
         action="store_true",
         help=(
-            "Reap an old lock even when its host/PID identity cannot be disproved; "
-            "use only after confirming no writer is active"
+            "Reap an old lock, bypassing --stale-after only when the recorded "
+            "owner PID is confirmed dead on this host; a live same-host owner, "
+            "or an unresolvable or foreign-host owner, still requires "
+            "--stale-after to elapse. Use only after confirming no writer is "
+            "active"
         ),
     )
     recover.set_defaults(handler=command_transaction_recover)
@@ -1125,8 +1128,11 @@ def build_parser() -> argparse.ArgumentParser:
         "--force-stale-lock",
         action="store_true",
         help=(
-            "Reap an old queue lock even when its host/PID identity cannot be disproved; "
-            "use only after confirming no queue worker is active"
+            "Reap an old queue lock, bypassing --lock-stale-after only when "
+            "the recorded owner PID is confirmed dead on this host; a live "
+            "same-host owner, or an unresolvable or foreign-host owner, still "
+            "requires --lock-stale-after to elapse. Use only after confirming "
+            "no queue worker is active"
         ),
     )
     queue_recover.set_defaults(handler=command_capture_queue_recover)

--- a/claude_obsidian/lint_engine.py
+++ b/claude_obsidian/lint_engine.py
@@ -15,6 +15,13 @@ small allowlist may be placed at ``.vault-meta/lint-allowlist.json`` (a JSON
 array, or an object with a ``dangling_links``-style array) or at
 ``.vault-meta/lint-allowlist.txt`` (one target or glob per line).
 
+The walk skips every dot-prefixed directory by default, mirroring Obsidian's
+own indexer, so a duplicated or archived page under a hidden folder (a
+``.raw`` ingest archive, a ``.claude`` agent worktree, Obsidian's own
+``.trash``, and similar) is never a link-resolution candidate. ``exclude``
+globs, passed to ``lint_vault`` or set vault-side, scope specific paths out of
+every finding category.
+
 This module never creates directories or files. Even its command-line entry
 point writes only to stdout. Provenance freshness uses the explicit ``as_of``
 date when supplied and the current UTC calendar date otherwise.
@@ -54,14 +61,17 @@ REQUIRED_FRONTMATTER_FIELDS = ("title", "type", "status", "created", "updated", 
 _EXTENSIONLESS_WIKILINK_SUFFIXES = frozenset({".md", ".canvas", ".base"})
 
 _IGNORED_WALK_DIRS = {
-    ".git",
-    ".obsidian",
-    ".vault-meta",
-    ".cache",
-    ".pytest_cache",
-    "__pycache__",
     "node_modules",
+    "__pycache__",
 }
+# Obsidian hides every dot-prefixed folder from its own indexer (app/plugin
+# state such as .obsidian and .vault-meta, and any user- or tool-created
+# hidden directory such as a .raw ingest archive, .claude agent worktrees, or
+# Obsidian's own .trash). The linter mirrors that rule by default so
+# link-resolution candidates match what Obsidian itself would resolve. Add a
+# name here only for a confirmed, legitimate dot-prefixed vault-content
+# directory that must still be walked; none is known today.
+_DOT_DIR_KEEPLIST: frozenset[str] = frozenset()
 _ORPHAN_EXCLUDED_NAMES = {
     "_index.md",
     "index.md",
@@ -378,6 +388,7 @@ def _walk_files(root: Path) -> list[Path]:
                 name
                 for name in dirnames
                 if name not in _IGNORED_WALK_DIRS
+                and not (name.startswith(".") and name not in _DOT_DIR_KEEPLIST)
                 and not (current_path / name).is_symlink()
             ),
             key=lambda value: (value.casefold(), value),
@@ -602,23 +613,67 @@ def _allowlist_values(data: Any) -> list[str]:
     return values
 
 
-def _load_allowlist(root: Path) -> tuple[tuple[str, ...], list[dict[str, str]]]:
+_EXCLUDE_KEYS = {
+    "exclude",
+    "exclude_globs",
+    "excluded_paths",
+}
+
+
+def _exclude_values(data: Any) -> list[str]:
+    if not isinstance(data, dict):
+        return []
+    values: list[str] = []
+    for key, value in data.items():
+        if str(key).casefold() in _EXCLUDE_KEYS and isinstance(value, list):
+            values.extend(
+                item.strip() for item in value if isinstance(item, str) and item.strip()
+            )
+    return values
+
+
+def _normalize_exclude_patterns(values: Sequence[str] | None) -> tuple[str, ...]:
+    if not values:
+        return ()
+    result: list[str] = []
+    for value in values:
+        if not isinstance(value, str):
+            raise ValueError("exclude patterns must be strings")
+        stripped = value.strip()
+        if stripped:
+            result.append(stripped)
+    return tuple(result)
+
+
+def _is_excluded(relative: str, patterns: Sequence[str]) -> bool:
+    if not patterns:
+        return False
+    candidate = relative.casefold()
+    return any(
+        fnmatch.fnmatchcase(candidate, pattern.casefold()) for pattern in patterns
+    )
+
+
+def _load_allowlist(
+    root: Path,
+) -> tuple[tuple[str, ...], tuple[str, ...], list[dict[str, str]]]:
     meta = root / ".vault-meta"
     patterns: list[str] = []
+    exclude_patterns: list[str] = []
     errors: list[dict[str, str]] = []
     try:
         meta.lstat()
     except FileNotFoundError:
-        return (), []
+        return (), (), []
     except OSError as exc:
-        return (), [
+        return (), (), [
             {
                 "path": ".vault-meta",
                 "message": f"cannot inspect allowlist directory: {exc.__class__.__name__}",
             }
         ]
     if meta.is_symlink() or not meta.is_dir():
-        return (), [
+        return (), (), [
             {
                 "path": ".vault-meta",
                 "message": "allowlist directory must be a non-symlink directory",
@@ -641,6 +696,7 @@ def _load_allowlist(root: Path) -> tuple[tuple[str, ...], list[dict[str, str]]]:
             )
             continue
         patterns.extend(_allowlist_values(data))
+        exclude_patterns.extend(_exclude_values(data))
 
     text_path = meta / "lint-allowlist.txt"
     try:
@@ -657,8 +713,10 @@ def _load_allowlist(root: Path) -> tuple[tuple[str, ...], list[dict[str, str]]]:
                 "message": f"invalid allowlist text: {exc.__class__.__name__}",
             }
         )
-    return tuple(sorted(set(patterns), key=_path_sort_key)), sorted(
-        errors, key=_entry_sort_key
+    return (
+        tuple(sorted(set(patterns), key=_path_sort_key)),
+        tuple(sorted(set(exclude_patterns), key=_path_sort_key)),
+        sorted(errors, key=_entry_sort_key),
     )
 
 
@@ -886,13 +944,28 @@ def _sanitize_report_value(value: Any) -> Any:
 
 
 def lint_vault(
-    root: str | os.PathLike[str], *, as_of: date | str | None = None
+    root: str | os.PathLike[str],
+    *,
+    as_of: date | str | None = None,
+    exclude: Sequence[str] | None = None,
 ) -> dict[str, Any]:
     """Return a deterministic, JSON-serializable lint report.
 
     ``root`` is normally the vault directory containing ``wiki/``.  Passing a
     directory named ``wiki`` is also supported.  Symlinked files and symlinked
     directories are not followed.  The function performs no filesystem writes.
+
+    ``exclude`` is an optional sequence of shell-style glob patterns (matched
+    case-insensitively with :mod:`fnmatch`, where ``*`` also matches ``/``)
+    evaluated against each candidate's path relative to ``root``. A matching
+    path is dropped before page parsing, so it contributes no page, no
+    link-resolution candidate, and no orphan/frontmatter/empty-section/
+    stale-index finding. The same patterns may be set vault-side via an
+    ``exclude`` (or ``exclude_globs`` / ``excluded_paths``) array in
+    ``.vault-meta/lint-allowlist.json``, ``wiki-lint.json``, or ``lint.json``;
+    CLI-supplied and vault-config patterns are combined. When ``root`` is the
+    ``wiki`` directory itself, relative paths omit the ``wiki/`` prefix, so
+    vault-config patterns written as ``wiki/...`` do not match in that mode.
     """
 
     root_path = Path(root).expanduser()
@@ -914,14 +987,24 @@ def lint_vault(
             raise ValueError("as_of must be an ISO YYYY-MM-DD date") from exc
     else:
         raise ValueError("as_of must be an ISO date, date object, or null")
-    patterns, configuration_errors = _load_allowlist(vault_root)
+    patterns, config_exclude_patterns, configuration_errors = _load_allowlist(vault_root)
 
     all_paths = _walk_files(root_path)
+    exclude_patterns = tuple(
+        sorted(
+            {*_normalize_exclude_patterns(exclude), *config_exclude_patterns},
+            key=_path_sort_key,
+        )
+    )
+    excluded_paths = 0
     pages_by_path: dict[str, _Page] = {}
     targets: list[_Target] = []
     read_errors: list[dict[str, str]] = []
     for path in all_paths:
         relative = path.relative_to(root_path).as_posix()
+        if _is_excluded(relative, exclude_patterns):
+            excluded_paths += 1
+            continue
         page: _Page | None = None
         if path.suffix.casefold() == ".md":
             try:
@@ -1107,6 +1190,7 @@ def lint_vault(
             "links_scanned": links_scanned,
             "issues_found": issues_found,
             "allowlisted_dangling_links": len(allowlisted),
+            "excluded_paths": excluded_paths,
             "category_counts": category_counts,
         },
         **categories,
@@ -1150,6 +1234,7 @@ def render_markdown(report: dict[str, Any]) -> str:
         "",
         f"- Pages scanned: {summary.get('pages_scanned', 0)}",
         f"- Links scanned: {summary.get('links_scanned', 0)}",
+        f"- Excluded paths: {summary.get('excluded_paths', 0)}",
         f"- Issues found: {summary.get('issues_found', 0)}",
         f"- Allowlisted dangling links: {summary.get('allowlisted_dangling_links', 0)}",
     ]

--- a/claude_obsidian/package_validation.py
+++ b/claude_obsidian/package_validation.py
@@ -307,6 +307,28 @@ def _validate_skill_helper_paths(root: Path) -> list[dict[str, str]]:
     return findings
 
 
+def _validate_wiki_reference_link_anchors(root: Path) -> list[dict[str, str]]:
+    """A ../wiki/references/ link must state its skill-relative resolution root."""
+
+    findings: list[dict[str, str]] = []
+    link_pattern = re.compile(r"\.\./wiki/references/")
+    anchor_phrase = "relative to this skill's own directory under `$PRODUCT_ROOT`"
+    for path in sorted((root / "skills").glob("*/SKILL.md")):
+        text = path.read_text(encoding="utf-8")
+        if not link_pattern.search(text):
+            continue
+        normalized = " ".join(text.split())
+        if anchor_phrase not in normalized:
+            findings.append(
+                _finding(
+                    "unanchored_wiki_reference_link",
+                    path.relative_to(root).as_posix(),
+                    "a ../wiki/references/ link needs the skill-relative resolution sentence",
+                )
+            )
+    return findings
+
+
 def _validate_hooks(root: Path) -> list[dict[str, str]]:
     document, errors = _load_json(root, "hooks/hooks.json")
     if errors:
@@ -522,6 +544,7 @@ def validate_package(root: Path) -> dict[str, Any]:
         *_validate_skills(root),
         *_validate_documented_apply_examples(root),
         *_validate_skill_helper_paths(root),
+        *_validate_wiki_reference_link_anchors(root),
         *_validate_hooks(root),
         *_validate_versions(root),
     ]

--- a/claude_obsidian/package_validation.py
+++ b/claude_obsidian/package_validation.py
@@ -329,6 +329,21 @@ def _validate_wiki_reference_link_anchors(root: Path) -> list[dict[str, str]]:
     return findings
 
 
+def _validate_no_legacy_bin_directory(root: Path) -> list[dict[str, str]]:
+    """claude.ai rejects a plugin distributing a top-level bin/ directory."""
+
+    if (root / "bin").exists():
+        return [
+            _finding(
+                "top_level_bin_directory",
+                "bin",
+                "top-level bin/ is rejected by claude.ai plugin distribution; "
+                "use scripts/ instead",
+            )
+        ]
+    return []
+
+
 def _validate_hooks(root: Path) -> list[dict[str, str]]:
     document, errors = _load_json(root, "hooks/hooks.json")
     if errors:
@@ -545,6 +560,7 @@ def validate_package(root: Path) -> dict[str, Any]:
         *_validate_documented_apply_examples(root),
         *_validate_skill_helper_paths(root),
         *_validate_wiki_reference_link_anchors(root),
+        *_validate_no_legacy_bin_directory(root),
         *_validate_hooks(root),
         *_validate_versions(root),
     ]

--- a/claude_obsidian/transaction.py
+++ b/claude_obsidian/transaction.py
@@ -2147,7 +2147,6 @@ def _bounded_runtime_names(directory_fd: int, *, limit: int, label: str) -> list
     return sorted(names)
 
 
-_RUNTIME_READ_STABILITY_ATTEMPTS = 3
 _RUNTIME_READ_STABILITY_DELAY = 0.02
 
 
@@ -2215,24 +2214,20 @@ def _read_runtime_bytes_at(
 
         raw, after = _read_current()
         _require_stable_identity(after)
-        attempts = 1
-        while True:
-            if after.st_mtime_ns == opened.st_mtime_ns:
-                return raw
-            if attempts >= _RUNTIME_READ_STABILITY_ATTEMPTS:
-                raise error_type(
-                    "CORRUPT_RUNTIME_STATE", f"{label} changed while it was read"
-                )
-            # A metadata-only touch (a sync client refreshing timestamps) moves
-            # the mtime without moving a byte, so re-read and accept the content
-            # only once two consecutive reads are byte-identical.
-            time.sleep(_RUNTIME_READ_STABILITY_DELAY)
-            next_raw, next_after = _read_current()
-            attempts += 1
-            _require_stable_identity(next_after)
-            if next_raw == raw:
-                return next_raw
-            raw, after = next_raw, next_after
+        if after.st_mtime_ns == opened.st_mtime_ns:
+            return raw
+        # A metadata-only touch (a sync client refreshing timestamps) moves the
+        # mtime without moving a byte. Re-read once and accept only if the bytes
+        # are identical to the first read; any difference means the content
+        # changed while it was read and the read fails closed.
+        time.sleep(_RUNTIME_READ_STABILITY_DELAY)
+        confirmation, confirmed = _read_current()
+        _require_stable_identity(confirmed)
+        if confirmation != raw:
+            raise error_type(
+                "CORRUPT_RUNTIME_STATE", f"{label} changed while it was read"
+            )
+        return raw
     except TransactionError:
         raise
     except OSError as exc:

--- a/claude_obsidian/transaction.py
+++ b/claude_obsidian/transaction.py
@@ -1689,14 +1689,20 @@ class MutationLock:
         host = owner.get("host")
         if not isinstance(started, (int, float)) or not isinstance(pid, int):
             return False
+        same_host = isinstance(host, str) and host == socket.gethostname()
+        alive = _process_alive(pid) if same_host else None
+        if self.force_stale_lock and same_host and alive is False:
+            # An explicit override may reap a confirmed-dead same-host owner
+            # immediately: age alone must never be what stands between an
+            # operator and a lock whose owner is provably gone on this host.
+            return True
         age = now - float(started)
         if age <= self.stale_after:
             return False
         if self.force_stale_lock:
             return True
-        if not isinstance(host, str) or host != socket.gethostname():
+        if not same_host:
             return False
-        alive = _process_alive(pid)
         return alive is False
 
     def duplicate_parent_fd(self) -> int:
@@ -2141,6 +2147,10 @@ def _bounded_runtime_names(directory_fd: int, *, limit: int, label: str) -> list
     return sorted(names)
 
 
+_RUNTIME_READ_STABILITY_ATTEMPTS = 3
+_RUNTIME_READ_STABILITY_DELAY = 0.02
+
+
 def _read_runtime_bytes_at(
     directory_fd: int,
     name: str,
@@ -2177,25 +2187,52 @@ def _read_runtime_bytes_at(
             raise error_type(
                 "CORRUPT_RUNTIME_STATE", f"{label} changed before it was read"
             )
-        chunks: list[bytes] = []
-        total = 0
-        while True:
-            block = os.read(descriptor, min(1024 * 1024, limit + 1 - total))
-            if not block:
-                break
-            chunks.append(block)
-            total += len(block)
-            if total > limit:
+
+        def _read_current() -> tuple[bytes, os.stat_result]:
+            os.lseek(descriptor, 0, os.SEEK_SET)
+            chunks: list[bytes] = []
+            total = 0
+            while True:
+                block = os.read(descriptor, min(1024 * 1024, limit + 1 - total))
+                if not block:
+                    break
+                chunks.append(block)
+                total += len(block)
+                if total > limit:
+                    raise error_type(
+                        "CORRUPT_RUNTIME_STATE", f"{label} exceeds its size limit"
+                    )
+            return b"".join(chunks), os.fstat(descriptor)
+
+        def _require_stable_identity(observed: os.stat_result) -> None:
+            rigid = ("st_dev", "st_ino", "st_size", "st_mode")
+            if any(
+                getattr(opened, field) != getattr(observed, field) for field in rigid
+            ):
                 raise error_type(
-                    "CORRUPT_RUNTIME_STATE", f"{label} exceeds its size limit"
+                    "CORRUPT_RUNTIME_STATE", f"{label} changed while it was read"
                 )
-        after = os.fstat(descriptor)
-        stable = ("st_dev", "st_ino", "st_size", "st_mtime_ns", "st_mode")
-        if any(getattr(opened, field) != getattr(after, field) for field in stable):
-            raise error_type(
-                "CORRUPT_RUNTIME_STATE", f"{label} changed while it was read"
-            )
-        return b"".join(chunks)
+
+        raw, after = _read_current()
+        _require_stable_identity(after)
+        attempts = 1
+        while True:
+            if after.st_mtime_ns == opened.st_mtime_ns:
+                return raw
+            if attempts >= _RUNTIME_READ_STABILITY_ATTEMPTS:
+                raise error_type(
+                    "CORRUPT_RUNTIME_STATE", f"{label} changed while it was read"
+                )
+            # A metadata-only touch (a sync client refreshing timestamps) moves
+            # the mtime without moving a byte, so re-read and accept the content
+            # only once two consecutive reads are byte-identical.
+            time.sleep(_RUNTIME_READ_STABILITY_DELAY)
+            next_raw, next_after = _read_current()
+            attempts += 1
+            _require_stable_identity(next_after)
+            if next_raw == raw:
+                return next_raw
+            raw, after = next_raw, next_after
     except TransactionError:
         raise
     except OSError as exc:

--- a/config/capabilities.json
+++ b/config/capabilities.json
@@ -254,7 +254,7 @@
       "tier": "core",
       "implementation_paths": [
         "skills/wiki/SKILL.md",
-        "bin/setup-vault.sh"
+        "scripts/setup-vault.sh"
       ],
       "read_scope": [
         "plugin:skills/**",
@@ -531,7 +531,7 @@
       "tier": "extension",
       "implementation_paths": [
         "skills/wiki-mode/SKILL.md",
-        "bin/setup-mode.sh",
+        "scripts/setup-mode.sh",
         "scripts/wiki-mode.py"
       ],
       "read_scope": [
@@ -599,7 +599,7 @@
       "tier": "extension",
       "implementation_paths": [
         "skills/wiki-retrieve/SKILL.md",
-        "bin/setup-retrieve.sh",
+        "scripts/setup-retrieve.sh",
         "scripts/bm25-index.py",
         "scripts/contextual-prefix.py",
         "scripts/rerank.py",

--- a/config/product-contract.json
+++ b/config/product-contract.json
@@ -43,7 +43,7 @@
       "id": "cursor",
       "support_level": "compatible",
       "implementation_paths": [
-        "bin/setup-multi-agent.sh",
+        "scripts/setup-multi-agent.sh",
         "skills"
       ]
     },
@@ -51,7 +51,7 @@
       "id": "gemini-cli",
       "support_level": "compatible",
       "implementation_paths": [
-        "bin/setup-multi-agent.sh",
+        "scripts/setup-multi-agent.sh",
         "skills"
       ]
     },
@@ -67,7 +67,7 @@
       "id": "windsurf",
       "support_level": "compatible",
       "implementation_paths": [
-        "bin/setup-multi-agent.sh",
+        "scripts/setup-multi-agent.sh",
         "skills"
       ]
     }
@@ -77,7 +77,7 @@
       "id": "agent-skills-link",
       "host": "agent-skills-compatible",
       "implementation_paths": [
-        "bin/setup-multi-agent.sh",
+        "scripts/setup-multi-agent.sh",
         "skills"
       ]
     },
@@ -103,7 +103,7 @@
       "id": "codex-skills-link",
       "host": "codex-cli",
       "implementation_paths": [
-        "bin/setup-multi-agent.sh",
+        "scripts/setup-multi-agent.sh",
         "skills"
       ]
     },
@@ -111,7 +111,7 @@
       "id": "cursor-workspace-skills-link",
       "host": "cursor",
       "implementation_paths": [
-        "bin/setup-multi-agent.sh",
+        "scripts/setup-multi-agent.sh",
         "skills"
       ]
     },
@@ -119,7 +119,7 @@
       "id": "gemini-skills-link",
       "host": "gemini-cli",
       "implementation_paths": [
-        "bin/setup-multi-agent.sh",
+        "scripts/setup-multi-agent.sh",
         "skills"
       ]
     },
@@ -127,7 +127,7 @@
       "id": "opencode-skills-link",
       "host": "opencode",
       "implementation_paths": [
-        "bin/setup-multi-agent.sh",
+        "scripts/setup-multi-agent.sh",
         "skills"
       ]
     },
@@ -135,7 +135,7 @@
       "id": "windsurf-workspace-skills-link",
       "host": "windsurf",
       "implementation_paths": [
-        "bin/setup-multi-agent.sh",
+        "scripts/setup-multi-agent.sh",
         "skills"
       ]
     }

--- a/config/release-allowlist.json
+++ b/config/release-allowlist.json
@@ -58,7 +58,6 @@
     ".windsurf",
     "agents",
     "assets",
-    "bin",
     "claude_obsidian",
     "config",
     "docs",

--- a/docs/compound-vault-guide.md
+++ b/docs/compound-vault-guide.md
@@ -102,8 +102,8 @@ The optional retrieval pipeline stores contextual chunks and BM25 state below
 `.vault-meta/`. Provisioning is preview-first:
 
 ```bash
-bash bin/setup-retrieve.sh --vault <vault> --no-llm
-bash bin/setup-retrieve.sh --vault <vault> --no-llm --apply
+bash scripts/setup-retrieve.sh --vault <vault> --no-llm
+bash scripts/setup-retrieve.sh --vault <vault> --no-llm --apply
 ```
 
 BM25 is deterministic and local. Optional cosine reranking defaults to the

--- a/docs/dragonscale-guide.md
+++ b/docs/dragonscale-guide.md
@@ -9,13 +9,13 @@ their maturity and dependencies differ.
 Preview the create-only setup transaction:
 
 ```bash
-bash bin/setup-dragonscale.sh --vault <vault>
+bash scripts/setup-dragonscale.sh --vault <vault>
 ```
 
 Apply only after reviewing the missing paths:
 
 ```bash
-bash bin/setup-dragonscale.sh --vault <vault> \
+bash scripts/setup-dragonscale.sh --vault <vault> \
   --generated-at <ISO-UTC> --approved-plan-sha256 <reviewed-sha256> --apply
 ```
 

--- a/docs/install-guide.md
+++ b/docs/install-guide.md
@@ -57,8 +57,8 @@ not convert the product repository into a user vault.
 The installer defaults to a no-write preview for Codex, OpenCode, and Gemini:
 
 ```bash
-bash bin/setup-multi-agent.sh
-bash bin/setup-multi-agent.sh --apply
+bash scripts/setup-multi-agent.sh
+bash scripts/setup-multi-agent.sh --apply
 ```
 
 It links each canonical `skills/<name>/` directory into the host's direct
@@ -67,14 +67,14 @@ when absent; an existing skill or link is never replaced. Check readiness
 without writing:
 
 ```bash
-bash bin/setup-multi-agent.sh --check
+bash scripts/setup-multi-agent.sh --check
 ```
 
 Cursor and Windsurf use workspace-local discovery and require an explicit
 workspace:
 
 ```bash
-bash bin/setup-multi-agent.sh --host cursor --host windsurf \
+bash scripts/setup-multi-agent.sh --host cursor --host windsurf \
   --workspace <workspace> --apply
 ```
 
@@ -182,9 +182,9 @@ bash scripts/detect-transport.sh --peek --vault <vault>
 Optional extensions are explicit and vault-scoped:
 
 ```bash
-bash bin/setup-mode.sh --vault <vault>
-bash bin/setup-retrieve.sh --vault <vault>
-bash bin/setup-dragonscale.sh --vault <vault>
+bash scripts/setup-mode.sh --vault <vault>
+bash scripts/setup-retrieve.sh --vault <vault>
+bash scripts/setup-dragonscale.sh --vault <vault>
 ```
 
 Read each script's preview before applying. Retrieval may use local BM25 alone;

--- a/docs/methodology-modes-guide.md
+++ b/docs/methodology-modes-guide.md
@@ -50,8 +50,8 @@ python3 scripts/claude-obsidian.py mode set para --vault <vault> \
 The compatibility wrapper has the same behavior:
 
 ```bash
-bash bin/setup-mode.sh --vault <vault> --mode para
-bash bin/setup-mode.sh --vault <vault> --mode para \
+bash scripts/setup-mode.sh --vault <vault> --mode para
+bash scripts/setup-mode.sh --vault <vault> --mode para \
   --generated-at <ISO-UTC> --approved-plan-sha256 <reviewed-sha256> --apply
 ```
 

--- a/docs/windows-wsl.md
+++ b/docs/windows-wsl.md
@@ -13,10 +13,38 @@ exists, and how to unstick WSL when it misbehaves.
 | Capture queue commands (including read-only `capture queue list`) | Yes | No — currently refused; tracked in [#151](https://github.com/AgriciDaniel/claude-obsidian/issues/151) |
 | Git checkpoints (`checkpoint`) | Linux and macOS only | No |
 | Bash setup scripts and shell test suites | Yes | No (POSIX-only) |
+| Claude Code hooks (`SessionStart`, `Stop`) | Yes (works out of the box) | Partial: requires `python3` on `PATH`; see [below](#claude-code-hooks-and-python3-on-windows) |
 
 Vaults must live on a filesystem with stable file identity: NTFS is fine, but
 FAT/exFAT volumes (typical USB sticks) and some network shares are refused with
 `UNSAFE_VAULT_IDENTITY` — move the vault to NTFS or work inside WSL.
+
+## Claude Code hooks and python3 on Windows
+
+`hooks/hooks.json` spawns each hook using the [Claude Code exec-form command
+hook](https://code.claude.com/docs/en/hooks): `"command": "python3"` with an
+`args` array. Claude Code resolves `python3` as an executable on `PATH` and
+spawns it directly; there is no shell, so no `.bat` shim, alias function, or
+shell profile is consulted.
+
+WSL and most Linux and macOS Python installs provide a `python3` on `PATH` by
+default, so hooks work there without extra setup. Native Windows commonly does
+not:
+
+- python.org installer: installs `python.exe`, not `python3.exe`. Either add
+  a `python3.exe` shim earlier on `PATH` than the interpreter, install a
+  distribution that provides `python3.exe`, or run Claude Code from WSL so
+  hooks resolve the WSL `python3`.
+- Microsoft Store Python: the `python3` app execution alias can be a stub
+  that opens the Store instead of running Python. Disable the `python3` app
+  execution alias in Windows Settings, then install Python from python.org
+  or WSL and confirm the real interpreter is on `PATH`.
+
+When `python3` cannot be resolved, Claude Code fails to spawn the hook
+process, so claude-obsidian's own code never runs and cannot emit a
+diagnostic. SessionStart context and Stop recovery warnings are both silently
+absent in that case; the rest of claude-obsidian (skills and the CLI) is
+unaffected, since only the optional hook path depends on `python3`.
 
 ## Why writes require WSL
 

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -2,6 +2,13 @@
 
 `hooks.json` is a thin Claude Code adapter around the portable core.
 
+Hooks require a current Claude Code release: the exec-form `command` and
+`args` hook shape and the `compact` `SessionStart` matcher used below need it
+(see the [Claude Code hooks contract](https://code.claude.com/docs/en/hooks)).
+Both hooks also need an interpreter reachable as `python3` on `PATH`; see the
+[Windows and WSL guide](../docs/windows-wsl.md#claude-code-hooks-and-python3-on-windows)
+for native Windows setup.
+
 | Event | Matcher | Behavior |
 |---|---|---|
 | `SessionStart` | `startup|resume|clear|compact` | Silent by default. With `CLAUDE_OBSIDIAN_SESSION_CONTEXT=1`, resolves a real user vault and emits a bounded, sanitized `wiki/hot.md` data block. A workspace-configured vault outside that project also requires an exact `CLAUDE_OBSIDIAN_SESSION_CONTEXT_VAULT` path. |

--- a/scripts/retrieve.py
+++ b/scripts/retrieve.py
@@ -141,7 +141,7 @@ def import_sibling(name, filename):
     target = SCRIPTS_DIR / filename
     if not target.is_file():
         log(f"ERR: sibling helper {filename} not found at {target}")
-        log("  Run `bash bin/setup-retrieve.sh --check` to verify the install.")
+        log("  Run `bash scripts/setup-retrieve.sh --check` to verify the install.")
         sys.exit(EXIT_NOT_PROVISIONED)
     try:
         spec = importlib.util.spec_from_file_location(name, target)
@@ -257,7 +257,7 @@ def main(argv=None):
         return EXIT_USAGE
 
     if not BM25_INDEX.is_file():
-        log(f"ERR: no BM25 index at {BM25_INDEX}. Run `bash bin/setup-retrieve.sh` "
+        log(f"ERR: no BM25 index at {BM25_INDEX}. Run `bash scripts/setup-retrieve.sh` "
             "to provision, or fall back to legacy hot→index→drill.")
         return EXIT_NOT_PROVISIONED
     if not CHUNKS_DIR.is_dir() or not any(CHUNKS_DIR.iterdir()):

--- a/scripts/setup-dragonscale.sh
+++ b/scripts/setup-dragonscale.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Thin compatibility wrapper for transactional methodology configuration.
+# Compatibility entry point for dry-run-first DragonScale state provisioning.
 
 set -euo pipefail
 export PYTHONDONTWRITEBYTECODE=1
@@ -7,7 +7,6 @@ export PYTHONDONTWRITEBYTECODE=1
 PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CLI="$PLUGIN_ROOT/scripts/claude-obsidian.py"
 VAULT=""
-MODE=""
 APPLY=false
 CHECK=false
 GENERATED_AT=""
@@ -15,13 +14,13 @@ APPROVED_PLAN_SHA256=""
 
 usage() {
   cat <<'EOF'
-Usage: bin/setup-mode.sh [--vault PATH] [--mode MODE] [--check] [--apply]
-                         [--generated-at ISO-UTC]
-                         [--approved-plan-sha256 SHA256]
+Usage: scripts/setup-dragonscale.sh [--vault PATH] [--check] [--apply]
+                                [--generated-at ISO-UTC]
+                                [--approved-plan-sha256 SHA256]
 
-MODE is generic, lyt, para, or zettelkasten. Without --apply, setting a mode
-prints a complete transaction dry run. Without --mode, the current config is
-shown. This command never moves existing notes or seeds folders implicitly.
+The default prints a create-only transaction plan. --apply creates only missing
+address/tiling compatibility state. Existing values and raw manifests are never
+replaced. This does not install, probe, or download Ollama or any model.
 Pin --generated-at for the preview, then repeat that exact value with the
 reviewed --approved-plan-sha256 when applying the plan.
 EOF
@@ -32,11 +31,6 @@ while [ "$#" -gt 0 ]; do
     --vault)
       [ "$#" -ge 2 ] || { echo "ERROR: --vault requires a path" >&2; exit 2; }
       VAULT="$2"
-      shift
-      ;;
-    --mode)
-      [ "$#" -ge 2 ] || { echo "ERROR: --mode requires a value" >&2; exit 2; }
-      MODE="$2"
       shift
       ;;
     --check) CHECK=true ;;
@@ -57,21 +51,22 @@ while [ "$#" -gt 0 ]; do
   shift
 done
 
-if $CHECK || [ -z "$MODE" ]; then
-  if [ -n "$VAULT" ]; then
-    exec python3 "$CLI" mode get --vault "$VAULT"
-  fi
-  exec python3 "$CLI" mode get
+if $CHECK && $APPLY; then
+  echo "ERROR: --check cannot be combined with --apply" >&2
+  exit 2
+fi
+if $CHECK && [ -n "$APPROVED_PLAN_SHA256" ]; then
+  echo "ERROR: --check cannot be combined with --approved-plan-sha256" >&2
+  exit 2
 fi
 
-case "$MODE" in
-  generic|lyt|para|zettelkasten) ;;
-  *) echo "ERROR: invalid mode: $MODE" >&2; exit 2 ;;
-esac
-
-arguments=(mode set "$MODE")
+arguments=(extension dragonscale)
 [ -n "$VAULT" ] && arguments+=(--vault "$VAULT")
 $APPLY && arguments+=(--apply)
 [ -n "$APPROVED_PLAN_SHA256" ] && arguments+=(--approved-plan-sha256 "$APPROVED_PLAN_SHA256")
 [ -n "$GENERATED_AT" ] && arguments+=(--generated-at "$GENERATED_AT")
+
+if $CHECK; then
+  arguments+=(--check)
+fi
 exec python3 "$CLI" "${arguments[@]}"

--- a/scripts/setup-mode.sh
+++ b/scripts/setup-mode.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Compatibility entry point for dry-run-first DragonScale state provisioning.
+# Thin compatibility wrapper for transactional methodology configuration.
 
 set -euo pipefail
 export PYTHONDONTWRITEBYTECODE=1
@@ -7,6 +7,7 @@ export PYTHONDONTWRITEBYTECODE=1
 PLUGIN_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 CLI="$PLUGIN_ROOT/scripts/claude-obsidian.py"
 VAULT=""
+MODE=""
 APPLY=false
 CHECK=false
 GENERATED_AT=""
@@ -14,13 +15,13 @@ APPROVED_PLAN_SHA256=""
 
 usage() {
   cat <<'EOF'
-Usage: bin/setup-dragonscale.sh [--vault PATH] [--check] [--apply]
-                                [--generated-at ISO-UTC]
-                                [--approved-plan-sha256 SHA256]
+Usage: scripts/setup-mode.sh [--vault PATH] [--mode MODE] [--check] [--apply]
+                         [--generated-at ISO-UTC]
+                         [--approved-plan-sha256 SHA256]
 
-The default prints a create-only transaction plan. --apply creates only missing
-address/tiling compatibility state. Existing values and raw manifests are never
-replaced. This does not install, probe, or download Ollama or any model.
+MODE is generic, lyt, para, or zettelkasten. Without --apply, setting a mode
+prints a complete transaction dry run. Without --mode, the current config is
+shown. This command never moves existing notes or seeds folders implicitly.
 Pin --generated-at for the preview, then repeat that exact value with the
 reviewed --approved-plan-sha256 when applying the plan.
 EOF
@@ -31,6 +32,11 @@ while [ "$#" -gt 0 ]; do
     --vault)
       [ "$#" -ge 2 ] || { echo "ERROR: --vault requires a path" >&2; exit 2; }
       VAULT="$2"
+      shift
+      ;;
+    --mode)
+      [ "$#" -ge 2 ] || { echo "ERROR: --mode requires a value" >&2; exit 2; }
+      MODE="$2"
       shift
       ;;
     --check) CHECK=true ;;
@@ -51,22 +57,21 @@ while [ "$#" -gt 0 ]; do
   shift
 done
 
-if $CHECK && $APPLY; then
-  echo "ERROR: --check cannot be combined with --apply" >&2
-  exit 2
-fi
-if $CHECK && [ -n "$APPROVED_PLAN_SHA256" ]; then
-  echo "ERROR: --check cannot be combined with --approved-plan-sha256" >&2
-  exit 2
+if $CHECK || [ -z "$MODE" ]; then
+  if [ -n "$VAULT" ]; then
+    exec python3 "$CLI" mode get --vault "$VAULT"
+  fi
+  exec python3 "$CLI" mode get
 fi
 
-arguments=(extension dragonscale)
+case "$MODE" in
+  generic|lyt|para|zettelkasten) ;;
+  *) echo "ERROR: invalid mode: $MODE" >&2; exit 2 ;;
+esac
+
+arguments=(mode set "$MODE")
 [ -n "$VAULT" ] && arguments+=(--vault "$VAULT")
 $APPLY && arguments+=(--apply)
 [ -n "$APPROVED_PLAN_SHA256" ] && arguments+=(--approved-plan-sha256 "$APPROVED_PLAN_SHA256")
 [ -n "$GENERATED_AT" ] && arguments+=(--generated-at "$GENERATED_AT")
-
-if $CHECK; then
-  arguments+=(--check)
-fi
 exec python3 "$CLI" "${arguments[@]}"

--- a/scripts/setup-multi-agent.sh
+++ b/scripts/setup-multi-agent.sh
@@ -13,7 +13,7 @@ HOST_COUNT=0
 
 usage() {
   cat <<'EOF'
-Usage: bin/setup-multi-agent.sh [--check|--dry-run|--apply]
+Usage: scripts/setup-multi-agent.sh [--check|--dry-run|--apply]
        [--host codex|opencode|gemini|cursor|windsurf|all] [--workspace PATH]
 
 Default: dry-run for Codex, OpenCode, and Gemini user-level per-skill links.

--- a/scripts/setup-retrieve.sh
+++ b/scripts/setup-retrieve.sh
@@ -15,7 +15,7 @@ ALLOW_REMOTE_OLLAMA=false
 
 usage() {
   cat <<'EOF'
-Usage: bin/setup-retrieve.sh [--vault PATH] [--check] [--apply]
+Usage: scripts/setup-retrieve.sh [--vault PATH] [--check] [--apply]
        [--no-llm|--allow-egress] [--rebuild] [--allow-remote-ollama]
 
 Default is a read-only synthetic-prefix preview. --apply builds vault-scoped

--- a/scripts/setup-vault.sh
+++ b/scripts/setup-vault.sh
@@ -6,11 +6,11 @@
 # dry-run planning, exact plan approval, and recoverable transactions live.
 #
 # Usage:
-#   bash bin/setup-vault.sh [--dry-run] [--init|--adopt] [--vault PATH|PATH]
-#   bash bin/setup-vault.sh --check [--vault PATH|PATH]
-#   bash bin/setup-vault.sh --apply --approved-plan-sha256 HASH \
+#   bash scripts/setup-vault.sh [--dry-run] [--init|--adopt] [--vault PATH|PATH]
+#   bash scripts/setup-vault.sh --check [--vault PATH|PATH]
+#   bash scripts/setup-vault.sh --apply --approved-plan-sha256 HASH \
 #     --generated-at ISO-UTC --operation-id ID [--init|--adopt] [--vault PATH|PATH]
-#   bash bin/setup-vault.sh --dry-run --force --adopt [--vault PATH|PATH]
+#   bash scripts/setup-vault.sh --dry-run --force --adopt [--vault PATH|PATH]
 #
 # Compatibility:
 #   - preview is the default;

--- a/scripts/wiki-mode.py
+++ b/scripts/wiki-mode.py
@@ -7,7 +7,7 @@ new content of type X be filed under mode Y." Consumed by:
   - skills/wiki-ingest/SKILL.md  (where to file new source/entity/concept pages)
   - skills/save/SKILL.md         (where to file session notes)
   - skills/autoresearch/SKILL.md (where to file research output)
-  - bin/setup-mode.sh            (delegates configuration to the transaction core)
+  - scripts/setup-mode.sh            (delegates configuration to the transaction core)
 
 If `.vault-meta/mode.json` is absent → mode = "generic" → behavior identical
 to v1.7. No skill needs to special-case the missing-config path.

--- a/skills/autoresearch/SKILL.md
+++ b/skills/autoresearch/SKILL.md
@@ -24,6 +24,10 @@ CORE="$PRODUCT_ROOT/scripts/claude-obsidian.py"
 test -f "$CORE"
 ```
 
+Every `../wiki/references/` link in this file resolves the same way, relative
+to this skill's own directory under `$PRODUCT_ROOT`, never relative to the
+selected vault's `wiki/` directory.
+
 ## Establish the research contract
 
 Read [program.md](references/program.md). Treat it as user-configurable guidance,

--- a/skills/canvas/SKILL.md
+++ b/skills/canvas/SKILL.md
@@ -17,6 +17,10 @@ CORE="$PRODUCT_ROOT/scripts/claude-obsidian.py"
 test -f "$CORE"
 ```
 
+Every `../wiki/references/` link in this file resolves the same way, relative
+to this skill's own directory under `$PRODUCT_ROOT`, never relative to the
+selected vault's `wiki/` directory.
+
 ## Choose the syntax source
 
 Prefer a separately installed `kepano/obsidian-skills` `json-canvas` skill for

--- a/skills/defuddle/SKILL.md
+++ b/skills/defuddle/SKILL.md
@@ -17,6 +17,10 @@ CORE="$PRODUCT_ROOT/scripts/claude-obsidian.py"
 test -f "$CORE"
 ```
 
+Every `../wiki/references/` link in this file resolves the same way, relative
+to this skill's own directory under `$PRODUCT_ROOT`, never relative to the
+selected vault's `wiki/` directory.
+
 If a separately installed `kepano/obsidian-skills` `defuddle` skill is
 available, prefer it for current CLI flags. Retain the privacy, consent, and
 transaction rules in this skill.

--- a/skills/obsidian-bases/SKILL.md
+++ b/skills/obsidian-bases/SKILL.md
@@ -23,6 +23,10 @@ CORE="$PRODUCT_ROOT/scripts/claude-obsidian.py"
 test -f "$CORE"
 ```
 
+Every `../wiki/references/` link in this file resolves the same way, relative
+to this skill's own directory under `$PRODUCT_ROOT`, never relative to the
+selected vault's `wiki/` directory.
+
 ## Workflow
 
 1. Inspect representative note properties and any existing `.base` file.

--- a/skills/obsidian-markdown/SKILL.md
+++ b/skills/obsidian-markdown/SKILL.md
@@ -19,6 +19,10 @@ CORE="$PRODUCT_ROOT/scripts/claude-obsidian.py"
 test -f "$CORE"
 ```
 
+Every `../wiki/references/` link in this file resolves the same way, relative
+to this skill's own directory under `$PRODUCT_ROOT`, never relative to the
+selected vault's `wiki/` directory.
+
 Answer syntax questions read-only. If the user requests a vault edit, draft the
 complete note, read [operation-transactions.md](../wiki/references/operation-transactions.md),
 and build one `claude-obsidian.transaction.v1` bundle with

--- a/skills/save/SKILL.md
+++ b/skills/save/SKILL.md
@@ -28,6 +28,10 @@ CORE="$PRODUCT_ROOT/scripts/claude-obsidian.py"
 test -f "$CORE"
 ```
 
+Every `../wiki/references/` link in this file resolves the same way, relative
+to this skill's own directory under `$PRODUCT_ROOT`, never relative to the
+selected vault's `wiki/` directory.
+
 ## Prepare
 
 1. Resolve the user vault by explicit `--vault`, then

--- a/skills/wiki-cli/SKILL.md
+++ b/skills/wiki-cli/SKILL.md
@@ -18,6 +18,10 @@ DETECT_TRANSPORT="$PRODUCT_ROOT/scripts/detect-transport.sh"
 test -f "$DETECT_TRANSPORT"
 ```
 
+Every `../wiki/references/` link in this file resolves the same way, relative
+to this skill's own directory under `$PRODUCT_ROOT`, never relative to the
+selected vault's `wiki/` directory.
+
 ## Detect safely
 
 Probe without persisting host state:

--- a/skills/wiki-fold/SKILL.md
+++ b/skills/wiki-fold/SKILL.md
@@ -19,6 +19,10 @@ CORE="$PRODUCT_ROOT/scripts/claude-obsidian.py"
 test -f "$CORE"
 ```
 
+Every `../wiki/references/` link in this file resolves the same way, relative
+to this skill's own directory under `$PRODUCT_ROOT`, never relative to the
+selected vault's `wiki/` directory.
+
 This skill needs no network egress. Do not call external services.
 
 ## Select a bounded range

--- a/skills/wiki-ingest/SKILL.md
+++ b/skills/wiki-ingest/SKILL.md
@@ -20,6 +20,10 @@ CORE="$PRODUCT_ROOT/scripts/claude-obsidian.py"
 test -f "$CORE"
 ```
 
+Every `../wiki/references/` link in this file resolves the same way, relative
+to this skill's own directory under `$PRODUCT_ROOT`, never relative to the
+selected vault's `wiki/` directory.
+
 ## Agree on scope and egress
 
 Before processing, list the inputs and set a budget for source count, source

--- a/skills/wiki-lint/SKILL.md
+++ b/skills/wiki-lint/SKILL.md
@@ -17,6 +17,10 @@ CORE="$PRODUCT_ROOT/scripts/claude-obsidian.py"
 test -f "$CORE"
 ```
 
+Every `../wiki/references/` link in this file resolves the same way, relative
+to this skill's own directory under `$PRODUCT_ROOT`, never relative to the
+selected vault's `wiki/` directory.
+
 ## Run
 
 Resolve the user vault, then run one of:

--- a/skills/wiki-lint/SKILL.md
+++ b/skills/wiki-lint/SKILL.md
@@ -28,14 +28,20 @@ Resolve the user vault, then run one of:
 ```bash
 python3 "$CORE" lint --vault "$VAULT"
 python3 "$CORE" lint --vault "$VAULT" --format markdown
+python3 "$CORE" lint --vault "$VAULT" --exclude "wiki/scratchpad/*"
 ```
+
+The repeatable `--exclude GLOB` flag scopes a path (for example a scratchpad
+folder) out of page, link-resolution, orphan, frontmatter, empty-section, and
+stale-index scanning.
 
 Use `--strict` only when a nonzero exit for findings is useful in automation.
 The command remains read-only either way.
 
 The deterministic parser understands Obsidian wikilinks and embeds, Markdown
 links, aliases, heading and block fragments, escaped aliases, and code fences.
-It reports such categories as dead or ambiguous links, orphan pages, required
+It skips dot-prefixed directories by default, mirroring Obsidian's own
+indexer. It reports such categories as dead or ambiguous links, orphan pages, required
 frontmatter gaps (including `title`), empty sections, stale index entries, and
 source/claim ledger contract violations. Report only the
 checks and counts present in its output; do not claim that it performed

--- a/skills/wiki-mode/SKILL.md
+++ b/skills/wiki-mode/SKILL.md
@@ -21,6 +21,10 @@ MODE_HELPER="$PRODUCT_ROOT/scripts/wiki-mode.py"
 test -f "$CORE" && test -f "$MODE_HELPER"
 ```
 
+Every `../wiki/references/` link in this file resolves the same way, relative
+to this skill's own directory under `$PRODUCT_ROOT`, never relative to the
+selected vault's `wiki/` directory.
+
 ## Read and route safely
 
 Always select the vault explicitly:

--- a/skills/wiki-query/SKILL.md
+++ b/skills/wiki-query/SKILL.md
@@ -24,6 +24,10 @@ RETRIEVE="$PRODUCT_ROOT/scripts/retrieve.py"
 test -f "$CORE" && test -f "$RETRIEVE"
 ```
 
+Every `../wiki/references/` link in this file resolves the same way, relative
+to this skill's own directory under `$PRODUCT_ROOT`, never relative to the
+selected vault's `wiki/` directory.
+
 ## Select depth
 
 - **Quick**: read `wiki/hot.md` and `wiki/index.md`; answer only when those

--- a/skills/wiki/references/install-modes.md
+++ b/skills/wiki/references/install-modes.md
@@ -27,7 +27,7 @@ directory, or configure the vault explicitly.
 
 ## Portable Agent Skills
 
-Use `bin/setup-multi-agent.sh` or link each `skills/<name>/` directory at the
+Use `scripts/setup-multi-agent.sh` or link each `skills/<name>/` directory at the
 host's direct `<skill-root>/<name>/SKILL.md` discovery path. Codex, OpenCode,
 and other Agent Skills hosts consume the same `SKILL.md` files. Claude-only
 hooks are adapters, not core workflow logic.

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -355,6 +355,27 @@ def test_url_privacy_policy_has_no_network_dependency() -> None:
         socket.socket = original_socket
 
 
+def test_public_host_validation_rejects_alternate_loopback_spellings() -> None:
+    must_block = {
+        "hex_dotted": "https://0x7f.0.0.1/",
+        "octal_dotted": "https://0177.0.0.1/",
+        "short_form": "https://127.1/",
+        "hex_all_labels": "https://0x7f.0x0.0x0.0x1/",
+    }
+    still_blocked = {
+        "decimal_single_label": "https://2130706433/",
+        "hex_single_label": "https://0x7f000001/",
+        "ipv6_loopback": "https://[::1]/",
+        "ipv4_mapped_ipv6": "https://[::ffff:127.0.0.1]/",
+        "link_local_metadata": "https://169.254.169.254/",
+        "trailing_dot_localhost": "https://localhost./",
+    }
+    for label, url in must_block.items():
+        expect_code("URL_PRIVATE_HOST", lambda url=url: validate_https_url(url))
+    for label, url in still_blocked.items():
+        expect_code("URL_PRIVATE_HOST", lambda url=url: validate_https_url(url))
+
+
 def test_aws_signed_urls_and_userinfo_are_rejected() -> None:
     expect_code(
         "URL_USERINFO_FORBIDDEN",
@@ -1161,6 +1182,7 @@ def main() -> None:
     test_batch_budgets_are_preflighted_before_copy()
     test_direct_batch_rolls_back_as_one_transaction()
     test_url_privacy_policy_has_no_network_dependency()
+    test_public_host_validation_rejects_alternate_loopback_spellings()
     test_aws_signed_urls_and_userinfo_are_rejected()
     test_external_work_is_only_an_inert_plan()
     test_queue_lifecycle_is_idempotent()

--- a/tests/test_capture.py
+++ b/tests/test_capture.py
@@ -755,6 +755,48 @@ def test_explicit_queue_recovery_can_reap_stale_pid_reuse_lock() -> None:
         assert not seeded.path.exists()
 
 
+def test_queue_force_stale_lock_reaps_dead_same_host_owner() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        vault = make_vault(Path(td) / "vault")
+        seeded = CaptureQueueLock(vault)
+        seeded.path.mkdir()
+        seeded.owner_path.write_text(
+            json.dumps(
+                {
+                    "schema": "claude-obsidian.capture-lock.v1",
+                    "pid": 999999,
+                    "host": socket.gethostname(),
+                    "token": "dead-owner",
+                    "started_epoch": time.time() - 780,
+                }
+            ),
+            encoding="utf-8",
+        )
+        original_alive = capture_module._process_alive
+        capture_module._process_alive = lambda pid: False
+        try:
+            try:
+                CaptureQueueLock(vault, timeout=0, stale_after=3600.0).acquire()
+            except CaptureConflict as exc:
+                assert exc.code == "QUEUE_LOCK_TIMEOUT"
+            else:
+                raise AssertionError(
+                    "automatic recovery must not steal a young queue lock"
+                )
+            assert seeded.path.is_dir()
+
+            with CaptureQueueLock(
+                vault,
+                timeout=0,
+                stale_after=3600.0,
+                force_stale_lock=True,
+            ):
+                assert seeded.path.is_dir()
+            assert not seeded.path.exists()
+        finally:
+            capture_module._process_alive = original_alive
+
+
 def test_ownerless_queue_lock_requires_explicit_force() -> None:
     with tempfile.TemporaryDirectory() as td:
         vault = make_vault(Path(td) / "vault")
@@ -1194,6 +1236,7 @@ def main() -> None:
     test_queue_lock_maps_advisory_lock_platform_errors()
     test_concurrent_queue_writers_are_lossless_and_serialized()
     test_explicit_queue_recovery_can_reap_stale_pid_reuse_lock()
+    test_queue_force_stale_lock_reaps_dead_same_host_owner()
     test_ownerless_queue_lock_requires_explicit_force()
     test_queue_lock_release_and_reaping_ignore_replaced_external_alias()
     test_queue_io_stays_on_pinned_runtime_across_directory_replacement()

--- a/tests/test_installed_tree_boundary.py
+++ b/tests/test_installed_tree_boundary.py
@@ -15,18 +15,26 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 PYTHON_LAUNCHERS = tuple(sorted((ROOT / "scripts").glob("*.py")))
-SHELL_LAUNCHERS = (
-    *sorted((ROOT / "bin").glob("*.sh")),
-    *sorted(
+SETUP_SCRIPT_NAMES = frozenset(
+    {
+        "setup-dragonscale.sh",
+        "setup-mode.sh",
+        "setup-multi-agent.sh",
+        "setup-retrieve.sh",
+        "setup-vault.sh",
+    }
+)
+SHELL_LAUNCHERS = tuple(
+    sorted(
         path
         for path in (ROOT / "scripts").glob("*.sh")
-        if "python3" in path.read_text(encoding="utf-8")
-    ),
+        if path.name in SETUP_SCRIPT_NAMES
+        or "python3" in path.read_text(encoding="utf-8")
+    )
 )
 PRODUCT_DIRS = (
     ".claude-plugin",
     "agents",
-    "bin",
     "claude_obsidian",
     "config",
     "hooks",
@@ -134,7 +142,7 @@ class InstalledTreeBoundaryTests(unittest.TestCase):
                     (
                         [
                             "bash",
-                            str(installed / "bin/setup-dragonscale.sh"),
+                            str(installed / "scripts/setup-dragonscale.sh"),
                             "--vault",
                             str(vault),
                             "--check",
@@ -144,7 +152,7 @@ class InstalledTreeBoundaryTests(unittest.TestCase):
                     (
                         [
                             "bash",
-                            str(installed / "bin/setup-mode.sh"),
+                            str(installed / "scripts/setup-mode.sh"),
                             "--vault",
                             str(vault),
                             "--check",
@@ -154,7 +162,7 @@ class InstalledTreeBoundaryTests(unittest.TestCase):
                     (
                         [
                             "bash",
-                            str(installed / "bin/setup-multi-agent.sh"),
+                            str(installed / "scripts/setup-multi-agent.sh"),
                             "--dry-run",
                             "--host",
                             "codex",
@@ -164,7 +172,7 @@ class InstalledTreeBoundaryTests(unittest.TestCase):
                     (
                         [
                             "bash",
-                            str(installed / "bin/setup-retrieve.sh"),
+                            str(installed / "scripts/setup-retrieve.sh"),
                             "--vault",
                             str(vault),
                             "--check",
@@ -174,7 +182,7 @@ class InstalledTreeBoundaryTests(unittest.TestCase):
                     (
                         [
                             "bash",
-                            str(installed / "bin/setup-vault.sh"),
+                            str(installed / "scripts/setup-vault.sh"),
                             "--vault",
                             str(vault),
                             "--check",

--- a/tests/test_lint_engine.py
+++ b/tests/test_lint_engine.py
@@ -731,5 +731,118 @@ tags:
         )
 
 
+class WalkScopeTests(unittest.TestCase):
+    def test_raw_claude_and_trash_captures_are_not_walked(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            vault = Path(directory) / "vault"
+            concepts = vault / "wiki" / "concepts"
+            concepts.mkdir(parents=True)
+            (concepts / "Thing.md").write_text(
+                "---\ntitle: Thing\ntype: concept\nstatus: draft\ncreated: "
+                "2026-07-01\nupdated: 2026-07-01\ntags: []\n---\n\nThe thing.\n",
+                encoding="utf-8",
+            )
+            (vault / "wiki" / "Note.md").write_text(
+                "---\ntitle: Note\ntype: note\nstatus: draft\ncreated: "
+                "2026-07-01\nupdated: 2026-07-01\ntags: []\n---\n\n"
+                "See [[Thing]].\n",
+                encoding="utf-8",
+            )
+            for hidden in (
+                vault / ".raw" / "captures",
+                vault / ".claude" / "worktrees" / "example" / "wiki" / "concepts",
+                vault / ".trash",
+            ):
+                hidden.mkdir(parents=True)
+                (hidden / "Thing.md").write_text(
+                    "---\ntitle: Thing\ntype: concept\nstatus: draft\ncreated: "
+                    "2026-07-01\nupdated: 2026-07-01\ntags: []\n---\n\n"
+                    "A duplicated capture.\n",
+                    encoding="utf-8",
+                )
+            report = lint_engine.lint_vault(vault)
+        self.assertEqual([], report["ambiguous_targets"])
+        self.assertEqual([], report["dead_links"])
+        self.assertEqual(2, report["summary"]["pages_scanned"])
+
+    def test_exclude_param_and_vault_config_scope_out_pages_and_orphans(self) -> None:
+        def build_vault(directory: Path) -> Path:
+            vault = directory / "vault"
+            scratchpad = vault / "wiki" / "scratchpad"
+            scratchpad.mkdir(parents=True)
+            (scratchpad / "Draft.md").write_text("Unfinished draft.\n", encoding="utf-8")
+            (vault / "wiki" / "index.md").write_text(
+                "---\ntitle: Index\ntype: index\nstatus: draft\ncreated: "
+                "2026-07-01\nupdated: 2026-07-01\ntags: []\n---\n\nIndex.\n",
+                encoding="utf-8",
+            )
+            return vault
+
+        draft_path = "wiki/scratchpad/Draft.md"
+
+        with tempfile.TemporaryDirectory() as directory:
+            vault = build_vault(Path(directory))
+            report = lint_engine.lint_vault(vault)
+        self.assertIn(draft_path, {item["path"] for item in report["orphans"]})
+        self.assertEqual(0, report["summary"]["excluded_paths"])
+
+        with tempfile.TemporaryDirectory() as directory:
+            vault = build_vault(Path(directory))
+            report = lint_engine.lint_vault(vault, exclude=["wiki/scratchpad/*"])
+        self.assertNotIn(draft_path, {item["path"] for item in report["orphans"]})
+        self.assertNotIn(
+            draft_path, {item["path"] for item in report["missing_frontmatter"]}
+        )
+        self.assertEqual(1, report["summary"]["excluded_paths"])
+
+        with tempfile.TemporaryDirectory() as directory:
+            vault = build_vault(Path(directory))
+            meta = vault / ".vault-meta"
+            meta.mkdir(parents=True, exist_ok=True)
+            (meta / "lint.json").write_text(
+                json.dumps({"exclude": ["wiki/scratchpad/*"]}), encoding="utf-8"
+            )
+            report = lint_engine.lint_vault(vault)
+        self.assertNotIn(draft_path, {item["path"] for item in report["orphans"]})
+        self.assertNotIn(
+            draft_path, {item["path"] for item in report["missing_frontmatter"]}
+        )
+        self.assertEqual(1, report["summary"]["excluded_paths"])
+
+    def test_cli_exclude_flag_matches_engine_parameter(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            vault = Path(directory) / "vault"
+            scratchpad = vault / "wiki" / "scratchpad"
+            scratchpad.mkdir(parents=True)
+            (scratchpad / "Draft.md").write_text("Unfinished draft.\n", encoding="utf-8")
+            (vault / "wiki" / "index.md").write_text(
+                "---\ntitle: Index\ntype: index\nstatus: draft\ncreated: "
+                "2026-07-01\nupdated: 2026-07-01\ntags: []\n---\n\nIndex.\n",
+                encoding="utf-8",
+            )
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(ROOT / "scripts" / "claude-obsidian.py"),
+                    "lint",
+                    "--vault",
+                    str(vault),
+                    "--format",
+                    "json",
+                    "--exclude",
+                    "wiki/scratchpad/*",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+        self.assertEqual(0, completed.returncode, completed.stderr)
+        report = json.loads(completed.stdout)
+        self.assertNotIn(
+            "wiki/scratchpad/Draft.md", {item["path"] for item in report["orphans"]}
+        )
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_package_validation.py
+++ b/tests/test_package_validation.py
@@ -327,6 +327,35 @@ class PackageValidationTests(unittest.TestCase):
                 )
             )
 
+    def test_wiki_reference_links_require_the_skill_relative_anchor_sentence(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.fixture(
+                root, frontmatter="---\nname: sample\ndescription: Sample.\n---"
+            )
+            skill = root / "skills/sample/SKILL.md"
+            skill.write_text(
+                skill.read_text(encoding="utf-8")
+                + "\nRead [the transaction contract]"
+                "(../wiki/references/operation-transactions.md).\n",
+                encoding="utf-8",
+            )
+            codes = {item["code"] for item in validate_package(root)["findings"]}
+            self.assertIn("unanchored_wiki_reference_link", codes)
+
+            skill.write_text(
+                skill.read_text(encoding="utf-8")
+                + "\nEvery `../wiki/references/` link in this file resolves the"
+                " same way, relative to this skill's own directory under"
+                " `$PRODUCT_ROOT`, never relative to the selected vault's"
+                " `wiki/` directory.\n",
+                encoding="utf-8",
+            )
+            codes = {item["code"] for item in validate_package(root)["findings"]}
+            self.assertNotIn("unanchored_wiki_reference_link", codes)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_package_validation.py
+++ b/tests/test_package_validation.py
@@ -356,6 +356,20 @@ class PackageValidationTests(unittest.TestCase):
             codes = {item["code"] for item in validate_package(root)["findings"]}
             self.assertNotIn("unanchored_wiki_reference_link", codes)
 
+    def test_top_level_bin_directory_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            self.fixture(
+                root, frontmatter="---\nname: sample\ndescription: Sample.\n---"
+            )
+            (root / "bin").mkdir()
+            (root / "bin" / "setup-example.sh").write_text(
+                "#!/usr/bin/env bash\n", encoding="utf-8"
+            )
+            findings = validate_package(root)["findings"]
+            codes = {item["code"] for item in findings}
+            self.assertIn("top_level_bin_directory", codes)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_setup_multi_agent.py
+++ b/tests/test_setup_multi_agent.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-SCRIPT = ROOT / "bin/setup-multi-agent.sh"
+SCRIPT = ROOT / "scripts/setup-multi-agent.sh"
 
 
 class SetupMultiAgentTests(unittest.TestCase):

--- a/tests/test_setup_retrieve.py
+++ b/tests/test_setup_retrieve.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-SCRIPT = ROOT / "bin/setup-retrieve.sh"
+SCRIPT = ROOT / "scripts/setup-retrieve.sh"
 
 
 class SetupRetrieveTests(unittest.TestCase):

--- a/tests/test_setup_vault.py
+++ b/tests/test_setup_vault.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parent.parent
-SCRIPT = ROOT / "bin" / "setup-vault.sh"
+SCRIPT = ROOT / "scripts" / "setup-vault.sh"
 FIXTURES = ROOT / "tests" / "fixtures" / "setup"
 _OPERATION_COUNTER = itertools.count(1)
 _GENERATED_AT = "2026-07-11T12:00:00Z"

--- a/tests/test_setup_wrappers.py
+++ b/tests/test_setup_wrappers.py
@@ -12,9 +12,9 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-MODE = ROOT / "bin/setup-mode.sh"
-DRAGONSCALE = ROOT / "bin/setup-dragonscale.sh"
-SETUP_VAULT = ROOT / "bin/setup-vault.sh"
+MODE = ROOT / "scripts/setup-mode.sh"
+DRAGONSCALE = ROOT / "scripts/setup-dragonscale.sh"
+SETUP_VAULT = ROOT / "scripts/setup-vault.sh"
 
 
 class SetupWrapperTests(unittest.TestCase):

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -10,6 +10,7 @@ import os
 import socket
 import sys
 import tempfile
+import time
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -1880,6 +1881,110 @@ def test_explicit_recovery_can_reap_stale_pid_reuse_lock() -> None:
         assert not lock.exists()
 
 
+def test_force_stale_lock_reaps_dead_same_host_owner_before_stale_after() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        vault = make_vault(Path(td) / "vault")
+        lock = vault / ".vault-meta/mutation.lock"
+        lock.mkdir(parents=True)
+        (lock / "owner.json").write_text(
+            json.dumps(
+                {
+                    "schema": "claude-obsidian.mutation-lock.v1",
+                    "pid": 999999,
+                    "token": "dead-owner",
+                    "host": socket.gethostname(),
+                    "started_epoch": time.time() - 780,
+                }
+            ),
+            encoding="utf-8",
+        )
+        original_alive = transaction_module._process_alive
+        transaction_module._process_alive = lambda pid: False
+        try:
+            try:
+                MutationLock(vault, timeout=0, stale_after=3600.0).acquire()
+            except TransactionConflict as exc:
+                assert exc.code == "LOCK_TIMEOUT"
+            else:
+                raise AssertionError("automatic recovery must not steal a young lock")
+            assert lock.is_dir()
+
+            with MutationLock(
+                vault,
+                timeout=0,
+                stale_after=3600.0,
+                force_stale_lock=True,
+            ):
+                assert lock.is_dir()
+            assert not lock.exists()
+        finally:
+            transaction_module._process_alive = original_alive
+
+
+def test_force_stale_lock_does_not_reap_a_live_same_host_owner() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        vault = make_vault(Path(td) / "vault")
+        lock = vault / ".vault-meta/mutation.lock"
+        lock.mkdir(parents=True)
+        (lock / "owner.json").write_text(
+            json.dumps(
+                {
+                    "schema": "claude-obsidian.mutation-lock.v1",
+                    "pid": os.getpid(),
+                    "token": "live-owner",
+                    "host": socket.gethostname(),
+                    "started_epoch": time.time() - 780,
+                }
+            ),
+            encoding="utf-8",
+        )
+        try:
+            MutationLock(
+                vault,
+                timeout=0,
+                stale_after=3600.0,
+                force_stale_lock=True,
+            ).acquire()
+        except TransactionConflict as exc:
+            assert exc.code == "LOCK_TIMEOUT"
+        else:
+            raise AssertionError("force must never reap a live same-host owner")
+        assert lock.is_dir()
+        assert (lock / "owner.json").is_file()
+
+
+def test_force_stale_lock_keeps_the_age_gate_for_a_foreign_host_owner() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        vault = make_vault(Path(td) / "vault")
+        lock = vault / ".vault-meta/mutation.lock"
+        lock.mkdir(parents=True)
+        (lock / "owner.json").write_text(
+            json.dumps(
+                {
+                    "schema": "claude-obsidian.mutation-lock.v1",
+                    "pid": 999999,
+                    "token": "foreign-owner",
+                    "host": f"not-{socket.gethostname()}",
+                    "started_epoch": time.time() - 780,
+                }
+            ),
+            encoding="utf-8",
+        )
+        try:
+            MutationLock(
+                vault,
+                timeout=0,
+                stale_after=3600.0,
+                force_stale_lock=True,
+            ).acquire()
+        except TransactionConflict as exc:
+            assert exc.code == "LOCK_TIMEOUT"
+        else:
+            raise AssertionError("force must keep the age gate off this host")
+        assert lock.is_dir()
+        assert (lock / "owner.json").is_file()
+
+
 def test_ownerless_mutation_lock_requires_explicit_force() -> None:
     with tempfile.TemporaryDirectory() as td:
         vault = make_vault(Path(td) / "vault")
@@ -2184,6 +2289,82 @@ def test_recovery_never_reads_a_replaced_external_operation() -> None:
         assert victim.read_text(encoding="utf-8") == "victim-safe\n"
         assert external_journal.read_bytes() == external_before
         assert sorted(path.name for path in external.iterdir()) == ["journal.json"]
+
+
+def _seed_runtime_read_probe(base: Path) -> tuple[Path, bytes]:
+    """Write one bounded runtime file used by the stability read probes."""
+
+    target = base / "runtime-file.json"
+    payload = b'{"schema": "claude-obsidian.runtime-read-probe.v1"}\n'
+    target.write_bytes(payload)
+    return target, payload
+
+
+def test_read_runtime_bytes_tolerates_a_single_external_mtime_touch() -> None:
+    if not transaction_module._supports_confined_dirfd():
+        return
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td)
+        target, payload = _seed_runtime_read_probe(base)
+        directory_fd = os.open(base, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+        original_fstat = os.fstat
+        calls = 0
+
+        def counting_fstat(descriptor):
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                stamp = original_fstat(descriptor).st_mtime_ns + 5_000_000_000
+                os.utime(target, ns=(stamp, stamp))
+            return original_fstat(descriptor)
+
+        os.fstat = counting_fstat
+        try:
+            read = transaction_module._read_runtime_bytes_at(
+                directory_fd,
+                "runtime-file.json",
+                label="runtime read probe",
+                limit=1024,
+            )
+        finally:
+            os.fstat = original_fstat
+            os.close(directory_fd)
+        assert read == payload
+        assert calls >= 3
+
+
+def test_read_runtime_bytes_fails_closed_on_a_genuine_size_change() -> None:
+    if not transaction_module._supports_confined_dirfd():
+        return
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td)
+        target, payload = _seed_runtime_read_probe(base)
+        directory_fd = os.open(base, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+        original_fstat = os.fstat
+        calls = 0
+
+        def counting_fstat(descriptor):
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                target.write_bytes(payload + b"external-append-must-fail-closed\n")
+            return original_fstat(descriptor)
+
+        os.fstat = counting_fstat
+        try:
+            transaction_module._read_runtime_bytes_at(
+                directory_fd,
+                "runtime-file.json",
+                label="runtime read probe",
+                limit=1024,
+            )
+        except TransactionRecoveryError as exc:
+            assert exc.code == "CORRUPT_RUNTIME_STATE"
+        else:
+            raise AssertionError("a genuine runtime size change must fail closed")
+        finally:
+            os.fstat = original_fstat
+            os.close(directory_fd)
 
 
 def test_runtime_directory_cardinality_and_removal_are_bounded() -> None:
@@ -2634,12 +2815,17 @@ def main() -> None:
     test_binary_content_file_is_hash_checked_and_create_only()
     test_fresh_lock_survives_and_times_out()
     test_explicit_recovery_can_reap_stale_pid_reuse_lock()
+    test_force_stale_lock_reaps_dead_same_host_owner_before_stale_after()
+    test_force_stale_lock_does_not_reap_a_live_same_host_owner()
+    test_force_stale_lock_keeps_the_age_gate_for_a_foreign_host_owner()
     test_ownerless_mutation_lock_requires_explicit_force()
     test_mutation_lock_release_and_reaping_ignore_replaced_external_alias()
     test_mutation_lock_serializes_across_meta_directory_replacement()
     test_apply_runtime_namespaces_are_descriptor_anchored()
     test_meta_managed_targets_rollback_inside_pinned_namespace()
     test_recovery_never_reads_a_replaced_external_operation()
+    test_read_runtime_bytes_tolerates_a_single_external_mtime_touch()
+    test_read_runtime_bytes_fails_closed_on_a_genuine_size_change()
     test_runtime_directory_cardinality_and_removal_are_bounded()
     test_runtime_removal_enumerates_through_a_fresh_descriptor()
     test_mutation_and_runtime_descriptors_do_not_leak()

--- a/tests/test_transaction.py
+++ b/tests/test_transaction.py
@@ -2367,6 +2367,42 @@ def test_read_runtime_bytes_fails_closed_on_a_genuine_size_change() -> None:
             os.close(directory_fd)
 
 
+def test_read_runtime_bytes_fails_closed_on_a_same_size_content_change() -> None:
+    if not transaction_module._supports_confined_dirfd():
+        return
+    with tempfile.TemporaryDirectory() as td:
+        base = Path(td)
+        target, payload = _seed_runtime_read_probe(base)
+        directory_fd = os.open(base, os.O_RDONLY | getattr(os, "O_DIRECTORY", 0))
+        original_fstat = os.fstat
+        calls = 0
+        tampered = bytes(reversed(payload))
+        assert len(tampered) == len(payload) and tampered != payload
+
+        def counting_fstat(descriptor):
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                target.write_bytes(tampered)
+            return original_fstat(descriptor)
+
+        os.fstat = counting_fstat
+        try:
+            transaction_module._read_runtime_bytes_at(
+                directory_fd,
+                "runtime-file.json",
+                label="runtime read probe",
+                limit=1024,
+            )
+        except TransactionRecoveryError as exc:
+            assert exc.code == "CORRUPT_RUNTIME_STATE"
+        else:
+            raise AssertionError("a same-size content change must fail closed")
+        finally:
+            os.fstat = original_fstat
+            os.close(directory_fd)
+
+
 def test_runtime_directory_cardinality_and_removal_are_bounded() -> None:
     with tempfile.TemporaryDirectory() as td:
         vault = make_vault(Path(td) / "vault")
@@ -2826,6 +2862,7 @@ def main() -> None:
     test_recovery_never_reads_a_replaced_external_operation()
     test_read_runtime_bytes_tolerates_a_single_external_mtime_touch()
     test_read_runtime_bytes_fails_closed_on_a_genuine_size_change()
+    test_read_runtime_bytes_fails_closed_on_a_same_size_content_change()
     test_runtime_directory_cardinality_and_removal_are_bounded()
     test_runtime_removal_enumerates_through_a_fresh_descriptor()
     test_mutation_and_runtime_descriptors_do_not_leak()


### PR DESCRIPTION
## Summary

Backlog triage fixes from a full review of every open issue, pull request, and branch (2026-09-10). Eight commits, one per work package:

- fix(capture): reject numeric and hex-encoded loopback host spellings (`0x7f.0.0.1`, `0177.0.0.1`, `127.1`)
- docs(hooks): document the `python3` interpreter requirement for hooks on native Windows and the Claude Code requirement (refs #162, #168)
- fix(skills): state the `../wiki/references/` resolution rule in twelve skills and enforce it in package validation (fixes #170)
- refactor(layout): move the five setup scripts from `bin/` to `scripts/`; claude.ai rejects plugins with a top-level `bin/` (fixes #138)
- feat(lint): skip dot-prefixed directories by default and add `--exclude` globs, an engine parameter, and a vault-config array (fixes #163, #183, #184)
- fix(transaction): let `--force-stale-lock` reap a confirmed-dead same-host owner before `--stale-after`, in both lock types; tolerate metadata-only mtime touches when reading runtime files (fixes #157)
- fix(transaction): the confirmation read must be byte-identical to the first read; ignore `.mcp.json` at the repository root
- docs(attribution): credit the adopted reranker designs from PRs #62 and #77

## Verification

- Each work package was planned by a read-only planner, reviewed, executed in an isolated worktree with its regression test shown failing before the fix, then merged.
- `make test` passes on the integrated branch. `package validate` reports zero findings. `contracts --verify` exits 0.
- A fresh-context verifier reviewed the combined diff and found one blocker (the runtime read retry accepted content that changed mid-read once it stabilized); the seventh commit closes it with a same-size tamper regression test.
- No em dashes in added lines. `SHA256SUMS` and `RELEASE_MANIFEST.json` are intentionally not refreshed here; they are regenerated in the release commit.

## Compatibility and rollback

- `bash bin/setup-*.sh` invocations become `bash scripts/setup-*.sh`; all in-repo references are updated and the change is noted under Changed in the changelog.
- `lint_vault` gains a keyword-only `exclude` parameter and the report summary gains `excluded_paths`; existing keys are unchanged.
- `_load_allowlist` now returns a 3-tuple; it has a single caller.
- Revert any commit independently; none depends on a later one except the seventh, which refines the sixth.

## Open items

- Native Windows behavior of the hook and CRLF paths is documented from reports and code reading; this PR's CI matrix is the first execution on windows-latest.
- Wildcard-DNS loopback names (for example `127.0.0.1.nip.io`) remain a documented residual gap in the host validator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HsZx7kpCUXkZC9C7foH9Yg
